### PR TITLE
Fix TRR default title, parallel NetCDF warning

### DIFF
--- a/configure
+++ b/configure
@@ -885,6 +885,12 @@ if [[ $USEMPI -eq 1 ]] ; then
     echo "MPI not currently supported on Windows"
     exit 1
   fi
+  if [[ -z $PNETCDFLIB ]] ; then
+    echo ""
+    echo "Warning: No parallel NetCDF library specified."
+    echo "Warning: NetCDF parallel trajectory output requires parallel NetCDF."
+    echo ""
+  fi
   echo "Using MPI"
   DIRECTIVES="$DIRECTIVES -DMPI"
   CC=mpicc

--- a/src/Traj_GmxTrX.cpp
+++ b/src/Traj_GmxTrX.cpp
@@ -341,7 +341,7 @@ int Traj_GmxTrX::setupTrajout(FileName const& fname, Topology* trajParm,
     precision_ = 4;
     // Set up title
     if (Title().empty())
-      SetTitle("Cpptraj generated dcd file.");
+      SetTitle("Cpptraj generated TRR file.");
     // Set size defaults, box, velocity etc
     ir_size_ = 0;
     e_size_ = 0;


### PR DESCRIPTION
Addresses #227 and adds a warning when configuring MPI without parallel NetCDF.