### PR TITLE
Improve vec matrix

### DIFF
--- a/src/Action_Vector.cpp
+++ b/src/Action_Vector.cpp
@@ -182,8 +182,11 @@ Action::RetType Action_Vector::Setup(Topology* currentParm, Topology** parmAddre
   if (mask_.MaskStringSet()) {
     // Setup mask 1
     if (currentParm->SetupIntegerMask(mask_)) return Action::ERR;
-    mprintf("\tVector mask [%s] corresponds to %i atoms.\n",
-            mask_.MaskString(), mask_.Nselected());
+    mask_.MaskInfo();
+    if (mask_.None()) {
+      mprinterr("Error: First vector mask is empty.\n");
+      return Action::ERR;
+    }
   }
 
   // Allocate space for CORRPLANE. 
@@ -195,8 +198,11 @@ Action::RetType Action_Vector::Setup(Topology* currentParm, Topology** parmAddre
   // Setup mask 2
   if (mask2_.MaskStringSet()) {
     if (currentParm->SetupIntegerMask(mask2_)) return Action::ERR;
-    mprintf("\tVector mask [%s] corresponds to %i atoms.\n",
-            mask2_.MaskString(), mask2_.Nselected());
+    mask2_.MaskInfo();
+    if (mask2_.None()) {
+      mprinterr("Error: Second vector mask is empty.\n");
+      return Action::ERR;
+    }
   }
   CurrentParm_ = currentParm;
   return Action::OK;

--- a/src/Analysis_IRED.h
+++ b/src/Analysis_IRED.h
@@ -31,9 +31,10 @@ class Analysis_IRED : public Analysis {
     double* cf_cjt_;
     double* cfinf_;
     double* taum_;
-    std::string noeFilename_;
-    std::string filename_;
-    std::string orderparamfile_;
+    CpptrajFile* orderout_;
+    CpptrajFile* noefile_;
+    CpptrajFile* cmtfile_;
+    CpptrajFile* cjtfile_;
     DataSet_Modes* modinfo_;
     std::vector<DataSet_Vector*> IredVectors_;
 

--- a/src/Analysis_Matrix.h
+++ b/src/Analysis_Matrix.h
@@ -17,7 +17,7 @@ class Analysis_Matrix : public Analysis {
 
     DataSet_2D* matrix_;
     DataSet_Modes* modes_;
-    std::string outthermo_;
+    CpptrajFile* outthermo_;
     double thermo_temp_;
     int nevec_;
     bool thermopt_;

--- a/src/DataSet_Modes.cpp
+++ b/src/DataSet_Modes.cpp
@@ -85,7 +85,7 @@ int DataSet_Modes::CalcEigen(DataSet_2D const& mIn, int n_to_calc) {
   mprinterr("Error: modes: Compiled without ARPACK/LAPACK/BLAS routines.\n");
   return 1;
 #else
-  bool eigenvaluesOnly;
+  bool eigenvaluesOnly = false;
   int info = 0;
   if (mIn.MatrixKind() != DataSet_2D::HALF) {
     mprinterr("Error: DataSet_Modes: Eigenvector/value calc only for symmetric matrices.\n");
@@ -93,18 +93,20 @@ int DataSet_Modes::CalcEigen(DataSet_2D const& mIn, int n_to_calc) {
   }
   // If number to calc is 0, assume we want eigenvalues only
   if (n_to_calc < 1) {
-    eigenvaluesOnly = true;
+    if (n_to_calc == 0) eigenvaluesOnly = true;
     nmodes_ = (int)mIn.Ncols();
-  } else {
-    eigenvaluesOnly = false;
+  } else
     nmodes_ = n_to_calc;
-  }
   if (nmodes_ > (int)mIn.Ncols()) {
     mprintf("Warning: Specified # of eigenvalues to calc (%i) > matrix dimension (%i).\n",
             nmodes_, mIn.Ncols());
     nmodes_ = mIn.Ncols();
     mprintf("Warning: Only calculating %i eigenvalues.\n", nmodes_);
   }
+  if (eigenvaluesOnly)
+    mprintf("\tCalculating %i eigenvalues only.\n", nmodes_);
+  else
+    mprintf("\tCalculating %i eigenvectors and eigenvalues.\n", nmodes_);
   // -----------------------------------------------------------------
   if (nmodes_ == (int)mIn.Ncols()) {
     // Calculate all eigenvalues (and optionally eigenvectors). 

--- a/test/Test_IRED/RunTest.sh
+++ b/test/Test_IRED/RunTest.sh
@@ -3,12 +3,12 @@
 # Test of IRED 
 . ../MasterTest.sh
 
-CleanFiles orderparam ired.vec noe v0.cjt v0.cmt ptraj_ired_step1.in
+CleanFiles orderparam ired.vec noe v0.cjt v0.cmt ired.in
 
 CheckPtrajAnalyze
 
 TOP="1IEE_A_prot.prmtop"
-INPUT="ptraj_ired_step1.in"
+INPUT="ired.in"
 echo "trajin 1IEE_A_test.mdcrd" > $INPUT
 N=0
 # Define N-H vectors. H atom is always N atom plus one.
@@ -28,10 +28,10 @@ for NATOM in 25   41   61   68   92   102  117  136  146  156  166  183  205  \
 done
 cat >> $INPUT <<EOF
 matrix ired name matired order 2
-###Attention: adjust vecs to number of residues in your protein
-analyze matrix matired out ired.vec name ired.vec vecs 126 
-analyze ired relax freq 500.0 NHdist 1.02 tstep 1.0 tcorr 10000.0 norm out v0 noefile noe \
-        order 2 modes ired.vec orderparamfile orderparam
+diagmatrix matired out ired.vec name ired.vec
+ired order 2 modes ired.vec relax freq 500.0 NHdist 1.02 \
+     tstep 1.0 tcorr 10000.0 norm \
+     out v0 noefile noe orderparamfile orderparam
 EOF
 
 RunCpptraj "IRED vector/matrix test"


### PR DESCRIPTION
Fixes and improvements for 'vector', 'diagmatrix', and 'ired'. The 'vector' command will now exit with an error if masks are specified but do not correspond to any atoms. If no number of vectors specified to 'diagmatrix' it will try to calc the max (based on matrix dims). Text output for 'diagmatrix' and 'ired' now use DataFileList.