### PR TITLE
Misc fixes

### DIFF
--- a/src/Action_ReplicateCell.cpp
+++ b/src/Action_ReplicateCell.cpp
@@ -85,7 +85,7 @@ Action::RetType Action_ReplicateCell::Init(ArgList& actionArgs, ActionInit& init
         }
         ++iptr;
       }
-      mprintf("DEBUG: %s = %i %i %i\n", dirstring.c_str(), ixyz[0], ixyz[1], ixyz[2]);
+      //mprintf("DEBUG: %s = %i %i %i\n", dirstring.c_str(), ixyz[0], ixyz[1], ixyz[2]);
       directionArray_.push_back( ixyz[0] );
       directionArray_.push_back( ixyz[1] );
       directionArray_.push_back( ixyz[2] );
@@ -198,6 +198,7 @@ Action::RetType Action_ReplicateCell::DoAction(int frameNum, ActionFrame& frm) {
   for (idx = 0; idx < Mask1_.Nselected(); idx++) {
     // Convert to fractional coords
     frac = recip_ * Vec3(frm.Frm().XYZ( Mask1_[idx] ));
+    //mprintf("DEBUG: Atom %i frac={ %g %g %g }\n", Mask1_[idx]+1, frac[0], frac[1], frac[2]);
     // replicate in each direction
     newFrameIdx = idx * 3;
     for (id = 0; id != directionArray_.size(); id+=3, newFrameIdx += shift)

--- a/src/Action_ReplicateCell.cpp
+++ b/src/Action_ReplicateCell.cpp
@@ -13,6 +13,22 @@ void Action_ReplicateCell::Help() const {
           "    <XYZ>: X= 1, 0, -1, replicate in specified direction (e.g. 100 is +X only)\n");
 }
 
+static inline int toDigit(char c) {
+  switch (c) {
+    case '0' : return 0;
+    case '1' : return 1;
+    case '2' : return 2;
+    case '3' : return 3;
+    case '4' : return 4;
+    case '5' : return 5;
+    case '6' : return 6;
+    case '7' : return 7;
+    case '8' : return 8;
+    case '9' : return 9;
+  }
+  return 0; // SANITY CHECK
+}
+
 // Action_ReplicateCell::Init()
 Action::RetType Action_ReplicateCell::Init(ArgList& actionArgs, ActionInit& init, int debugIn)
 {
@@ -60,8 +76,13 @@ Action::RetType Action_ReplicateCell::Init(ArgList& actionArgs, ActionInit& init
         if      (*c == '+') ++c;
         else if (*c == '-') { sign = -1; ++c; }
         
-        if      (*c == '1') *iptr = 1 * sign;
-        else if (*c == '0') *iptr = 0;
+        if (isdigit( *c ))
+          *iptr = toDigit( *c ) * sign;
+        else {
+          mprinterr("Error: illegal character '%c' in 'dir' string '%s'; only numbers allowed.\n",
+                    *c, dirstring.c_str());
+          return Action::ERR;
+        }
         ++iptr;
       }
       mprintf("DEBUG: %s = %i %i %i\n", dirstring.c_str(), ixyz[0], ixyz[1], ixyz[2]);

--- a/src/Exec_CrdAction.cpp
+++ b/src/Exec_CrdAction.cpp
@@ -25,7 +25,7 @@ Exec::RetType Exec_CrdAction::DoCrdAction(CpptrajState& State, ArgList& actionar
   ActionFrame frm( &originalFrame );
   // Set up for this topology 
   Action::RetType setup_ret = act->Setup( originalSetup );
-  if ( setup_ret == Action::ERR )
+  if ( setup_ret == Action::ERR || setup_ret == Action::SKIP )
     return CpptrajState::ERR;
   // Loop over all frames in COORDS.
   ProgressBar progress( frameCount.TotalReadFrames() );

--- a/src/PDBfile.cpp
+++ b/src/PDBfile.cpp
@@ -45,6 +45,9 @@ bool PDBfile::IsPDBkeyword(std::string const& recname) {
   if (recname.compare(0,5,"ORIGX" )==0) return true; // ORIGXn
   if (recname.compare(0,5,"MTRIX" )==0) return true; // MTRIXn
   if (recname.compare(0,9,"USER  MOD")==0) return true; // reduce
+  // Bookkeeping Section
+  if (recname.compare(0,6,"MASTER")==0) return true;
+  if (recname.compare(0,3,"END"   )==0) return true;
   return false;
 }
 
@@ -56,7 +59,7 @@ bool PDBfile::ID_PDB(CpptrajFile& fileIn) {
   std::string line2 = fileIn.GetLine();
   fileIn.CloseFile();
   if (!IsPDBkeyword( line1 )) return false;
-  if (!IsPDBkeyword( line2 )) return false;
+  if (!line2.empty() && !IsPDBkeyword( line2 )) return false;
   return true;
 }
 


### PR DESCRIPTION
-Fix parsing of direction string in `replicatecell` so values other than 1 or 0 can be used.
-Hide debug info from `replicatecell`
-Recognize MASTER and END keywords during PDB identification; allow recognition of PDB files with only 1 ATOM record.