### PR TITLE
Convert to using Container-based Travis-CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,7 @@ env:
 install:
     - ./configure $OPENMP $COMPILER
     - make -j2 install
+      # Hack to get ambpdb installed with OpenMP
+    - make -C src ambpdb && mv src/ambpdb bin/
 script:
     - cd test && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,13 @@ addons:
       - libarpack2-dev
       - libnetcdf-dev
       - netcdf-bin
+env:
+    - COMPILER=gnu
+    - COMPILER=clang
+    - COMPILER=gnu OPENMP="-openmp"
+
 install:
-    - ./configure gnu
+    - ./configure $OPENMP $COMPILER
     - make install
 script:
     - cd test && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,10 @@ addons:
       - netcdf-bin
 env:
     - COMPILER=gnu
-    - COMPILER=clang
-    - COMPILER=gnu OPENMP="-openmp"
+    - COMPILER=gnu OPENMP="-openmp" OPT=openmp
 
 install:
     - ./configure $OPENMP $COMPILER
-    - make install
+    - make -j2 install
 script:
     - cd test && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: cpp
 compiler: gcc
-before_install:
-    - sudo apt-get install gfortran
-    - sudo apt-get install libbz2-dev
-    - sudo apt-get install libblas-dev liblapack-dev libarpack2-dev
-    - sudo apt-get install libnetcdf-dev
-    - sudo apt-get install netcdf-bin
+sudo: false
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+      - gfortran
+      - libbz2-dev
+      - libblas-dev
+      - liblapack-dev
+      - libarpack2-dev
+      - libnetcdf-dev
+      - netcdf-bin
 install:
     - ./configure gnu
     - make install


### PR DESCRIPTION
Faster builds (~1/2 the time), more resources (2 dedicated CPUs instead of 1.5
burst; 4 GB RAM instead of 3.5 GB). Builds also start almost instantly, rather
than sometimes needing to wait.