### PR TITLE
Remove uses of ParmBox where incorrect

### DIFF
--- a/src/Action_Channel.cpp
+++ b/src/Action_Channel.cpp
@@ -47,7 +47,7 @@ Action::RetType Action_Channel::Setup(ActionSetup& setup) {
   // Initial grid setup
   if (grid_->Size() == 0) {
     DataSet_3D& GRID = static_cast<DataSet_3D&>( *grid_ );
-    Box const& box = setup.Top().ParmBox();
+    Box const& box = setup.CoordInfo().TrajBox();
     if (box.Type() == Box::NOBOX) {
       mprinterr("Error: No box information to set up grid.\n");
       return Action::ERR;

--- a/src/DataSet_Coords_CRD.cpp
+++ b/src/DataSet_Coords_CRD.cpp
@@ -11,7 +11,7 @@ int DataSet_Coords_CRD::CoordsSetup(Topology const& topIn, CoordinateInfo const&
   top_ = topIn;
   cInfo_ = cInfoIn;
   numCrd_ = top_.Natom() * 3;
-  if (top_.ParmBox().HasBox())
+  if (cInfo_.TrajBox().HasBox())
     numBoxCrd_ = 6;
   else
     numBoxCrd_ = 0;

--- a/src/GridAction.cpp
+++ b/src/GridAction.cpp
@@ -33,7 +33,7 @@ DataSet_GridFlt* GridAction::GridInit(const char* callingRoutine, ArgList& argIn
     // Get grid parameters from reference structure box.
     DataSet_Coords_REF* REF = (DataSet_Coords_REF*)DSL.FindSetOfType( refname, DataSet::REF_FRAME );
     if (REF == 0) return 0;
-    if (REF->Top().ParmBox().Type() == Box::NOBOX) {
+    if (REF->CoordsInfo().TrajBox().Type() == Box::NOBOX) {
       mprinterr("Error: Reference '%s' does not have box information.\n", refname.c_str());
       return 0;
     }


### PR DESCRIPTION
Fix last few places where box info from Topology incorrectly used instead of box info from CoordinateInfo.