### PR TITLE
Fix reading of CONECT records in PDB files

### DIFF
--- a/src/PDBfile.cpp
+++ b/src/PDBfile.cpp
@@ -169,10 +169,29 @@ void PDBfile::pdb_Box(double* box) const {
             " this usually indicates an invalid box.\n");
 }
 
-int PDBfile::pdb_Bonds(int* bnd) const {
-  int Nscan = sscanf(linebuffer_, "%*6s%5i%5i%5i%5i%5i", bnd, bnd+1, bnd+2, bnd+3, bnd+4);
+int PDBfile::pdb_Bonds(int* bnd) {
+  unsigned int lb_size = strlen(linebuffer_);
+  int Nscan = 0;
+  for (unsigned int lb = 6; lb < lb_size; lb += 5) {
+    // Check if final char is blank.
+    if (linebuffer_[lb + 4] == ' ') break;
+    // Safety valve
+    if (Nscan == 5) {
+      mprintf("Warning: CONECT record has more than 4 bonds. Only using first 4 bonds.\n");
+      break;
+    }
+    unsigned int end = lb + 5;
+    char savechar = linebuffer_[end];
+    linebuffer_[end] = '\0';
+    bnd[Nscan++] = atof( linebuffer_ + lb );
+    linebuffer_[end] = savechar;
+  }
   if (Nscan < 2)
     mprintf("Warning: Malformed CONECT record: %s", linebuffer_);
+  //mprintf("DEBUG: CONECT: Atom record %i to", bnd[0]);
+  //for (int i = 1; i < Nscan; i++)
+  //  mprintf(" %i", bnd[i]);
+  //mprintf("\n");
   return Nscan;
 }
 

--- a/src/PDBfile.h
+++ b/src/PDBfile.h
@@ -27,10 +27,10 @@ class PDBfile : public CpptrajFile {
     /// Set given XYZ array with A/B/C/alpha/beta/gamma from CRYST1 record.
     void pdb_Box(double*) const;
     /// Set given array with atom and #s of bonded atoms from CONECT record.
-    int pdb_Bonds(int*) const;
+    int pdb_Bonds(int*);
     /// \return current record type.
     PDB_RECTYPE RecType()         const { return recType_; }
-
+    // -------------------------------------------
     /// Write PDB record header.
     void WriteRecordHeader(PDB_RECTYPE, int, NameType const&, char,
                            NameType const&, char, int, char);

--- a/src/PDBfile.h
+++ b/src/PDBfile.h
@@ -23,9 +23,9 @@ class PDBfile : public CpptrajFile {
     /// Set given XYZ array with coords from ATOM/HETATM record.
     void pdb_XYZ(double*);
     /// Get occupancy and B-factor from ATOM/HETATM record.
-    void pdb_OccupanyAndBfactor(float&, float&);
+    void pdb_OccupancyAndBfactor(float&, float&);
     /// Set given XYZ array with A/B/C/alpha/beta/gamma from CRYST1 record.
-    void pdb_Box(double*) const;
+    void pdb_Box(double*);
     /// Set given array with atom and #s of bonded atoms from CONECT record.
     int pdb_Bonds(int*);
     /// \return current record type.

--- a/src/Parm_PDB.cpp
+++ b/src/Parm_PDB.cpp
@@ -64,7 +64,7 @@ int Parm_PDB::ReadParm(FileName const& fname, Topology &TopIn) {
       if (atnum >= (int)serial.size())
         serial.resize( atnum+1, -1 );
       serial[atnum] = TopIn.Natom();
-      infile.pdb_OccupanyAndBfactor(occupancy, bfactor);
+      infile.pdb_OccupancyAndBfactor(occupancy, bfactor);
       if (readAsPQR_) {
         pdbAtom.SetCharge( occupancy );
         pdbAtom.SetGBradius( bfactor );

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -876,6 +876,15 @@ void Topology::AssignBondParameters() {
   * For bonds to H always insert the H second.
   */
 void Topology::AddBond(int atom1, int atom2) {
+  // Check if atoms are out of range.
+  if (atom1 < 0 || atom1 >= (int)atoms_.size()) {
+    mprintf("Warning: Atom # %i is out of range, cannot create bond.\n", atom1+1);
+    return;
+  }
+  if (atom2 < 0 || atom2 >= (int)atoms_.size()) {
+    mprintf("Warning: Atom # %i is out of range, cannot create bond.\n", atom2+1);
+    return;
+  }
   // Check for duplicate bond
   for (Atom::bond_iterator ba = atoms_[atom1].bondbegin();
                            ba != atoms_[atom1].bondend(); ++ba)

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -990,14 +990,17 @@ int Topology::DetermineMolecules() {
       molecule->SetFirst( atomNum );
       lastMol = atom->MolNum();
     } else if ( atom->MolNum()  < lastMol) {
-      mprinterr("Error: Atom %u was assigned a lower molecule # than previous atom. This can\n"
-                "Error:   happen if 1) bond information is incorrect or missing, or 2) if the\n"
-                "Error:   atom numbering in molecules is not sequential. If topology did not\n"
-                "Error:   originally contain bond info, 1) can potentially be fixed by\n"
-                "Error:   increasing the bondsearch cutoff offset. 2) can be\n"
-                "Error:   fixed by either using the 'fixatomorder' command, or using\n"
-                "Error:   the 'setMolecules' command in parmed.\n",
-                atom - atoms_.begin() + 1);
+      mprinterr("Error: Atom %u was assigned a lower molecule # than previous atom.\n"
+                "Error:   This can happen if bond information is incorrect or missing, or if the\n"
+                "Error:   atom numbering in molecules is not sequential. Try one of the\n"
+                "Error:   following:\n"
+                "Error: - If this is a PDB file, try using the 'noconect' keyword.\n"
+                "Error: - If this topology did not have bond info, try increasing the bond\n"
+                "Error:   search cutoff above 0.2 Ang. ('bondsearch <cutoff>').\n"
+                "Error: - Use the 'fixatomorder' command to reorder the topology and any\n"
+                "Error:   associated coordinates.\n"
+                "Error: - Use the 'setMolecules' command in parmed to reorder only the\n"
+                "Error:   topology.\n", atom - atoms_.begin() + 1);
       molecules_.clear();
       // Reset molecule info for each atom
       for (atom = atoms_.begin(); atom != atoms_.end(); atom++)


### PR DESCRIPTION
Previously, the code would not read atom record numbers from CONECT records properly when there was leading whitespace in the first number and no whitespace in the remaining numbers, e.g.
```
CONECT  78413624
```
would be read as 78413 and 624 instead of 784 and 13624. Both this and reading of CRYST1 records (which potentially had the same problem) have now been fixed. This PR also cleans up and updates the error message for atoms out of order in molecules (which can sometimes happen when reading CONECT records among other things). Addresses #122  