### PR TITLE
Truncated octahedron box detection.

### DIFF
--- a/src/Box.h
+++ b/src/Box.h
@@ -51,13 +51,13 @@ class Box {
   private:
     static inline bool IsTruncOct(double);
     static inline bool BadTruncOctAngle(double);
-    void SetTruncOctAngles();
     void SetBoxType();
 
     static const double TRUNCOCTBETA_;
     static const double TruncOctDelta_;
     static const double TruncOctMin_;
     static const double TruncOctMax_;
+    static const double TruncOctEps_;
     static const char* BoxNames_[];
     //int debug_; // TODO: Replace with ifdefs or just comment out?
     BoxType btype_; ///< Box type

--- a/src/Box.h
+++ b/src/Box.h
@@ -12,7 +12,7 @@ class Box {
     Box(const Box&);
     Box& operator=(const Box&);
 
-    const char* TypeName() const; 
+    const char* TypeName() const { return BoxNames_[btype_]; }
 
     void SetBetaLengths(double,double,double,double);
     void SetBox(const double*);
@@ -49,12 +49,18 @@ class Box {
     double const& operator[](int idx) const { return box_[idx]; }
     double&       operator[](int idx)       { return box_[idx]; }
   private:
-    static const double TRUNCOCTBETA;
-    static const char* BoxNames[];
-    //int debug_; // TODO: Replace with ifdefs or just comment out?
-    BoxType btype_;
-    double box_[6];
-
+    static inline bool IsTruncOct(double);
+    static inline bool BadTruncOctAngle(double);
+    void SetTruncOctAngles();
     void SetBoxType();
+
+    static const double TRUNCOCTBETA_;
+    static const double TruncOctDelta_;
+    static const double TruncOctMin_;
+    static const double TruncOctMax_;
+    static const char* BoxNames_[];
+    //int debug_; // TODO: Replace with ifdefs or just comment out?
+    BoxType btype_; ///< Box type
+    double box_[6]; ///< Box X Y Z alpha beta gamma
 };
 #endif


### PR DESCRIPTION
Improve detection of low-precision truncated octahedron angles. Also add a warning message when precision is low and inform users about using `box` command to use higher precision truncated octahedron angles. Addresses issues brought up in #171.