### PR TITLE
DRR - Cpptraj: Fix determination of whether libcpptraj.so can be built

### DIFF
--- a/configure
+++ b/configure
@@ -278,6 +278,7 @@ ARPACK="-larpack"
 FFT_LIB="pub_fft.o"
 FFT_LIBDIR=""
 FFT_DEPEND=$FFT_LIB
+LIBCPPTRAJ="nolibcpptraj" # Set to libcpptraj.so if library will be built
 SANDERLIB=""
 READLINE=$READLINE_HOME/libreadline.a
 USE_AMBER_LIB=0
@@ -397,6 +398,7 @@ while [[ ! -z $1 ]] ; do
     "-shared"       )
       echo "Enabling position-independent code for generating shared library."
       USESHARED=1
+      LIBCPPTRAJ="libcpptraj.so"
       ;;
     "-amberlib"     )
       if [[ -z $AMBERHOME ]] ; then
@@ -796,24 +798,14 @@ FFLAGS=$FFLAGS \$(DBGFLAGS)
 READLINE=$READLINE
 READLINE_HOME=$READLINE_HOME
 
+LIBCPPTRAJ=$LIBCPPTRAJ
+
 FFT_DEPEND=$FFT_DEPEND
 FFT_LIB=$FFT_LIB
 
 LDFLAGS=$LDFLAGS
 SFX=$SFX
 EOF
-
-# Add a rule to config to prevent libcpptraj from being built if not shared.
-if [[ $USESHARED -eq 1 ]] ; then
-  cat >> config.h <<EOF
-checkshared:
-EOF
-else
-  cat >> config.h <<EOF
-checkshared:
-	@(echo "Error: Cannot build libcpptraj; re-configure with '-shared'" ; exit 1 ; )
-EOF
-fi
 
 # Create directories if necessary
 if [[ ! -e $CPPTRAJBIN ]] ; then

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,9 +26,14 @@ depend: findDepend
 dependclean:
 	/bin/rm -f FindDepend.o findDepend
 
-libcpptraj: checkshared $(OBJECTS) $(FFT_DEPEND) $(READLINE)
+libcpptraj: $(LIBCPPTRAJ)
+
+libcpptraj.so: $(OBJECTS) $(FFT_DEPEND) $(READLINE)
 	$(CXX)  -shared -o libcpptraj.so $(OBJECTS) $(FFT_LIB) $(LDFLAGS) $(READLINE)
 	/bin/mv libcpptraj.so $(CPPTRAJLIB)
+
+nolibcpptraj:
+	@(echo "Error: Cannot build libcpptraj; re-configure with '-shared'" ; exit 1 ; )
 
 cpptraj$(SFX): $(OBJECTS) $(FFT_DEPEND) $(READLINE)
 	$(CXX)  -o cpptraj$(SFX) $(OBJECTS) $(READLINE) $(FFT_LIB) $(LDFLAGS)


### PR DESCRIPTION
Rules do not belong in config files. Also fixes default make behavior for standalone.