### PR TITLE
Fix overzealous error message for no topologies loaded.

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -1815,7 +1815,10 @@ static void Help_ScaleDihedralK() {
 Command::RetType ScaleDihedralK(CpptrajState& State, ArgList& argIn, Command::AllocType Alloc)
 {
   Topology* parm = State.DSL()->GetTopology( argIn );
-  if (parm == 0) return Command::C_ERR;
+  if (parm == 0) {
+    mprinterr("Error: No topologies loaded.\n");
+    return Command::C_ERR;
+  }
   double scale_factor = argIn.getNextDouble(1.0);
   std::string maskexpr = argIn.GetMaskNext();
   bool useAll = argIn.hasKey("useall");

--- a/src/DataSetList.cpp
+++ b/src/DataSetList.cpp
@@ -677,10 +677,7 @@ const char* DataSetList::TopArgs = "parm <name> | parmindex <#>";
 
 // DataSetList::GetTopology()
 Topology* DataSetList::GetTopology(ArgList& argIn) const {
-  if (TopList_.empty()) {
-    mprinterr("Error: No topologies loaded.\n");
-    return 0;
-  }
+  if (TopList_.empty()) return 0;
   DataSet* top = 0;
   std::string topname = argIn.GetStringKey("parm");
   if (!topname.empty()) {
@@ -703,10 +700,7 @@ Topology* DataSetList::GetTopology(ArgList& argIn) const {
 
 // DataSetList::GetTopByIndex()
 Topology* DataSetList::GetTopByIndex(ArgList& argIn) const {
-  if (TopList_.empty()) {
-    mprinterr("Error: No topologies loaded.\n");
-    return 0;
-  }
+  if (TopList_.empty()) return 0;
   Topology* top = GetTopology( argIn );
   if (top == 0) {
     int topindex = argIn.getNextInteger(-1);


### PR DESCRIPTION
Do not print error message when no Topology DataSets in DataSetList; leave it to calling methods to decide if this is an error or not. Should fix extraneous error messages in pytraj output mentioned in Amber-MD/pytraj#985.