### PR TITLE
Protect Actions that use nonbond info, fix detection of numbers, fix lowestcurve

### DIFF
--- a/src/ActionList.cpp
+++ b/src/ActionList.cpp
@@ -51,7 +51,7 @@ int ActionList::AddAction(DispatchObject::DispatchAllocatorType Alloc, ArgList& 
 /** Attempt to set up all actions in the action list with the given parm
   * If an action cannot be set up skip it.
   */
-int ActionList::SetupActions(ActionSetup& setup) {
+int ActionList::SetupActions(ActionSetup& setup, bool exitOnError) {
   if (actionList_.empty()) return 0;
   ActionSetup OriginalSetup = setup;
   mprintf(".....................................................\n");
@@ -66,7 +66,8 @@ int ActionList::SetupActions(ActionSetup& setup) {
       Action::RetType err = act->ptr_->Setup(setup);
       if (err == Action::ERR) {
         mprinterr("Error: Setup failed for [%s]\n", act->args_.Command());
-        return 1;
+        if (exitOnError) return 1;
+        act->status_ = INIT;
       } else if (err == Action::SKIP) {
         mprintf("Warning: Setup incomplete for [%s]: Skipping\n", act->args_.Command());
         // Reset action status to INIT (pre-setup)

--- a/src/ActionList.h
+++ b/src/ActionList.h
@@ -18,7 +18,7 @@ class ActionList {
     /// Add given action to the action list and initialize.
     int AddAction(DispatchObject::DispatchAllocatorType, ArgList&, ActionInit&);
     /// Set up Actions for the given Topology.
-    int SetupActions(ActionSetup&);
+    int SetupActions(ActionSetup&, bool);
     /// Perform Actions on the given Frame.
     bool DoActions(int, ActionFrame&);
     /// Call print for each Action.

--- a/src/Action_Energy.cpp
+++ b/src/Action_Energy.cpp
@@ -94,6 +94,14 @@ Action::RetType Action_Energy::Setup(ActionSetup& setup) {
   }
   Mask1_.MaskInfo();
   Imask_ = AtomMask(Mask1_.ConvertToIntMask(), Mask1_.Natom());
+  // Check for LJ terms
+  for (calc_it calc = Ecalcs_.begin(); calc != Ecalcs_.end(); ++calc)
+    if ((*calc == N14 || *calc == NBD) && !setup.Top().Nonbond().HasNonbond())
+    {
+      mprinterr("Error: Nonbonded energy calc requested but topology '%s'\n"
+                "Error:   does not have non-bonded parameters.\n", setup.Top().c_str());
+      return Action::ERR;
+    }
   currentParm_ = setup.TopAddress();
   return Action::OK;
 }

--- a/src/Action_Gist.cpp
+++ b/src/Action_Gist.cpp
@@ -168,6 +168,11 @@ Action::RetType Action_Gist::Setup(ActionSetup& setup) {
   CurrentParm_ = setup.TopAddress();
   NFRAME_ = 0;
   max_nwat_ = 0;
+  // Check for LJ info
+  if (!setup.Top().Nonbond().HasNonbond()) {
+    mprinterr("Error: Topology '%s' does not have LJ information.\n", setup.Top().c_str());
+    return Action::ERR;
+  }
 
   MAX_GRID_PT_ = griddim_[0] * griddim_[1] * griddim_[2];
   Vvox_ = gridspacn_*gridspacn_*gridspacn_;
@@ -731,6 +736,7 @@ void Action_Gist::Order(Frame const& frameIn) {
 }
 
 void Action_Gist::Print() {
+  if (dTSorient_norm_.empty()) return; // In case Action was not Setup
   gist_print_.Start();
   // Implement NN to compute orientational entropy for each voxel
   double NNr, rx, ry, rz, rR, dbl;

--- a/src/Action_Molsurf.cpp
+++ b/src/Action_Molsurf.cpp
@@ -166,6 +166,10 @@ Action::RetType Action_Molsurf::Setup(ActionSetup& setup) {
     mprintf("Warning: Mask contains 0 atoms.\n");
     return Action::ERR;
   }
+  if (radiiMode_ == VDW && !setup.Top().Nonbond().HasNonbond()) {
+    mprinterr("Error: Topology '%s' does not have vdW radii info.\n", setup.Top().c_str());
+    return Action::ERR;
+  }
 
   mprintf("\tCalculating surface area for %i atoms.\n",Mask1_.Nselected());
   // NOTE: If Mask is * dont include any solvent?

--- a/src/Action_Pairwise.cpp
+++ b/src/Action_Pairwise.cpp
@@ -140,7 +140,7 @@ int Action_Pairwise::SetupNonbondParm(AtomMask const& maskIn, Topology const& Pa
   // Check if LJ parameters present - need at least 2 atoms for it to matter.
   if (ParmIn.Natom() > 1 && !ParmIn.Nonbond().HasNonbond()) {
     mprinterr("Error: Topology does not have LJ information.\n");
-    return 1;
+    return -1;
   }
 
   // Determine the actual number of pairwise interactions that will be calcd.
@@ -179,7 +179,7 @@ Action::RetType Action_Pairwise::Setup(ActionSetup& setup) {
 
   // Set up exclusion list and determine total # interactions.
   int N_interactions = SetupNonbondParm(Mask0_, setup.Top());
-
+  if (N_interactions == -1) return Action::ERR;
   // Allocate matrix memory
   int previous_size = (int)vdwMat_->Size();
   if (previous_size == 0) {
@@ -458,6 +458,7 @@ Action::RetType Action_Pairwise::DoAction(int frameNum, ActionFrame& frm) {
 }
 
 void Action_Pairwise::Print() {
+  if (nframes_ < 1) return;
   // Divide matrices by # of frames
   double norm = 1.0 / (double)nframes_;
   for (unsigned int i = 0; i != vdwMat_->Size(); i++)

--- a/src/Analysis_LowestCurve.cpp
+++ b/src/Analysis_LowestCurve.cpp
@@ -62,10 +62,17 @@ Analysis::RetType Analysis_LowestCurve::Analyze() {
                                DS != input_dsets_.end();
                              ++DS, ++OUT)
   {
-    // Determine an appropriate dimension based on the step size.
+    // Determine an appropriate dimension based on the step size. Since there
+    // is no guarantee that X values are in order (e.g. in XY MESH), get
+    // min/max directly.
     HistBin Xdim;
     double min = (*DS)->Xcrd(0);
     double max = (*DS)->Xcrd((*DS)->Size()-1);
+    for (unsigned int n = 0; n != (*DS)->Size(); ++n) {
+      double xval = (*DS)->Xcrd( n );
+      min = std::min( min, xval );
+      max = std::max( max, xval );
+    }
     if (Xdim.CalcBinsOrStep(min,max,step_,-1,(*DS)->Dim(Dimension::X).Label())) continue;
     Larray bins_( Xdim.Bins() + 1 );
     mprintf("\tSet '%s' has %i bins (%g < %g, %g)\n", (*DS)->legend(),

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -408,7 +408,7 @@ int CpptrajState::RunEnsemble() {
         // Silence action output for all beyond first member.
         if (member > 0)
           SetWorldSilent( true );
-        if (ActionEnsemble[member]->SetupActions( EnsembleParm[member] )) {
+        if (ActionEnsemble[member]->SetupActions( EnsembleParm[member], exitOnError_ )) {
 #         ifdef MPI
           rprintf("Warning: Ensemble member %i: Could not set up actions for %s: skipping.\n",
                   worldrank, EnsembleParm[member].Top().c_str());
@@ -602,7 +602,7 @@ int CpptrajState::RunNormal() {
     // If Parm has changed, reset actions for new topology.
     if (parmHasChanged) {
       // Set up actions for this parm
-      if (actionList_.SetupActions( currentParm )) {
+      if (actionList_.SetupActions( currentParm, exitOnError_ )) {
         mprintf("WARNING: Could not set up actions for %s: skipping.\n",
                 currentParm.Top().c_str());
         continue;

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -34,7 +34,7 @@ void DataIO_Std::ReadHelp() {
           "\tread2d:      Read data as 2D square matrix.\n"
           "\tvector:      Read data as vector: VX VY VZ [OX OY OZ]\n"
           "\tmat3x3:      Read data as 3x3 matrices: M(1,1) M(1,2) ... M(3,2) M(3,3)\n"
-          "\tindex <col>: (1D) Use column # (starting from 1) as index column.\n");
+          "\tindex <col>: (1D) Use column # (starting from 1) as index (X) column.\n");
 
 }
 

--- a/src/RPNcalc.cpp
+++ b/src/RPNcalc.cpp
@@ -79,9 +79,14 @@ int RPNcalc::ProcessExpression(std::string const& expression) {
             hasExponent = -1;
             ++ptr;
           }
+          else if (*ptr == '+')
+          {
+            hasExponent = 1;
+            ++ptr;
+          }
           else
             hasExponent = 1;
-        } 
+        }
       }
       if (debug_ > 0) mprintf("Number detected: %s\n", number.c_str());
       std::istringstream iss(number);

--- a/src/StringRoutines.cpp
+++ b/src/StringRoutines.cpp
@@ -167,7 +167,7 @@ bool validInteger(std::string const &argument) {
   if (argument.empty()) return false;
   std::locale loc;
   std::string::const_iterator c;
-  if (argument[0]=='-') {
+  if (argument[0]=='-' || argument[0]=='+') {
     c = argument.begin()+1;
     if (c == argument.end()) return false;
   } else
@@ -178,26 +178,11 @@ bool validInteger(std::string const &argument) {
 }
 
 // validDouble()
-bool validDouble(std::string const &argument) {
+bool validDouble(std::string const& argument) {
   if (argument.empty()) return false;
-  std::locale loc;
-  std::string::const_iterator c;
-  bool hasDecPt = (argument[0]=='.');
-  if (argument[0]=='-' || hasDecPt) {
-    c = argument.begin()+1;
-    if (c == argument.end()) return false;
-  } else
-    c = argument.begin();
-  if (!isdigit(*c,loc)) return false;
-  for (; c != argument.end(); ++c)
-  {
-    if (*c == 'e' || *c == 'E')
-      return validInteger( argument.substr(c - argument.begin() + 1) );
-    bool isDecPt = (*c == '.');
-    if (!isdigit(*c,loc) && (!isDecPt || (hasDecPt && isDecPt))) return false;
-    if (isDecPt) hasDecPt = true;
-  }
-  return true;
+  std::istringstream iss(argument);
+  double val;
+  return (iss >> val);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Add code in actions that use non-bonded parameters (Lennard-Jones or vdW radius) that checks if non-bonded parameters are actually present (prevents segfaults). Improve number detection. Also do not assume that X values are in order in `lowestcurve`, which could result in incorrect X bins for XY Mesh data sets. Addresses part of #131 and fixes segfault from #102.