### PR TITLE
Adding in support for Amber netcdf trajectories with forces

### DIFF
--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -28,6 +28,7 @@ class CoordinateInfo {
     void SetTime(bool m)        { hasTime_ = m; }
     void SetTemperature(bool t) { hasTemp_ = t; }
     void SetVelocity(bool v)    { hasVel_ = v;  }
+    void SetForce(bool f)       { hasFrc_ = f;  }
     void SetEnsembleSize(int s) { ensembleSize_ = s; }
     void SetBox(Box const& b)   { box_ = b;     }
     void SetReplicaDims(ReplicaDimArray const& r) { remdDim_ = r; }

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -32,6 +32,7 @@ Frame::Frame( ) :
   time_(0.0),
   X_(0),
   V_(0),
+  F_(0),
   memIsExternal_(false)
 {}
 
@@ -41,6 +42,7 @@ Frame::~Frame( ) {
   if (!memIsExternal_) {
     if (X_ != 0) delete[] X_;
     if (V_ != 0) delete[] V_;
+    if (F_ != 0) delete[] F_;
   }
 }
 
@@ -53,6 +55,7 @@ Frame::Frame(int natomIn) :
   time_(0.0),
   X_(0),
   V_(0),
+  F_(0),
   Mass_(natomIn, 1.0),
   memIsExternal_(false)
 {
@@ -69,6 +72,7 @@ Frame::Frame(std::vector<Atom> const& atoms) :
   time_(0.0),
   X_(0),
   V_(0),
+  F_(0),
   memIsExternal_(false)
 {
   if (ncoord_ > 0) {
@@ -89,6 +93,7 @@ Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) :
   time_( frameIn.time_ ),
   X_(0),
   V_(0),
+  F_(0),
   remd_indices_(frameIn.remd_indices_),
   memIsExternal_(false)
 {
@@ -96,27 +101,36 @@ Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) :
     Mass_.reserve(natom_);
     X_ = new double[ ncoord_ ];
     double* newX = X_;
-    if ( frameIn.V_ != 0 ) {
-      // Copy coords/mass/velo
-      V_ = new double[ ncoord_ ];
-      double* newV = V_;
-      for (AtomMask::const_iterator atom = maskIn.begin(); atom != maskIn.end(); ++atom)
-      {
-        int oldcrd = ((*atom) * 3);
-        memcpy(newX, frameIn.X_ + oldcrd, COORDSIZE_);
-        newX += 3;
+    double* newV = NULL;
+    double* newF = NULL;
+    bool dupV = false;
+    bool dupF = false;
+   
+    // check if we should copy velocities
+    if ( frameIn.V_ != 0 ){
+      dupV = true;
+      newV = new double[ ncoord_ ];
+    }
+    // check if we should copy forces
+    if ( frameIn.F_ != 0 ){
+      dupF = true;
+      newF = new double[ ncoord_ ];
+    }
+
+    // do the copying
+    for (AtomMask::const_iterator atom = maskIn.begin(); atom != maskIn.end(); ++atom){
+      int oldcrd = ((*atom) * 3);
+      memcpy(newX, frameIn.X_ + oldcrd, COORDSIZE_);
+      newX += 3;
+      if ( dupV ){
         memcpy(newV, frameIn.V_ + oldcrd, COORDSIZE_);
         newV += 3;
-        Mass_.push_back( frameIn.Mass_[*atom] );
       }
-    } else {
-      // Copy coords/mass
-      for (AtomMask::const_iterator atom = maskIn.begin(); atom != maskIn.end(); ++atom)
-      {
-        memcpy(newX, frameIn.X_ + ((*atom) * 3), COORDSIZE_);
-        newX += 3;
-        Mass_.push_back( frameIn.Mass_[*atom] );
+      if ( dupF ){
+        memcpy(newF, frameIn.F_ + oldcrd, COORDSIZE_);
+        newF += 3;
       }
+      Mass_.push_back( frameIn.Mass_[*atom] );
     }
   }
 }
@@ -128,6 +142,7 @@ Frame::Frame(int natom, double* Xptr) :
   ncoord_(natom*3),
   X_(Xptr),
   V_(0),
+  F_(0),
   Mass_(natom, 1.0),
   memIsExternal_(true)
 {
@@ -147,6 +162,7 @@ Frame::Frame(const Frame& rhs) :
   time_(rhs.time_),
   X_(0),
   V_(0),
+  F_(0),
   remd_indices_(rhs.remd_indices_),
   Mass_(rhs.Mass_),
   memIsExternal_(rhs.memIsExternal_)
@@ -154,8 +170,9 @@ Frame::Frame(const Frame& rhs) :
   if (memIsExternal_) {
     X_ = rhs.X_;
     V_ = rhs.V_;
+    F_ = rhs.F_;
   } else {
-    // Copy coords/velo; allocate for maxnatom but copy natom
+    // Copy coords/velo/forces; allocate for maxnatom but copy natom
     int maxncoord = maxnatom_ * 3;
     if (rhs.X_!=0) {
       X_ = new double[ maxncoord ];
@@ -164,6 +181,10 @@ Frame::Frame(const Frame& rhs) :
     if (rhs.V_!=0) {
       V_ = new double[ maxncoord ];
       memcpy(V_, rhs.V_, natom_ * COORDSIZE_);
+    }
+    if (rhs.F_!=0) {
+      F_ = new double[ maxncoord ];
+      memcpy(F_, rhs.F_, natom_ * COORDSIZE_);
     }
   }
 }
@@ -1150,6 +1171,8 @@ int Frame::SendFrame(int recvrank) {
   parallel_send( X_,                ncoord_, PARA_DOUBLE, recvrank, 1212 );
   if (V_ != 0)
     parallel_send( V_,              ncoord_, PARA_DOUBLE, recvrank, 1215 );
+  if (F_ != 0)
+    parallel_send( F_,              ncoord_, PARA_DOUBLE, recvrank, 1218 );
   parallel_send( box_.boxPtr(),     6,       PARA_DOUBLE, recvrank, 1213 );
   parallel_send( &T_,               1,       PARA_DOUBLE, recvrank, 1214 );
   parallel_send( &time_,            1,       PARA_DOUBLE, recvrank, 1217 );
@@ -1163,6 +1186,8 @@ int Frame::RecvFrame(int sendrank) {
   parallel_recv( X_,                ncoord_, PARA_DOUBLE, sendrank, 1212 );
   if (V_ != 0)
     parallel_recv( V_,              ncoord_, PARA_DOUBLE, sendrank, 1215 );
+  if (F_ != 0)
+    parallel_recv( F_,              ncoord_, PARA_DOUBLE, sendrank, 1218 );
   parallel_recv( box_.boxPtr(),     6,       PARA_DOUBLE, sendrank, 1213 );
   parallel_recv( &T_,               1,       PARA_DOUBLE, sendrank, 1214 );
   parallel_recv( &time_,            1,       PARA_DOUBLE, sendrank, 1217 );

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -217,6 +217,7 @@ class Frame {
     double time_;   ///< Time FIXME Should this be float?
     double* X_;     ///< Coord array, X0 Y0 Z0 X1 Y1 Z1 ...
     double* V_;     ///< Velocities (same arrangement as Coords).
+    double* F_;     ///< Frame (same arrangement as Coords).
     RemdIdxType remd_indices_; ///< replica indices.
     Darray Mass_;   ///< Masses.
     bool memIsExternal_; ///< True if Frame is not responsible for freeing memory.

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -57,6 +57,7 @@ NetcdfFile::NetcdfFile() :
   TempVID_(-1),
   coordVID_(-1),
   velocityVID_(-1),
+  frcVID_(-1),
   cellAngleVID_(-1),
   cellLengthVID_(-1),
   timeVID_(-1),
@@ -241,6 +242,11 @@ int NetcdfFile::SetupCoordsVelo(bool useVelAsCoords) {
     mprintf("\tUsing velocities as coordinates.\n");
     coordVID_ = velocityVID_;
     velocityVID_ = -1;
+  }
+  // Get force info
+  frcVID_ = -1;
+  if ( nc_inq_varid(ncid_, NCFRC, &frcVID_) == NC_NOERR ) {
+    if (ncdebug_>0) mprintf("    Netcdf file has forces.\n");
   }
   // Get overall replica and coordinate indices
   crdidxVID_ = -1;
@@ -902,9 +908,9 @@ void NetcdfFile::WriteIndices() const {
 }
 
 void NetcdfFile::WriteVIDs() const {
-  rprintf("TempVID_=%i  coordVID_=%i  velocityVID_=%i  cellAngleVID_=%i"
+  rprintf("TempVID_=%i  coordVID_=%i  velocityVID_=%i frcVID_=%i  cellAngleVID_=%i"
           "  cellLengthVID_=%i  indicesVID_=%i\n",
-          TempVID_, coordVID_, velocityVID_, cellAngleVID_, cellLengthVID_, indicesVID_);
+          TempVID_, coordVID_, velocityVID_, frcVID_, cellAngleVID_, cellLengthVID_, indicesVID_);
 }
 
 void NetcdfFile::Sync() {

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -39,6 +39,7 @@ class NetcdfFile {
     inline int Ncatom3()  const { return ncatom3_; }
     inline int Ncframe()  const { return ncframe_; }
     inline int CoordVID() const { return coordVID_; }
+    bool HasForces()       { return (frcVID_ != -1); }
     bool HasVelocities()   { return (velocityVID_ != -1); }
     bool HasCoords()       { return (coordVID_ != -1);    }
     bool HasTemperatures() { return (TempVID_ != -1);     }

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -15,7 +15,8 @@ Traj_AmberNetcdf::Traj_AmberNetcdf() :
   useVelAsCoords_(false),
   readAccess_(false),
   outputTemp_(false),
-  outputVel_(false)
+  outputVel_(false),
+  outputFrc_(false)
 { }
 
 // DESTRUCTOR
@@ -106,9 +107,8 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
   // Replica Dimensions
   ReplicaDimArray remdDim;
   if ( SetupMultiD(remdDim) == -1 ) return TRAJIN_ERR;
-  // Set traj info: FIXME - no forces yet
   SetCoordInfo( CoordinateInfo(remdDim, Box(boxcrd), HasVelocities(),
-                               HasTemperatures(), HasTimes(), false) ); 
+                               HasTemperatures(), HasTimes(), HasForces()) ); 
   // NOTE: TO BE ADDED
   // labelDID;
   //int cell_spatialDID, cell_angularDID;
@@ -124,13 +124,15 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
 
 void Traj_AmberNetcdf::WriteHelp() {
   mprintf("\tremdtraj: Write temperature to trajectory (makes REMD trajectory).\n"
-          "\tvelocity: Write velocities to trajectory.\n");
+          "\tvelocity: Write velocities to trajectory.\n"
+          "\tforce: Write forces to trajectory.\n");
 }
 
 // Traj_AmberNetcdf::processWriteArgs()
 int Traj_AmberNetcdf::processWriteArgs(ArgList& argIn) {
   outputTemp_ = argIn.hasKey("remdtraj");
   outputVel_ = argIn.hasKey("velocity");
+  outputFrc_ = argIn.hasKey("force");
   return 0;
 }
 
@@ -150,6 +152,7 @@ int Traj_AmberNetcdf::setupTrajout(FileName const& fname, Topology* trajParm,
     if (outputTemp_ && !cInfo.HasTemp()) cInfo.SetTemperature(true);
     // Explicitly write velocity - initial frames may not have velocity info.
     if (outputVel_ && !cInfo.HasVel()) cInfo.SetVelocity(true);
+    if (outputFrc_ && !cInfo.HasForce()) cInfo.SetForce(true);
     SetCoordInfo( cInfo );
     filename_ = fname;
     // Set up title
@@ -174,6 +177,9 @@ int Traj_AmberNetcdf::setupTrajout(FileName const& fname, Topology* trajParm,
               filename_.base());
     if (outputVel_ && !CoordInfo().HasVel())
       mprintf("Warning: Cannot append velocity data to NetCDF file '%s'; no velocity dimension.\n",
+              filename_.base());
+    if (outputFrc_ && !CoordInfo().HasForce())
+      mprintf("Warning: Cannot append velocity data to NetCDF file '%s'; no force diemnsion.\n",
               filename_.base());
     if (debug_ > 0)
       mprintf("\tNetCDF: Appending %s starting at frame %i\n", filename_.base(), Ncframe()); 
@@ -233,6 +239,15 @@ int Traj_AmberNetcdf::readFrame(int set, Frame& frameIn) {
     FloatToDouble(frameIn.vAddress(), Coord_);
   }
 
+  // Read Forces
+  if (frcVID_ != -1) {
+    if ( checkNCerr(nc_get_vara_float(ncid_, frcVID_, start_, count_, Coord_)) ) {
+      mprinterr("Error: Getting forces for frame %i\n", set+1);
+      return 1;
+    }
+    FloatToDouble(frameIn.vAddress(), Coord_);
+  }
+
   // Read indices. Input array must be allocated to be size remd_dimension.
   if (indicesVID_!=-1) {
     count_[1] = remd_dimension_;
@@ -276,6 +291,25 @@ int Traj_AmberNetcdf::readVelocity(int set, Frame& frameIn) {
   if (velocityVID_ != -1) {
     if ( checkNCerr(nc_get_vara_float(ncid_, velocityVID_, start_, count_, Coord_)) ) {
       mprinterr("Error: Getting velocities for frame %i\n", set+1);
+      return 1;
+    }
+    FloatToDouble(frameIn.vAddress(), Coord_);
+  }
+  return 0;
+}
+
+// Traj_AmberNetcdf::readForce()
+int Traj_AmberNetcdf::readForce(int set, Frame& frameIn) {
+  start_[0] = set;
+  start_[1] = 0;
+  start_[2] = 0;
+  count_[0] = 1;
+  count_[1] = Ncatom();
+  count_[2] = 3;
+  // Read Velocities
+  if (velocityVID_ != -1) {
+    if ( checkNCerr(nc_get_vara_float(ncid_, frcVID_, start_, count_, Coord_)) ) {
+      mprinterr("Error: Getting forces for frame %i\n", set+1);
       return 1;
     }
     FloatToDouble(frameIn.vAddress(), Coord_);
@@ -415,6 +449,7 @@ void Traj_AmberNetcdf::Info() {
   mprintf("is a NetCDF AMBER trajectory");
   if (readAccess_ && !HasCoords()) mprintf(" (no coordinates)");
   if (CoordInfo().HasVel()) mprintf(" containing velocities");
+  if (CoordInfo().HasForce()) mprintf(" containing forces");
   if (CoordInfo().HasTemp()) mprintf(" with replica temperatures");
   if (remd_dimension_ > 0) mprintf(", with %i dimensions", remd_dimension_);
 }

--- a/src/Traj_AmberNetcdf.h
+++ b/src/Traj_AmberNetcdf.h
@@ -20,6 +20,7 @@ class Traj_AmberNetcdf : public TrajectoryIO, private NetcdfFile {
     void closeTraj();
     int readFrame(int,Frame&);
     int readVelocity(int, Frame&);
+    int readForce(int, Frame&);
     int writeFrame(int,Frame const&);
     void Info();
     int processWriteArgs(ArgList&);
@@ -36,6 +37,7 @@ class Traj_AmberNetcdf : public TrajectoryIO, private NetcdfFile {
     bool readAccess_;
     bool outputTemp_;
     bool outputVel_;
+    bool outputFrc_;
 };
 // ----- INLINE FUNCTIONS ------------------------------------------------------
 int Traj_AmberNetcdf::createReservoir(bool hasBins, double reservoirT, int iseed) {


### PR DESCRIPTION
Very minor addition to support the reading and writing of Netcdf trajectories with forces. The modifications pass the included unit tests. Here is an output of Summary.sh:

bash-4.2$ ./Summary.sh 
-rwxr-xr-x 1 clee mccammon 4311732 Oct 28 16:39 /net/home/clee/.local/cpptraj/bin/cpptraj
**************************************************************
TEST: /net/home/clee/.local/cpptraj/test
===================== TEST SUMMARY ======================
  241 out of 241 comparisons OK (0 failed).
  62 out of 62 tests completed with no issues.
ls: cannot access */Test_Error.dat: No such file or directory
=========================================================
