### PR TITLE
DRR - Cpptraj: Fully initialize matrix in blas/lapack test; can cause…

### DIFF
--- a/configure
+++ b/configure
@@ -140,7 +140,9 @@ extern "C" {
 int main() {
   int n_cols = 3, lwork = 102, info;
   double work[102], mat[9], vec[3], alpha = 1.0;
-  mat[0] = 1.0; mat[4] = 1.0; mat[8] = 1.0;
+  mat[0] = 1.0; mat[1] = 1.0; mat[2] = 1.0;
+  mat[3] = 1.0; mat[4] = 1.0; mat[5] = 1.0;
+  mat[6] = 1.0; mat[7] = 1.0; mat[8] = 1.0;
   dsyev_((char*)"V", (char*)"U", n_cols, mat, n_cols, vec, work, lwork, info);
   dgemm_((char*)"N",(char*)"N", n_cols, n_cols, n_cols, alpha,
          mat, n_cols, mat, n_cols, alpha, mat, n_cols);


### PR DESCRIPTION
… resulting binary to hang with certain compilers/optimizations.