### PR TITLE
DRR - Cpptraj: Add 'noconect' option to PDB parm read.

### DIFF
--- a/src/Parm_PDB.h
+++ b/src/Parm_PDB.h
@@ -3,7 +3,7 @@
 #include "ParmIO.h"
 class Parm_PDB : public ParmIO {
   public :
-    Parm_PDB() : readAsPQR_(false), readBox_(false) {}
+    Parm_PDB() : readAsPQR_(false), readBox_(false), readConect_(true) {}
     static BaseIOtype* Alloc() { return (BaseIOtype*)new Parm_PDB(); }
     static void ReadHelp();
     bool ID_ParmFormat(CpptrajFile&);
@@ -14,7 +14,8 @@ class Parm_PDB : public ParmIO {
     int processWriteArgs(ArgList&) { return 0; }
     bool NeedsBondSearch() const { return true; }
   private:
-    bool readAsPQR_; ///< If true get charge and radius from occ/b factor cols
-    bool readBox_;   ///< If true try to read CRYST1 record as box info.
+    bool readAsPQR_;  ///< If true get charge and radius from occ/b factor cols
+    bool readBox_;    ///< If true try to read CRYST1 record as box info.
+    bool readConect_; ///< If true read bonds from CONECT records.
 };
 #endif


### PR DESCRIPTION
Allows users to workaround PDBs where CONECT information would result in molecules with non-consecutive atom ordering. Addresses #60.