### PR TITLE
add more constructor for Frame

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -56,6 +56,20 @@ Frame::Frame(int natomIn) :
     X_ = new double[ ncoord_ ];
 }
 
+Frame::Frame(int natomIn, double* ptr) :
+  natom_(natomIn),
+  maxnatom_(natomIn),
+  ncoord_(natomIn*3), 
+  T_(0.0),
+  time_(0.0),
+  X_(0),
+  V_(0),
+  Mass_(natomIn, 1.0)
+{
+  if (ncoord_ > 0)
+    X_ = ptr;
+}
+
 // CONSTRUCTOR
 Frame::Frame(std::vector<Atom> const& atoms) :
   natom_(atoms.size()),

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -25,6 +25,7 @@ const size_t Frame::COORDSIZE_ = 3 * sizeof(double);
 // ---------- CONSTRUCTION/DESTRUCTION/ASSIGNMENT ------------------------------
 /// CONSTRUCTOR
 Frame::Frame( ) : 
+  only_free_V(false),
   natom_(0),
   maxnatom_(0),
   ncoord_(0),
@@ -37,12 +38,18 @@ Frame::Frame( ) :
 /// DESTRUCTOR
 // Defined since this class can be inherited.
 Frame::~Frame( ) { 
-  if (X_ != 0) delete[] X_;
-  if (V_ != 0) delete[] V_;
+  if (only_free_V) {
+        if (V_ != 0) delete[] V_;
+   }
+  else {
+    if (X_ != 0) delete[] X_;
+    if (V_ != 0) delete[] V_;
+  }
 }
 
 // CONSTRUCTOR
 Frame::Frame(int natomIn) :
+  only_free_V(false),
   natom_(natomIn),
   maxnatom_(natomIn),
   ncoord_(natomIn*3), 
@@ -57,6 +64,7 @@ Frame::Frame(int natomIn) :
 }
 
 Frame::Frame(int natomIn, double* ptr) :
+  only_free_V(true),
   natom_(natomIn),
   maxnatom_(natomIn),
   ncoord_(natomIn*3), 
@@ -72,6 +80,7 @@ Frame::Frame(int natomIn, double* ptr) :
 
 // CONSTRUCTOR
 Frame::Frame(std::vector<Atom> const& atoms) :
+  only_free_V(false),
   natom_(atoms.size()),
   maxnatom_(natom_),
   ncoord_(natom_*3),
@@ -90,6 +99,7 @@ Frame::Frame(std::vector<Atom> const& atoms) :
 
 // CONSTRUCTOR
 Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) : 
+  only_free_V(false),
   natom_( maskIn.Nselected() ),
   maxnatom_(natom_),
   ncoord_(natom_*3),
@@ -131,6 +141,7 @@ Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) :
 
 // COPY CONSTRUCTOR
 Frame::Frame(const Frame& rhs) :
+  only_free_V(false),
   natom_(rhs.natom_),
   maxnatom_(rhs.maxnatom_),
   ncoord_(rhs.ncoord_),

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -25,7 +25,7 @@ const size_t Frame::COORDSIZE_ = 3 * sizeof(double);
 // ---------- CONSTRUCTION/DESTRUCTION/ASSIGNMENT ------------------------------
 /// CONSTRUCTOR
 Frame::Frame( ) : 
-  only_free_V(false),
+  OnlyFreeV_(false),
   natom_(0),
   maxnatom_(0),
   ncoord_(0),
@@ -38,7 +38,7 @@ Frame::Frame( ) :
 /// DESTRUCTOR
 // Defined since this class can be inherited.
 Frame::~Frame( ) { 
-  if (only_free_V) {
+  if (OnlyFreeV_) {
         if (V_ != 0) delete[] V_;
    }
   else {
@@ -49,7 +49,7 @@ Frame::~Frame( ) {
 
 // CONSTRUCTOR
 Frame::Frame(int natomIn) :
-  only_free_V(false),
+  OnlyFreeV_(false),
   natom_(natomIn),
   maxnatom_(natomIn),
   ncoord_(natomIn*3), 
@@ -64,7 +64,7 @@ Frame::Frame(int natomIn) :
 }
 
 Frame::Frame(int natomIn, double* ptr) :
-  only_free_V(true),
+  OnlyFreeV_(true),
   natom_(natomIn),
   maxnatom_(natomIn),
   ncoord_(natomIn*3), 
@@ -80,7 +80,7 @@ Frame::Frame(int natomIn, double* ptr) :
 
 // CONSTRUCTOR
 Frame::Frame(std::vector<Atom> const& atoms) :
-  only_free_V(false),
+  OnlyFreeV_(false),
   natom_(atoms.size()),
   maxnatom_(natom_),
   ncoord_(natom_*3),
@@ -99,7 +99,7 @@ Frame::Frame(std::vector<Atom> const& atoms) :
 
 // CONSTRUCTOR
 Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) : 
-  only_free_V(false),
+  OnlyFreeV_(false),
   natom_( maskIn.Nselected() ),
   maxnatom_(natom_),
   ncoord_(natom_*3),
@@ -141,7 +141,7 @@ Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) :
 
 // COPY CONSTRUCTOR
 Frame::Frame(const Frame& rhs) :
-  only_free_V(false),
+  OnlyFreeV_(false),
   natom_(rhs.natom_),
   maxnatom_(rhs.maxnatom_),
   ncoord_(rhs.ncoord_),

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -196,7 +196,7 @@ class Frame {
     int RecvFrame(int);
 #   endif
   private:
-    bool only_free_V;
+    bool OnlyFreeV_;
     typedef std::vector<double> Darray;
     static const size_t COORDSIZE_;
     static const size_t BOXSIZE_;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -196,6 +196,7 @@ class Frame {
     int RecvFrame(int);
 #   endif
   private:
+    bool only_free_V;
     typedef std::vector<double> Darray;
     static const size_t COORDSIZE_;
     static const size_t BOXSIZE_;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -36,6 +36,8 @@ class Frame {
     ~Frame();
     /// Set up empty frame for given # of atoms.
     Frame(int);
+    /// Set up Frame as a memoryview. mostly for pytraj.
+    Frame(int, double*);
     /// Set up to be the size of given atom array (including masses).
     Frame(std::vector<Atom> const&);
     /// Copy input frame according to input mask.


### PR DESCRIPTION
@drroe 

So I "officially" create this PR to add one more constructor for Frame. (as we discussed in g-doc a while ago). 

**Motivation**: current implementation of cpptraj require coordinates copied twice when transferring from disk to in-memory numpy array. `cpptraj` read coords from disk to Frame class, then pytraj copy frame's coordinates to numpy (two copies need to be done to convert `discontiguous memory` (vector of frames) to contiguous memory block in numpy).

* I think it's not ok to do this for very large system (may be > 100K atoms).  So I add this constructor to use Frame just as a pointer to a **pre-allocated** numpy array and instruct cpptraj to read coords directly to numpy memory block. Memory is not own by cpptraj but numpy (controlled through `pytraj`).

So this constructor is just designed for cpptraj/pytraj interface.
This implementation 2 times speeds up + memory saving.

* Secondly, this is also speed up the frame slicing of numpy array. Current implementation needs to slice numpy array, convert to Frame object so cpptraj can understand. If we use constructor above, no data is copied. Of course, this only good for cpptraj's actions that does not change mem location. 

let me know if it's ok to merge.

Hai