### PR TITLE
Improve handling of extra points with PDB files

### DIFF
--- a/src/AmbPDB.cpp
+++ b/src/AmbPDB.cpp
@@ -26,6 +26,7 @@ static void Help(const char* prgname, bool showAdditional) {
             "    -tit <TITLE>  Write a REMARK record containing TITLE.\n"
             "                      (default: use prmtop title)\n"
             "    -aatm         Left-justified Amber atom names.\n"
+            "    -ep           Include extra points if present.\n"
             "    -bres         Brookhaven Residue names (HIE->HIS, etc.).\n"
             "    -ctr          Center molecule on (0,0,0).\n"
             "    -noter        Do not write TER records.\n"
@@ -88,6 +89,8 @@ int main(int argc, char** argv) {
       return 0;
     } else if (arg == "-aatm") // Amber atom names, include extra pts
       aatm.assign(" include_ep");
+    else if (arg == "-ep") // PDB atom names, include extra pts
+      aatm.append(" include_ep");
     else if (arg == "-bres") // PDB residue names
       bres.assign(" pdbres");
     else if (arg == "-ext") // Use extended PDB info from Topology

--- a/src/Traj_PDBfile.cpp
+++ b/src/Traj_PDBfile.cpp
@@ -413,12 +413,13 @@ int Traj_PDBfile::writeFrame(int set, Frame const& frameOut) {
         else if (atomName == "H3T ") atomName = "HO3'";
         else if (atomName == "HO'2") atomName = "HO2'";
       }
-      file_.WriteCoord(PDBfile::ATOM, anum++, atomName, altLoc, resNames_[res],
+      file_.WriteCoord(PDBfile::ATOM, anum, atomName, altLoc, resNames_[res],
                        chainID_[res], pdbTop_->Res(res).OriginalResNum(),
                        pdbTop_->Res(res).Icode(),
                        Xptr[0], Xptr[1], Xptr[2], Occ, B,
                        atom.ElementName(), 0, dumpq_);
     }
+    anum++;
     // Check and see if a TER card should be written.
     if (aidx == *terIdx) {
       // FIXME: Should anum not be incremented until after? 


### PR DESCRIPTION
This PR ensures that ATOM record numbers line up with topology atom numbering, even when extra points are skipped. Also add `-ep` command line flag for `ambpdb` to enable printing of extra points.