### PR TITLE
Hbond indices

### DIFF
--- a/src/Action_Hbond.cpp
+++ b/src/Action_Hbond.cpp
@@ -81,7 +81,7 @@ Action::RetType Action_Hbond::Init(ArgList& actionArgs, ActionInit& init, int de
   acut_ = actionArgs.getKeyDouble("angle",135.0);
   noIntramol_ = actionArgs.hasKey("nointramol");
   if (actionArgs.hasKey("atomindex")) {
-    AHDIndices_ = (DataSet_integer*) init.DSL().AddSet(DataSet::INTEGER, "atomIndices");
+    AHDIndices_ = (DataSet_integer*) init.DSL().AddSet(DataSet::INTEGER, "atomindex");
   }
   // Convert angle cutoff to radians
   acut_ *= Constants::DEGRAD;

--- a/src/Action_Hbond.cpp
+++ b/src/Action_Hbond.cpp
@@ -30,7 +30,7 @@ Action_Hbond::Action_Hbond() :
   NumSolvent_(0),
   NumBridge_(0),
   BridgeID_(0),
-  Indices_(0),
+  AHDIndices_(0),
   masterDSL_(0)
 {}
 
@@ -81,7 +81,7 @@ Action::RetType Action_Hbond::Init(ArgList& actionArgs, ActionInit& init, int de
   acut_ = actionArgs.getKeyDouble("angle",135.0);
   noIntramol_ = actionArgs.hasKey("nointramol");
   if (actionArgs.hasKey("atomindex")) {
-    Indices_ = (DataSet_integer*) init.DSL().AddSet(DataSet::INTEGER, "atomIndices");
+    AHDIndices_ = (DataSet_integer*) init.DSL().AddSet(DataSet::INTEGER, "atomIndices");
   }
   // Convert angle cutoff to radians
   acut_ *= Constants::DEGRAD;
@@ -801,10 +801,10 @@ void Action_Hbond::Print() {
       if ((int)hb->second.data_->Size() < Nframes_)
         hb->second.data_->Add( Nframes_-1, &ZERO );
 
-      if (Indices_ != 0) {
-        Indices_->AddElement(hb->second.A);
-        Indices_->AddElement(hb->second.H);
-        Indices_->AddElement(hb->second.D);
+      if (AHDIndices_ != 0) {
+        AHDIndices_->AddElement(hb->second.A);
+        AHDIndices_->AddElement(hb->second.H);
+        AHDIndices_->AddElement(hb->second.D);
       }
     }
     for (HBmapType::iterator hb = SolventMap_.begin(); hb != SolventMap_.end(); ++hb)

--- a/src/Action_Hbond.cpp
+++ b/src/Action_Hbond.cpp
@@ -22,6 +22,7 @@ Action_Hbond::Action_Hbond() :
   hasSolventAcceptor_(false),
   calcSolvent_(false),
   noIntramol_(false),
+  useAtomIndex_(false),
   acut_(0),
   dcut2_(0),
   CurrentParm_(0),
@@ -80,9 +81,7 @@ Action::RetType Action_Hbond::Init(ArgList& actionArgs, ActionInit& init, int de
   useAtomNum_ = actionArgs.hasKey("printatomnum");
   acut_ = actionArgs.getKeyDouble("angle",135.0);
   noIntramol_ = actionArgs.hasKey("nointramol");
-  if (actionArgs.hasKey("atomindex")) {
-    AHDIndices_ = (DataSet_integer*) init.DSL().AddSet(DataSet::INTEGER, "atomindex");
-  }
+  useAtomIndex_ = actionArgs.hasKey("atomindex");
   // Convert angle cutoff to radians
   acut_ *= Constants::DEGRAD;
   double dcut = actionArgs.getKeyDouble("dist",3.0);
@@ -143,6 +142,10 @@ Action::RetType Action_Hbond::Init(ArgList& actionArgs, ActionInit& init, int de
     if (DF != 0) DF->AddDataSet( BridgeID_ );
     solvout_ = init.DFL().AddCpptrajFile(solvname,"Avg. solute-solvent HBonds");
     bridgeout_ = init.DFL().AddCpptrajFile(bridgename,"Solvent bridging info");
+  }
+
+  if (useAtomIndex_) {
+    AHDIndices_ = (DataSet_integer*)init.DSL().AddSet(DataSet::INTEGER, MetaData(hbsetname_,"atomindex"));
   }
 
   mprintf( "  HBOND: ");
@@ -801,7 +804,7 @@ void Action_Hbond::Print() {
       if ((int)hb->second.data_->Size() < Nframes_)
         hb->second.data_->Add( Nframes_-1, &ZERO );
 
-      if (AHDIndices_ != 0) {
+      if (useAtomIndex_) {
         AHDIndices_->AddElement(hb->second.A);
         AHDIndices_->AddElement(hb->second.H);
         AHDIndices_->AddElement(hb->second.D);

--- a/src/Action_Hbond.cpp
+++ b/src/Action_Hbond.cpp
@@ -30,6 +30,7 @@ Action_Hbond::Action_Hbond() :
   NumSolvent_(0),
   NumBridge_(0),
   BridgeID_(0),
+  Indices_(0),
   masterDSL_(0)
 {}
 

--- a/src/Action_Hbond.cpp
+++ b/src/Action_Hbond.cpp
@@ -799,6 +799,12 @@ void Action_Hbond::Print() {
     {
       if ((int)hb->second.data_->Size() < Nframes_)
         hb->second.data_->Add( Nframes_-1, &ZERO );
+
+      if (Indices_ != 0) {
+        Indices_->AddElement(hb->second.A);
+        Indices_->AddElement(hb->second.H);
+        Indices_->AddElement(hb->second.D);
+      }
     }
     for (HBmapType::iterator hb = SolventMap_.begin(); hb != SolventMap_.end(); ++hb)
     {
@@ -815,7 +821,7 @@ void Action_Hbond::Print() {
   if (useAtomNum_) NUM += ( DigitWidth( CurrentParm_->Natom() ) + 1 );
 
   // Solute Hbonds 
-  if (avgout_ != 0 || Indices_ != 0) { 
+  if (avgout_ != 0) { 
     // Place all detected Hbonds in a list and sort.
     for (HBmapType::const_iterator it = HbondMap_.begin(); it!=HbondMap_.end(); ++it) {
       HbondList.push_back( (*it).second );
@@ -838,11 +844,6 @@ void Action_Hbond::Print() {
         Aname.append("_" + integerToString((*hbond).A+1));
         Hname.append("_" + integerToString((*hbond).H+1));
         Dname.append("_" + integerToString((*hbond).D+1));
-      }
-      if (Indices_ != 0) {
-        Indices_->AddElement((*hbond).A);
-        Indices_->AddElement((*hbond).H);
-        Indices_->AddElement((*hbond).D);
       }
       avgout_->Printf("%-*s %*s %*s %8i %12.4f %12.4f %12.4f\n",
                      NUM, Aname.c_str(), NUM, Hname.c_str(), NUM, Dname.c_str(),

--- a/src/Action_Hbond.h
+++ b/src/Action_Hbond.h
@@ -70,7 +70,8 @@ class Action_Hbond : public Action {
     DataSet* NumHbonds_;
     DataSet* NumSolvent_;
     DataSet* NumBridge_;
-    DataSet* BridgeID_;
+    DataSet* BridgeID_; 
+    DataSet_integer* Indices_; // store atom indices
     // TODO: Replace these with new DataSet type
     DataSetList* masterDSL_;
     /// Return true if the first hbond has more frames than the second.

--- a/src/Action_Hbond.h
+++ b/src/Action_Hbond.h
@@ -71,7 +71,7 @@ class Action_Hbond : public Action {
     DataSet* NumSolvent_;
     DataSet* NumBridge_;
     DataSet* BridgeID_; 
-    DataSet_integer* Indices_; // store atom indices
+    DataSet_integer* AHDIndices_; // store atom indices
     // TODO: Replace these with new DataSet type
     DataSetList* masterDSL_;
     /// Return true if the first hbond has more frames than the second.

--- a/src/Action_Hbond.h
+++ b/src/Action_Hbond.h
@@ -61,6 +61,7 @@ class Action_Hbond : public Action {
     bool hasSolventAcceptor_;
     bool calcSolvent_;
     bool noIntramol_;
+    bool useAtomIndex_;
     double acut_;
     double dcut2_;
     Topology* CurrentParm_;


### PR DESCRIPTION
This is my proposal to add atom indices to hbond.

Benefit:
- `pytraj` can use hbond atom indices to compute angle, distance

- viewing: for example, I want to colorize all atoms that form hbond, I can pass atom index array to different programs to do the coloring. (given that those programs do not understand amber mask syntax).

So just adding **hidden** keyword 'atomindex' to dump atom indices to DataSet_integer (pytraj can use numpy to reshape to (n_hbonds, 3)).