### PR TITLE
Allow reading of some non-compliant NetCDF files.

### DIFF
--- a/src/Box.cpp
+++ b/src/Box.cpp
@@ -141,19 +141,24 @@ static inline bool IsTruncOct(double angle) {
 /** Determine box type (none/ortho/nonortho) based on box angles. */
 void Box::SetBoxType() {
   btype_ = NONORTHO;
-  // No lengths, no box
-  if (box_[0] < Constants::SMALL && box_[1] < Constants::SMALL && box_[2] < Constants::SMALL) {
+  bool noLengths = (box_[0] < Constants::SMALL &&
+                    box_[1] < Constants::SMALL &&
+                    box_[2] < Constants::SMALL);
+  bool noAngles = ( box_[3] <= 0 && box_[4] <= 0 && box_[5] <= 0);
+  if ( noLengths ) {
+    // No lengths, no box
     btype_ = NOBOX;
-    mprintf("Warning: Box length(s) <= 0.0; setting box to NONE.\n");
-  // No angles, no box
-  } else if ( box_[3] <= 0 && box_[4] <= 0 && box_[5] <= 0) {
+    if (!noAngles)
+      mprintf("Warning: Box length(s) <= 0.0; setting box to NONE.\n");
+  } else if ( noAngles ) {
+    // No angles, no box
     mprintf("Warning: Box angle(s) <= 0.0; setting box to NONE.\n");
     btype_ = NOBOX;
-  // All 90, orthogonal 
   } else if (box_[3] == 90.0 && box_[4] == 90.0 && box_[5] == 90.0)
+    // All 90, orthogonal
     btype_ = ORTHO;
-  // All 109.47, truncated octahedron
   else if ( IsTruncOct( box_[3] ) && IsTruncOct( box_[4] ) && IsTruncOct( box_[5] ) )
+    // All 109.47, truncated octahedron
     btype_ = TRUNCOCT;
   else if (box_[3] == 0 && box_[4] != 0 && box_[5] == 0) {
     // Only beta angle is set (e.g. from Amber topology).


### PR DESCRIPTION
Make NetCDF nc_strerror and attribute error messages warnings instead since they are not always fatal (e.g. when getting a title that's not there). Make failing to get the spatial VID a non-fatal warning that the file may not be Amber-compliant, but if spatial VID is present make sure it contains 'x', 'y', 'z'. This addresses #123 .

Also, only warn about setting NOBOX from zero box lengths if box angles are present (otherwise it could legimately be a NOBOX situation).