### PR TITLE
Add Appveyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For more information see the following publication:
 Build Status
 =============
 [![Build Status](https://travis-ci.org/Amber-MD/cpptraj.svg?branch=master)](https://travis-ci.org/Amber-MD/cpptraj)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/Amber-MD/cpptraj?branch=master&svg=true&retina=true)](https://ci.appveyor.com/project/drroe/cpptraj-aof9y/branch/master)
 
 Disclaimer and Copyright
 ========================


### PR DESCRIPTION
Adds build status badge.

Also, I submitted a PR to the msys2 package repo (https://github.com/Alexpux/MINGW-packages/pull/921) to add a recipe upstream for netcdf, so at some point (if it gets merged) it should become possible to remove the necessity for rebuilding netcdf in each PR on windows.