### PR TITLE
Stronger check netcdf

### DIFF
--- a/configure
+++ b/configure
@@ -122,6 +122,7 @@ TestNetcdf() {
     cat > testp.cpp <<EOF
 #include <cstdio>
 #include "netcdf.h"
+void unused() {int ncid; nc_open("foo.nc", 0, &ncid);}
 int main() { printf("Testing\n"); printf("%s\n",nc_strerror(0)); return 0; }
 EOF
     TestCxxProgram "Checking NetCDF" "$NETCDFLIB"


### PR DESCRIPTION
It turns out that the existing netcdf check doesn't actually detect a bunch of possible link time errors. For example, if you statically compile netcdf with netcdf-4 support, the link line isn't correct and you get unresolved hdf5 symbols. But for whatever reason, the check with only `nc_strerror` doesn't flag this.