### PR TITLE
Fix potential segfault with volmap

### DIFF
--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -5,7 +5,6 @@
 #include "CpptrajStdio.h"
 
 const double Action_Volmap::sqrt_8_pi_cubed = sqrt(8.0*Constants::PI*Constants::PI*Constants::PI);
-const double Action_Volmap::one_over_6 = 1.0 / 6.0;
 // CONSTRUCTOR
 Action_Volmap::Action_Volmap() :
   dx_(0.0), dy_(0.0), dz_(0.0),
@@ -163,8 +162,15 @@ Action::RetType Action_Volmap::Setup(ActionSetup& setup) {
   // Set up our radii_
   halfradii_.clear();
   halfradii_.reserve( setup.Top().Natom() );
-  for (int i = 0; i < setup.Top().Natom(); i++)
-    halfradii_.push_back( (float)(setup.Top().GetVDWradius(i) * radscale_ / 2) );
+  if (setup.Top().Nonbond().HasNonbond()) {
+    for (int i = 0; i < setup.Top().Natom(); i++)
+      halfradii_.push_back( (float)(setup.Top().GetVDWradius(i) * radscale_ / 2) );
+  } else {
+    for (Topology::atom_iterator it = setup.Top().begin();
+            it != setup.Top().end(); it++) {
+      halfradii_.push_back( (float)(it->ElementRadius() * radscale_ / 2) );
+    }
+  }
 
   // DEBUG
 //for (AtomMask::const_iterator it = densitymask_.begin(); it != densitymask_.end(); it++)

--- a/src/Action_Volmap.h
+++ b/src/Action_Volmap.h
@@ -39,6 +39,5 @@ class Action_Volmap : public Action {
     /// the scaling factor to divide all radii by
     double radscale_;
     static const double sqrt_8_pi_cubed;
-    static const double one_over_6;
 };
 #endif

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -55,7 +55,25 @@ const double Atom::AtomicElementMass[NUMELEMENTS] = { 1.0,
   180.94788,  204.3833,    50.9415,    183.84,     131.293,    91.224,
    88.90585,  174.9668,
     0.0
-};  
+};
+
+/** Values taken from parm10.dat and ion frcmod files as the average Rmin/2
+  * parameter for that element type. (HO types ignored in average, since
+  * they are 0). Unknown values set to 1.00
+  *
+  * Silicon radius taken from http://www.chem.hope.edu/~krieg/shorb/ (2.419)
+  */
+const double Atom::AtomicElementRadius[NUMELEMENTS] = { 1.0,
+  1.212, 1.000, 1.908, 1.824, 1.724, 1.750, 2.100, 2.000, 1.948, 2.220,
+  1.353, 1.649, 2.860, 1.360, 1.218, 1.025, 1.705, 1.813, 1.976, 1.271,
+  1.369, 1.297, 1.000, 1.000, 1.500, 1.000, 1.000, 0.956, 2.019, 1.000,
+  1.344, 1.299, 1.412, 1.000, 1.000, 1.000, 1.000, 1.000, 1.407, 1.000,
+  1.000, 1.000, 1.407, 1.000, 1.000, 1.255, 1.000, 1.000, 1.303, 1.266,
+  1.745, 1.000, 1.000, 1.000, 1.000, 1.000, 2.019, 2.419, 1.000, 1.000,
+  1.000, 1.666, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000,
+  1.000, 1.000, 1.000,
+  0.000 /* extra point has no radius */
+};
 
 // CONSTRUCTOR
 Atom::Atom() : charge_(0.0), polar_(0.0), mass_(1.0), gb_radius_(0.0),

--- a/src/Atom.h
+++ b/src/Atom.h
@@ -60,6 +60,7 @@ class Atom {
     inline AtomicElementType Element() const { return element_; }
     inline int AtomicNumber()          const { return AtomicElementNum[element_];  }
     inline const char* ElementName()   const { return AtomicElementName[element_]; }
+    inline const double ElementRadius()const { return AtomicElementRadius[element_]; }
     inline const NameType& Name()      const { return aname_; }
     inline const NameType& Type()      const { return atype_; }
     inline int TypeIndex()             const { return atype_index_; }
@@ -90,6 +91,7 @@ class Atom {
     static const int AtomicElementNum[];
     static const char* AtomicElementName[];
     static const double AtomicElementMass[];
+    static const double AtomicElementRadius[];
     double charge_;    ///< Charge in e-
     double polar_;     ///< Atomic polarizability in Ang^3
     double mass_;      ///< mass in amu


### PR DESCRIPTION
Also adds a default set of radii to use when parameters are not available in the topology.