### PR TITLE
Fix vectraj and crd

### DIFF
--- a/src/DataIO_VecTraj.h
+++ b/src/DataIO_VecTraj.h
@@ -16,5 +16,6 @@ class DataIO_VecTraj : public DataIO {
   private:
     TrajectoryFile::TrajFormatType trajoutFmt_;
     std::string parmoutName_;
+    bool includeOrigin_;
 };
 #endif

--- a/src/DataSet_Vector.h
+++ b/src/DataSet_Vector.h
@@ -34,6 +34,7 @@ class DataSet_Vector : public DataSet {
         return ZERO;
       return origins_[i];
     }
+    bool HasOrigins()             const { return !origins_.empty(); }
     void ReserveVecs(size_t n)          { vectors_.reserve( n );   }
     void AddVxyz(Vec3 const& v)         { vectors_.push_back( v ); }
     void AddVxyz(Vec3 const& v, Vec3 const& c) {


### PR DESCRIPTION
Two minor fixes. The first improves `vectraj` output by not writing out origins if no origin data is present in the vector data sets, as well as giving users the option to just prevent writing of origin data. The second skips box detection in Amber coordinate trajectories when the number of atoms is less than 3. I wish we could retire that format...

Addresses #161.