### PR TITLE
DRR - Cpptraj: Add default data set name generation to lowestcurve when no name specified.

### DIFF
--- a/src/Analysis_LowestCurve.cpp
+++ b/src/Analysis_LowestCurve.cpp
@@ -31,6 +31,8 @@ Analysis::RetType Analysis_LowestCurve::Setup(ArgList& analyzeArgs, DataSetList*
     return Analysis::ERR;
   }
   // Create output data sets
+  if (setname.empty())
+    setname = datasetlist->GenerateDefaultName("LOWCURVE");
   for (Array1D::const_iterator DS = input_dsets_.begin(); DS != input_dsets_.end(); ++DS) {
     DataSet* dsout = datasetlist->AddSetIdx(DataSet::DOUBLE, setname, DS - input_dsets_.begin());
     if (dsout == 0)


### PR DESCRIPTION
Fixes error in lowestcurve command when no name specified.