### PR TITLE
Do not require ncdump to come from AmberTools in the bundled build

### DIFF
--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -411,7 +411,9 @@ SetBinaries() {
       if [[ $USEDACDIF -eq 1 ]] ; then
         DACDIF=$DIRPREFIX/test/dacdif
       fi
-      NCDUMP=$DIRPREFIX/bin/ncdump
+      if [[ -f "$DIRPREFIX/bin/ncdump" && -e "$DIRPREFIX/bin/ncdump" ]]; then
+        NCDUMP=$DIRPREFIX/bin/ncdump
+      fi
       CPPTRAJ=$DIRPREFIX/bin/cpptraj$SFX
       AMBPDB=$DIRPREFIX/bin/ambpdb
     else


### PR DESCRIPTION
If any users specified `--with-netcdf /path/to/netcdf` in their Amber configure,
then ncdump will need to be taken from the PATH, not AMBERHOME/bin.  As I
(almost) exclusively use --with-netcdf, I get tons of errors like "ncdump not
found".