### PR TITLE
Do not depend in isatty on Windows

### DIFF
--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -315,15 +315,14 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
   if (interactive) {
     // User explicitly requested ``--interactive``. Do not check isatty.
     return INTERACTIVE;
-  }
-  if (!hasInput && isatty(fileno(stdin))) {
-     // No input and stdin is a console tty
-    return INTERACTIVE;
-  } else {
-    // "" means read from STDIN
-    Command::RetType c_err = Command::ProcessInput( State_, "" );
-    if (c_err == Command::C_ERR && State_.ExitOnError()) return ERROR;
-    if (c_err == Command::C_QUIT) return QUIT;
+  } else if (!hasInput) {
+    if (isatty(fileno(stdin)))
+      return INTERACTIVE;
+    else {
+      Cmd::RetType c_err = Command::ProcessInput( State_, "" );
+      if (c_err == Cmd::ERR && State_.ExitOnError()) return ERROR;
+      if (c_err == Cmd::QUIT) return QUIT;
+    }
   }
   return BATCH;
 }

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -311,23 +311,19 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
       if (c_err == Command::C_QUIT) return QUIT;
     }
   }
-  // Determine whether to enter interactive mode
-  if (!hasInput || interactive) {
-    // Test if input is really from a console
-    if ( isatty(fileno(stdin)) ) {
-      return INTERACTIVE;
-    }
-#ifdef _WIN32
-    else if (true) {
-      return INTERACTIVE;
-    }
-#endif
-    else {
-      // "" means read from STDIN
-      Command::RetType c_err = Command::ProcessInput( State_, "" ); 
-      if (c_err == Command::C_ERR && State_.ExitOnError()) return ERROR;
-      if (c_err == Command::C_QUIT) return QUIT;
-    }
+  // Determine whether to enter interactive mode.
+  if (interactive) {
+    // User explicitly requested ``--interactive``. Do not check isatty.
+    return INTERACTIVE;
+  }
+  if (!hasInput && isatty(fileno(stdin))) {
+     // No input and stdin is a console tty
+    return INTERACTIVE;
+  } else {
+    // "" means read from STDIN
+    Command::RetType c_err = Command::ProcessInput( State_, "" );
+    if (c_err == Command::C_ERR && State_.ExitOnError()) return ERROR;
+    if (c_err == Command::C_QUIT) return QUIT;
   }
   return BATCH;
 }

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -314,8 +314,14 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
   // Determine whether to enter interactive mode
   if (!hasInput || interactive) {
     // Test if input is really from a console
-    if ( isatty(fileno(stdin)) )
+    if ( isatty(fileno(stdin)) ) {
       return INTERACTIVE;
+    }
+#ifdef _WIN32
+    else if (true) {
+      return INTERACTIVE;
+    }
+#endif
     else {
       // "" means read from STDIN
       Command::RetType c_err = Command::ProcessInput( State_, "" ); 

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -70,7 +70,7 @@ int Cpptraj::RunCpptraj(int argc, char** argv) {
   total_time.Start();
   Mode cmode = ProcessCmdLineArgs(argc, argv);
   if ( cmode == BATCH ) {
-    // If State is not empty, run now. 
+    // If State is not empty, run now.
     if (!State_.EmptyState())
       err = State_.Run();
   } else if ( cmode == INTERACTIVE ) {
@@ -127,7 +127,7 @@ std::string Cpptraj::Defines() {
 #ifdef USE_SANDERLIB
   defined_str.append(" -DUSE_SANDERLIB");
 #endif
-  return defined_str; 
+  return defined_str;
 }
 
 /** Process a mask from the command line. */
@@ -154,7 +154,7 @@ int Cpptraj::ProcessMask( Sarray const& topFiles, Sarray const& refFiles,
     loudPrintf("Selected=");
     if (residue) {
       int res = -1;
-      for (AtomMask::const_iterator atom = tempMask.begin(); 
+      for (AtomMask::const_iterator atom = tempMask.begin();
                                     atom != tempMask.end(); ++atom)
       {
         if (parm[*atom].ResNum() > res) {
@@ -293,7 +293,7 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
     if (State_.AddTrajin( *trajinName )) return ERROR;
   // Add all output trajectories specified on command line.
   if (!trajoutFiles.empty()) {
-    hasInput = true; // This allows direct traj conversion with no other input 
+    hasInput = true; // This allows direct traj conversion with no other input
     for (Sarray::const_iterator trajoutName = trajoutFiles.begin();
                                 trajoutName != trajoutFiles.end();
                                 ++trajoutName)
@@ -319,9 +319,9 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
     if (isatty(fileno(stdin)))
       return INTERACTIVE;
     else {
-      Cmd::RetType c_err = Command::ProcessInput( State_, "" );
-      if (c_err == Cmd::ERR && State_.ExitOnError()) return ERROR;
-      if (c_err == Cmd::QUIT) return QUIT;
+      Command::RetType c_err = Command::ProcessInput( State_, "" );
+      if (c_err == Command::C_ERR && State_.ExitOnError()) return ERROR;
+      if (c_err == Command::C_QUIT) return QUIT;
     }
   }
   return BATCH;


### PR DESCRIPTION
This fixes https://github.com/Amber-MD/cpptraj/pull/192#issuecomment-162701749. It seems that you cannot depend on the output of `isatty` -- it works fine in the regular windows shell, but not in the shell emulators included with msys2 or cygwin, because they have to use pipes to emulate the terminal protocol. There is some discussion of this here: https://code.google.com/p/mintty/issues/detail?id=56. Python includes a "-i" flag that forces interactive mode even if stdin does not appear to be a tty for this purpose. With this, it seems to work fine in either of the shells or shell emulators.

I don't know the exact logic you want here with interactive vs. piping from stdin, but essentially, on windows, if user passes `--interactive`, it should be honored. Even if stdin does not "appear" to be a tty.