### PR TITLE
Improvements to configure, timing, and parallel ensemble processing

### DIFF
--- a/configure
+++ b/configure
@@ -89,7 +89,7 @@ CompileError() {
 # Test compile test program testp.cpp
 TestCxxProgram() {
   echo "$1"
-  COMPILELINE="$CXX $CXXFLAGS -o testp testp.cpp $2"
+  COMPILELINE="$CXX -o testp testp.cpp $2"
   $COMPILELINE > /dev/null 2> compile.err
   ./testp | grep "Testing" > /dev/null
   status=$?
@@ -131,6 +131,18 @@ void unused() {int ncid; nc_open("foo.nc", 0, &ncid);}
 int main() { printf("Testing\n"); printf("%s\n",nc_strerror(0)); return 0; }
 EOF
     TestCxxProgram "Checking NetCDF" "$NETCDFLIB"
+  fi
+}
+
+TestPnetcdf() {
+  if [[ ! -z $PNETCDFLIB ]] ; then
+    cat > testp.cpp <<EOF
+#include <cstdio>
+#include <pnetcdf.h>
+void unused() {int ncid; ncmpi_open(MPI_COMM_WORLD, "foo.nc", NC_NOWRITE, MPI_INFO_NULL, &ncid);}
+int main() { printf("Testing\n"); printf("%s\n",ncmpi_strerror(0)); return 0; }
+EOF
+    TestCxxProgram "Checking Parallel NetCDF" "$PNETCDFLIB"
   fi
 }
 
@@ -956,6 +968,7 @@ if [[ "$CROSS_COMPILE" = "no" ]]; then
   TestBzlib
   TestZlib
   TestNetcdf
+  TestPnetcdf
   TestMathlib
   TestArpack
   TestFFTW3

--- a/configure
+++ b/configure
@@ -89,7 +89,7 @@ CompileError() {
 # Test compile test program testp.cpp
 TestCxxProgram() {
   echo "$1"
-  COMPILELINE="$CXX -o testp testp.cpp $2"
+  COMPILELINE="$CXX $INCLUDE -o testp testp.cpp $2"
   $COMPILELINE > /dev/null 2> compile.err
   ./testp | grep "Testing" > /dev/null
   status=$?

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -514,8 +514,12 @@ CpptrajState::RetType Command::ProcessInput(CpptrajState& State, std::string con
     if (!input.Empty()) {
       // Print the input line that will be sent to dispatch
       mprintf("  [%s]\n", input.str());
+      Timer time_cmd; // DEBUG
+      time_cmd.Start(); // DEBUG
       // Call Dispatch to convert input to ArgList and process.
       cmode = Command::Dispatch(State, input.Str());
+      time_cmd.Stop(); // DEBUG
+      mprintf("  Command took %.2f s\n", time_cmd.Total()); // DEBUG
       if (cmode == CpptrajState::ERR) {
         nInputErrors++;
         if (State.ExitOnError()) break;

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -514,12 +514,16 @@ CpptrajState::RetType Command::ProcessInput(CpptrajState& State, std::string con
     if (!input.Empty()) {
       // Print the input line that will be sent to dispatch
       mprintf("  [%s]\n", input.str());
+#     ifdef TIMER
       Timer time_cmd; // DEBUG
       time_cmd.Start(); // DEBUG
+#     endif
       // Call Dispatch to convert input to ArgList and process.
       cmode = Command::Dispatch(State, input.Str());
+#     ifdef TIMER
       time_cmd.Stop(); // DEBUG
-      mprintf("  Command took %.2f s\n", time_cmd.Total()); // DEBUG
+      time_cmd.WriteTiming(0," Command time: "); // DEBUG
+#     endif
       if (cmode == CpptrajState::ERR) {
         nInputErrors++;
         if (State.ExitOnError()) break;

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -191,6 +191,9 @@ void Command::Init() {
   Command::AddCmd( new Exec_SilenceActions(),  Cmd::EXE, 1, "silenceactions" );
   Command::AddCmd( new Exec_SequenceAlign(),   Cmd::EXE, 1, "sequencealign" );
   Command::AddCmd( new Exec_WriteDataFile(),   Cmd::EXE, 2, "write", "writedata" );
+# ifdef MPI
+  Command::AddCmd( new Exec_ForceParaEnsemble(), Cmd::EXE, 1, "forceparaensemble" );
+# endif
   // SYSTEM
   Command::AddCmd( new Exec_System(), Cmd::EXE, 6, "gnuplot", "head", "less", "ls", "pwd", "xmgrace" );
   // COORDS

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -312,6 +312,7 @@ void CpptrajState::Init_Timers() {
 }
 
 void CpptrajState::Time_Summary() {
+  mprintf("\nRUN TIMING:\n");
   init_time_.WriteTiming(2,     "Init               :", run_time_.Total());
 # ifdef MPI
   master_time_.WriteTiming(2,   "Trajectory Process :", run_time_.Total());

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -21,6 +21,9 @@ CpptrajState::CpptrajState() :
   exitOnError_(true),
   noEmptyRun_(false),
   mode_(UNDEFINED)
+# ifdef MPI
+  , forceParallelEnsemble_(false)
+# endif
 {}
 
 /** This version of SetTrajMode() may be called from AddToActionQueue() to set
@@ -341,7 +344,7 @@ int CpptrajState::Run() {
           err = RunParallel();
         break;
       case ENSEMBLE:
-        if (Parallel::TrajComm().Size() > 1)
+        if (Parallel::TrajComm().Size() > 1 || forceParallelEnsemble_)
           err = RunParaEnsemble();
         else
           err = RunEnsemble();

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -706,7 +706,8 @@ int CpptrajState::PreloadCheck(int my_start, int my_frames,
   n_previous_frames = actionList_.NumPreviousFramesReqd();
   if (n_previous_frames < 1) return 0;
   preload_start = my_start - n_previous_frames;
-  rprintf("Preloading frames from %i to %i\n", my_start - n_previous_frames, my_start-1);
+  if (debug_ > 0)
+    rprintf("DEBUG: Preloading frames from %i to %i\n", my_start - n_previous_frames, my_start-1);
   if (preload_start < 0) {
     rprinterr("Error: Cannot preload, start is before beginning of traj.\n");
     return 1;
@@ -719,6 +720,8 @@ int CpptrajState::PreloadCheck(int my_start, int my_frames,
     rprintf("Warning: Number of preload frames is greater than half the "
                       "number of processed frames.\n"
             "Warning:   Try reducing the number of threads.\n");
+  rprintf("Warning: Preloading %i frames. These frames will NOT have Actions performed on them.\n",
+          n_previous_frames);
   return 0;
 }
 // -----------------------------------------------------------------------------

--- a/src/CpptrajState.h
+++ b/src/CpptrajState.h
@@ -7,6 +7,7 @@
 #include "DataFileList.h"
 #include "ActionList.h"
 #include "AnalysisList.h"
+#include "Timer.h"
 /// Hold all cpptraj state data
 class CpptrajState {
   public:
@@ -83,6 +84,8 @@ class CpptrajState {
     int RunParaEnsemble();
     //int RunSingleTrajParallel();
 #   endif
+    void Init_Timers();
+    void Time_Summary();
     // -------------------------------------------
     DataSetList DSL_;             ///< List of DataSets
     DataFileList DFL_;            ///< List of DataFiles that DataSets will be written to.
@@ -98,8 +101,16 @@ class CpptrajState {
     /// If true do not process input trajectories when no actions/output trajectories.
     bool noEmptyRun_; // DEBUG: false is used for benchmarking trajectory read speed.
     TrajModeType mode_; ///< Current trajectory mode (NORMAL/ENSEMBLE)
+    Timer init_time_;
+    Timer frames_time_;
+    Timer post_time_;
+    Timer analysis_time_;
+    Timer run_time_;
+    Timer write_time_;
 #   ifdef MPI
     bool forceParallelEnsemble_; ///< If true run parallel ensemble even with 1 thread/member
+    Timer sync_time_;
+    Timer master_time_;
 #   endif
 };
 #endif

--- a/src/CpptrajState.h
+++ b/src/CpptrajState.h
@@ -101,16 +101,16 @@ class CpptrajState {
     /// If true do not process input trajectories when no actions/output trajectories.
     bool noEmptyRun_; // DEBUG: false is used for benchmarking trajectory read speed.
     TrajModeType mode_; ///< Current trajectory mode (NORMAL/ENSEMBLE)
-    Timer init_time_;
-    Timer frames_time_;
-    Timer post_time_;
-    Timer analysis_time_;
-    Timer run_time_;
-    Timer write_time_;
+    Timer init_time_;     ///< Run initialization time.
+    Timer frames_time_;   ///< Run frame processing time.
+    Timer post_time_;     ///< Run post-frame processing (e.g. Action::Print()) time.
+    Timer analysis_time_; ///< Run analysis time.
+    Timer run_time_;      ///< Total run time.
+    Timer write_time_;    ///< Run data file write time.
 #   ifdef MPI
     bool forceParallelEnsemble_; ///< If true run parallel ensemble even with 1 thread/member
-    Timer sync_time_;
-    Timer master_time_;
+    Timer sync_time_;     ///< DataSet/Action total sync time.
+    Timer master_time_;   ///< Total frame processing time across all ranks.
 #   endif
 };
 #endif

--- a/src/CpptrajState.h
+++ b/src/CpptrajState.h
@@ -85,7 +85,7 @@ class CpptrajState {
     //int RunSingleTrajParallel();
 #   endif
     void Init_Timers();
-    void Time_Summary();
+    void Time_Summary() const;
     // -------------------------------------------
     DataSetList DSL_;             ///< List of DataSets
     DataFileList DFL_;            ///< List of DataFiles that DataSets will be written to.

--- a/src/CpptrajState.h
+++ b/src/CpptrajState.h
@@ -19,7 +19,9 @@ class CpptrajState {
     void SetNoExitOnError()  { exitOnError_ = false;  }
     void SetNoProgress()     { showProgress_ = false; }
     void SetActionSilence(bool b)  { actionList_.SetSilent(b); }
-
+#   ifdef MPI
+    void SetForceParaEnsemble(bool b) { forceParallelEnsemble_ = b; }
+#   endif
     DataSetList const& DSL()  const { return DSL_;         }
     DataSetList&       DSL()        { return DSL_;         }
     DataFileList const& DFL() const { return DFL_;         }
@@ -82,32 +84,22 @@ class CpptrajState {
     //int RunSingleTrajParallel();
 #   endif
     // -------------------------------------------
-     /// List of generated data sets
-    DataSetList DSL_;
-    /// List of datafiles that data sets will be written to
-    DataFileList DFL_;
-    /// List of input trajectory files
-    TrajinList trajinList_;
-    // -------------------------------------------
-    /// List of actions to be performed each frame
-    ActionList actionList_;
-    /// List of output trajectory files 
-    TrajoutList trajoutList_;
-    /// List of output ensemble files.
-    EnsembleOutList ensembleOut_;
-    // -------------------------------------------
-    /// List of analyses to be performed on datasets
-    AnalysisList analysisList_;
+    DataSetList DSL_;             ///< List of DataSets
+    DataFileList DFL_;            ///< List of DataFiles that DataSets will be written to.
+    TrajinList trajinList_;       ///< List of input trajectories/ensembles.
+    ActionList actionList_;       ///< List of Actions to be performed during a Run.
+    TrajoutList trajoutList_;     ///< List of trajectories to be written during a Run.
+    EnsembleOutList ensembleOut_; ///< List of ensembles to be written during a Run.
+    AnalysisList analysisList_;   ///< List of Analyses to be performed
     
-    /// State debug level
-    int debug_;
-    /// Display Progress bar during run
-    bool showProgress_;
-    /// If true cpptraj will exit if errors are encountered instead of trying to continue
-    bool exitOnError_;
+    int debug_;         ///< Debug level.
+    bool showProgress_; ///< If true, display progress during Run.
+    bool exitOnError_;  ///< If true exit when errors encountered instead of continuing.
     /// If true do not process input trajectories when no actions/output trajectories.
     bool noEmptyRun_; // DEBUG: false is used for benchmarking trajectory read speed.
-    /// Current trajectory mode
-    TrajModeType mode_;
+    TrajModeType mode_; ///< Current trajectory mode (NORMAL/ENSEMBLE)
+#   ifdef MPI
+    bool forceParallelEnsemble_; ///< If true run parallel ensemble even with 1 thread/member
+#   endif
 };
 #endif

--- a/src/EnsembleIn.cpp
+++ b/src/EnsembleIn.cpp
@@ -1,6 +1,13 @@
 #include "EnsembleIn.h"
 #include "CpptrajStdio.h"
 
+EnsembleIn::EnsembleIn() :
+  targetType_(ReplicaInfo::NONE), badEnsemble_(0), debug_(0)
+# ifdef MPI
+  , member_(-1)
+# endif
+{}
+
 #ifdef MPI
 int EnsembleIn::GatherTemperatures(double* tAddress, std::vector<double>& allTemps,
                                    Parallel::Comm const& commIn)

--- a/src/EnsembleIn.h
+++ b/src/EnsembleIn.h
@@ -13,7 +13,7 @@
 /// Read in an array of frames at a time.
 class EnsembleIn {
   public:
-    EnsembleIn() : targetType_(ReplicaInfo::NONE), badEnsemble_(0), debug_(0) {}
+    EnsembleIn();
     virtual ~EnsembleIn() {}
     virtual int SetupEnsembleRead(FileName const&, ArgList&, Topology*) = 0;
     virtual int ReadEnsemble(int, FrameArray&, FramePtrArray&) = 0;
@@ -51,8 +51,9 @@ class EnsembleIn {
 #   ifdef MPI
     RemdIdxType frameidx_;    ///< Hold position of each frame in ensemble.
 
-    int Member()                         const { return Parallel::EnsembleComm().Rank(); }
-    Parallel::Comm const& EnsembleComm() const { return Parallel::EnsembleComm();        }
+    void SetEnsembleMemberNum(int m)           { member_ = m;                     }
+    int Member()                         const { return member_;                  }
+    Parallel::Comm const& EnsembleComm() const { return Parallel::EnsembleComm(); }
     static int GatherTemperatures(double*, std::vector<double>&, Parallel::Comm const&);
     static int GatherIndices(int*, std::vector<RemdIdxType>&, int, Parallel::Comm const&);
 #   ifdef TIMER
@@ -67,6 +68,9 @@ class EnsembleIn {
     static void PrintReplicaImap(ReplicaMap<RemdIdxType> const&);
 
     InputTrajCommon traj_;
+#   ifdef MPI
+    int member_; ///< Internal ensemble member number.
+#   endif
 };
 // ----- INLINE FUNCTIONS ------------------------------------------------------
 int EnsembleIn::GetNextEnsemble(FrameArray& fa, FramePtrArray& fp) {

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -2,7 +2,6 @@
 #include "CpptrajStdio.h"
 #include "DataFile.h" // TODO remove
 #include "StringRoutines.h" // integerToString TODO remove
-#include "Timer.h" // DEBUG
 
 // EnsembleIn_Multi::SetupEnsembleRead()
 int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn, Topology *tparmIn)
@@ -34,8 +33,6 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
   if (argIn.Contains("crdidx"))
     crdidxarg.SetList( "crdidx " + argIn.GetStringKey("crdidx"), " " );
   // Set up replica file names.
-  Timer time_setrepnames; // DEBUG
-  time_setrepnames.Start(); // DEBUG
 # ifdef MPI
   int err = 0;
   if (eSize != -1)
@@ -49,10 +46,7 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
 # else
   if (REMDtraj_.SetupReplicaFilenames( tnameIn, argIn )) return 1;
 # endif
-  time_setrepnames.Stop(); // DEBUG
   // Set up TrajectoryIO classes for all file names.
-  Timer time_setrepio; // DEBUG
-  time_setrepio.Start(); // DEBUG
 # ifdef MPI
   if (eSize != -1)
     err = REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm(),
@@ -60,20 +54,15 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
   else
     err = REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm());
   if (Parallel::World().CheckError( err )) return 1;
-# else
-  if (REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm())) return 1;
-# endif
-  time_setrepio.Stop(); // DEBUG
-  time_setrepnames.WriteTiming(1, "Set replica file names :"); // DEBUG
-  time_setrepio.WriteTiming(1,    "Set replica IO         :"); // DEBUG
-# ifdef MPI
   // Set up communicators if not already done
   if (eSize == -1) {
     if (Parallel::SetupComms( REMDtraj_.size() )) return 1;
   } else
     mprintf("\tAll ranks set up total of %zu replicas.\n", REMDtraj_.size());
-  // Set ensemble member.
+  // Set ensemble member number.
   SetEnsembleMemberNum( EnsembleComm().Rank() );
+# else
+  if (REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm())) return 1;
 # endif
   // Unless nosort was specified, figure out target type
   if (no_sort)

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -2,6 +2,7 @@
 #include "CpptrajStdio.h"
 #include "DataFile.h" // TODO remove
 #include "StringRoutines.h" // integerToString TODO remove
+#include "Timer.h" // DEBUG
 
 // EnsembleIn_Multi::SetupEnsembleRead()
 int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn, Topology *tparmIn)
@@ -25,9 +26,17 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
   if (argIn.Contains("crdidx"))
     crdidxarg.SetList( "crdidx " + argIn.GetStringKey("crdidx"), " " );
   // Set up replica file names.
+  Timer time_setrepnames; // DEBUG
+  time_setrepnames.Start(); // DEBUG
   if (REMDtraj_.SetupReplicaFilenames( tnameIn, argIn )) return 1;
+  time_setrepnames.Stop(); // DEBUG
   // Set up TrajectoryIO classes for all file names.
+  Timer time_setrepio; // DEBUG
+  time_setrepio.Start(); // DEBUG
   if (REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm())) return 1;
+  time_setrepio.Stop(); // DEBUG
+  time_setrepnames.WriteTiming(1, "Set replica file names :"); // DEBUG
+  time_setrepio.WriteTiming(1,    "Set replica IO         :"); // DEBUG
 # ifdef MPI
   // Set up communicators
   if (Parallel::SetupComms( REMDtraj_.size() )) return 1;

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -322,9 +322,6 @@ int EnsembleIn_Multi::BeginEnsemble() {
 
 void EnsembleIn_Multi::EndEnsemble() {
 # ifdef MPI
-  // FIXME: At this point we may be calling this from the destructor. If so, Member()
-  //        is probably no longer valid since the EnsembleComm may be gone. Do not
-  //        try to do this is the EnsembleComm is null.
   if (Member() != -1)
     REMDtraj_[Member()]->closeTraj();
 # ifdef TIMER

--- a/src/EnsembleIn_Single.cpp
+++ b/src/EnsembleIn_Single.cpp
@@ -62,6 +62,8 @@ int EnsembleIn_Single::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn
 # ifdef MPI
   // Set up communicators
   if (Parallel::SetupComms( ensembleSize_ )) return 1;
+  // Set ensemble member number.
+  SetEnsembleMemberNum( EnsembleComm().Rank() );
 # endif
   // If dimensions are present, assume search by indices, otherwise by temp.
   targetType_ = ReplicaInfo::NONE;

--- a/src/EnsembleOut_Multi.cpp
+++ b/src/EnsembleOut_Multi.cpp
@@ -87,10 +87,12 @@ int EnsembleOut_Multi::InitEnsembleWrite(std::string const& tnameIn,
     }
   }
   // Set up TrajectoryIO for each member.
+  TrajectoryFile::TrajFormatType lastFormat = TrajectoryFile::UNKNOWN_TRAJ;
   for (unsigned int m = 0; m != fileNames_.size(); ++m) {
-    if (debug_ > 0)
-      rprintf("\tWriting ensemble member '%s' as %s\n", fileNames_[m].c_str(),
+    if (fileFormats[m] != lastFormat)
+      mprintf("\tWriting ensemble member '%s' as %s\n", fileNames_[m].c_str(),
               TrajectoryFile::FormatString(fileFormats[m]));
+    lastFormat = fileFormats[m];
     TrajectoryIO* tio = TrajectoryFile::AllocTrajIO( fileFormats[m] );
     if (tio == 0) return 1;
     ioarray_.push_back( tio );

--- a/src/Exec_Commands.cpp
+++ b/src/Exec_Commands.cpp
@@ -19,6 +19,19 @@ Exec::RetType Exec_NoExitOnError::Execute(CpptrajState& State, ArgList&)
   mprintf("\tAttempting to ignore errors if possible.\n");
   return CpptrajState::OK;
 }
+#ifdef MPI
+// -----------------------------------------------------------------------------
+void Exec_ForceParaEnsemble::Help() const {
+  mprintf("  Use parallel trajectory routines in ensemble mode even with 1 thread/member.\n"
+          "  Can potentially result in faster execution but has some reduced functionality.\n");
+}
+
+Exec::RetType Exec_ForceParaEnsemble::Execute(CpptrajState& State, ArgList&) {
+  State.SetForceParaEnsemble( true );
+  mprintf("\tAlways using parallel trajectory routines during ensemble mode.\n");
+  return CpptrajState::OK;
+}
+#endif
 // -----------------------------------------------------------------------------
 void Exec_NoProgress::Help() const {
   mprintf("  Do not print progress while reading in trajectories.\n");

--- a/src/Exec_Commands.h
+++ b/src/Exec_Commands.h
@@ -34,7 +34,7 @@ class Exec_NoProgress : public Exec {
 /// Tell CpptrajState to run parallel ensemble even with 1 thread/member
 class Exec_ForceParaEnsemble : public Exec {
   public:
-    Exec_ForceParaEnsemble() : Exec(GENERAL) {}
+    Exec_ForceParaEnsemble() : Exec(HIDDEN) {}
     void Help() const;
     DispatchObject* Alloc() const { return (DispatchObject*)new Exec_ForceParaEnsemble(); }
     RetType Execute(CpptrajState&, ArgList&);

--- a/src/Exec_Commands.h
+++ b/src/Exec_Commands.h
@@ -30,7 +30,16 @@ class Exec_NoProgress : public Exec {
     DispatchObject* Alloc() const { return (DispatchObject*)new Exec_NoProgress(); }
     RetType Execute(CpptrajState&, ArgList&);
 };
-
+#ifdef MPI
+/// Tell CpptrajState to run parallel ensemble even with 1 thread/member
+class Exec_ForceParaEnsemble : public Exec {
+  public:
+    Exec_ForceParaEnsemble() : Exec(GENERAL) {}
+    void Help() const;
+    DispatchObject* Alloc() const { return (DispatchObject*)new Exec_ForceParaEnsemble(); }
+    RetType Execute(CpptrajState&, ArgList&);
+};
+#endif
 /// Exit CPPTRAJ
 class Exec_Quit : public Exec {
   public:

--- a/src/Exec_Traj.cpp
+++ b/src/Exec_Traj.cpp
@@ -14,10 +14,12 @@ void Exec_Trajin::Help() const {
 void Exec_Ensemble::Help() const {
   mprintf("\t<file0> {[<start>] [<stop> | last] [offset]} | lastframe\n"
           "\t        [%s]\n", DataSetList::TopArgs);
-  mprintf("\t        [trajnames <file1>,<file2>,...,<fileN>\n"
+  mprintf("\t        [trajnames <file1>,<file2>,...,<fileN>] [size <# members>]\n"
           "\t        [remlog <remlogfile> [nstlim <nstlim> ntwx <ntwx>]]\n"
           "  Load an ensemble of trajectories starting with <file0> that will be\n"
-          "  processed together as an ensemble.\n");
+          "  processed together as an ensemble.\n"
+          "  When running in parallel, the 'size' keyword can be used to specify\n"
+          "  the number of members in the ensemble, which may improve set-up performance.\n");
 }
 // -----------------------------------------------------------------------------
 void Exec_Reference::Help() const {

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -248,8 +248,7 @@ int NetcdfFile::SetupCoordsVelo(bool useVelAsCoords) {
   // Get overall replica and coordinate indices
   crdidxVID_ = -1;
   if ( nc_inq_varid(ncid_, NCREMD_REPIDX, &repidxVID_) == NC_NOERR ) {
-    //if (ncdebug_ > 0)
-      mprintf("    Netcdf file has overall replica indices.\n");
+      if (ncdebug_>0) mprintf("\tNetcdf file has overall replica indices.\n");
     if ( checkNCerr(nc_inq_varid(ncid_, NCREMD_CRDIDX, &crdidxVID_)) ) {
       mprinterr("Error: Getting overall coordinate index variable ID.\n");
       return 1;

--- a/src/Parallel.cpp
+++ b/src/Parallel.cpp
@@ -122,15 +122,17 @@ int Parallel::SetupComms(int ngroups) {
   } else if (!ensembleComm_.IsNull()) {
     // If comms were previously set up make sure the number of groups remains the same!
     if (ensembleComm_.Size() != ngroups) {
-      fprintf(stderr,"Error: Ensemble size (%i) does not first ensemble size (%i).\n",
-              ngroups, ensembleComm_.Size());
+      if ( world_.Master() )
+        fprintf(stderr,"Error: Ensemble size (%i) does not match first ensemble size (%i).\n",
+                ngroups, ensembleComm_.Size());
       return 1;
     }
   } else {
     // Initial setup: Make sure that ngroups is a multiple of total # threads.
     if ( (world_.Size() % ngroups) != 0 ) {
-      fprintf(stderr,"Error: # of threads (%i) must be a multiple of # replicas (%i)\n",
-              world_.Size(), ngroups);
+      if ( world_.Master() )
+        fprintf(stderr,"Error: # of threads (%i) must be a multiple of # replicas (%i)\n",
+                world_.Size(), ngroups);
       return 1;
     }
     // Split into comms for parallel across trajectory

--- a/src/Parallel.cpp
+++ b/src/Parallel.cpp
@@ -86,6 +86,10 @@ int Parallel::Init(int argc, char** argv) {
 # ifdef PARALLEL_DEBUG_VERBOSE
   debug_init();
 # endif
+  //char processor_name[MPI_MAX_PROCESSOR_NAME];
+  //int namelen;
+  //MPI_Get_processor_name(processor_name, &namelen);
+  //printf("DEBUG: Thread %i of %i on %s\n", world_.Rank(), world_.Size(), processor_name);
   return 0;
 }
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -14,6 +14,12 @@
 
 Timer::Timer() : start_sec_(0), start_ns_(0), total_(0.0) {}
 
+void Timer::Reset() {
+  start_sec_ = 0;
+  start_ns_ = 0;
+  total_ = 0.0;
+}
+
 #ifdef _MSC_VER 
 /* tw 
  * replacement for gettimeofday based on  
@@ -90,6 +96,6 @@ void Timer::WriteTiming(int indents, const char* header, double FracTotal) const
     ptr += sprintf(ptr, "\t");
   ptr += sprintf(ptr, "%s %.4f s", header, total_);
   if (FracTotal > 0.0)
-    ptr += sprintf(ptr, " (%.2f%%)", (total_ / FracTotal) * 100.0);
+    ptr += sprintf(ptr, " (%6.2f%%)", (total_ / FracTotal) * 100.0);
   mprintf("TIME:%s\n", buffer);
 }

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -10,6 +10,7 @@
 class Timer {
   public:
     Timer();
+    void Reset();
     void Start() { GetWallTime(start_sec_, start_ns_); }
     void Stop();
     double Total() const { return total_; }

--- a/src/TrajIOarray.cpp
+++ b/src/TrajIOarray.cpp
@@ -149,6 +149,7 @@ int TrajIOarray::SetupIOarray(ArgList& argIn, TrajFrameCounter& counter,
   bool lowestRep = true;
   int rep0Frames = TrajectoryIO::TRAJIN_UNK;  // Total frames in replica 0
   int totalFrames = TrajectoryIO::TRAJIN_UNK; // Total # frames to be read from ensemble
+  TrajectoryFile::TrajFormatType lastRepFmt = TrajectoryFile::UNKNOWN_TRAJ;
   // Right now enforce that all replicas have the same metadata as lowest
   // replica, e.g. if replica 0 has temperature, replica 1 does too etc.
   for (File::NameArray::const_iterator repfile = replica_filenames_.begin();
@@ -161,7 +162,9 @@ int TrajIOarray::SetupIOarray(ArgList& argIn, TrajFrameCounter& counter,
       mprinterr("Error: Could not set up replica file %s\n", repfile->full());
       return 1;
     }
-    mprintf("\tReading '%s' as %s\n", repfile->full(), TrajectoryFile::FormatString(repformat));
+    if (repformat != lastRepFmt)
+      mprintf("\tReading '%s' as %s\n", repfile->full(), TrajectoryFile::FormatString(repformat));
+    lastRepFmt = repformat;
     replica0->SetDebug( debug_ );
     // Pushing replica0 here allows the destructor to handle it on errors
     IOarray_.push_back( replica0 );

--- a/src/TrajIOarray.cpp
+++ b/src/TrajIOarray.cpp
@@ -262,12 +262,14 @@ int TrajIOarray::SearchForReplicas(FileName const& fname, Parallel::Comm const& 
   FileName replicaFilename = repName.RepFilename( ensComm.Rank() );
   // Only traj comm masters actually check for files.
   if (trajComm.Master()) {
-    if (!File::Exists( replicaFilename )) return 1;
+    if (!File::Exists( replicaFilename )) {
+      rprinterr("Error: File '%s' does not exist.\n", replicaFilename.full());
+      return 1;
+    }
   }
   // At this point each rank has found its replica. Populate filename array.
   for (int offset = 0; offset < ensComm.Size(); ++offset)
     replica_filenames_.push_back( repName.RepFilename( offset ) );
-  mprintf("\tAll ranks found total of %zu replicas.\n", replica_filenames_.size());
   return 0;
 }
 

--- a/src/TrajIOarray.h
+++ b/src/TrajIOarray.h
@@ -63,8 +63,6 @@ class TrajIOarray::RepName {
     bool Error() const { return Prefix_.empty(); }
     /// \return Replica file name for given replica number.
     FileName RepFilename(int) const;
-    /// \return integer value of lowest replica traj filename extension.
-    int LowestRepNum() const { return lowestRepnum_; }
   private:
     std::string Prefix_;      ///< File name up to the numerical extension.
     std::string ReplicaExt_;  ///< Numerical extension.

--- a/src/TrajIOarray.h
+++ b/src/TrajIOarray.h
@@ -11,6 +11,10 @@ class TrajIOarray {
     void ClearIOarray();
     /// Set up replica file names from arguments or by searching.
     int SetupReplicaFilenames(FileName const&, ArgList&);
+#   ifdef MPI
+    int SetupReplicaFilenames(FileName const&, ArgList&, Parallel::Comm const&,
+                              Parallel::Comm const&);
+#   endif
     /// Setup TrajectoryIO classes for all file names.
     int SetupIOarray(ArgList&, TrajFrameCounter&, CoordinateInfo&, Topology*);
     /// Print file names and IO info to STDOUT
@@ -31,14 +35,40 @@ class TrajIOarray {
     /// 'remdout' deprecated error message.
     static const char* DEPRECATED_remdout;
   private:
+    /// Used for replica filename searching.
+    class RepName;
+    /// Split given filename into components for searching for other replicas.
+    int GetRepPrefixAndExt(FileName const&, std::string&, std::string&, std::string&,
+                           int&, int&) const;
     /// Given lowest replica name, search for all other replicas.
-    int SearchForReplicas(FileName const&); // TODO private?
+    int SearchForReplicas(FileName const&);
     /// Add the given file name and names from comma-separated list. 
-    int AddReplicasFromArgs(FileName const&, std::string const&); // TODO private
-
+    int AddReplicasFromArgs(FileName const&, std::string const&);
+#   ifdef MPI
+    int SearchForReplicas(FileName const&, Parallel::Comm const&);
+    int AddReplicasFromArgs(FileName const&, std::string const&, Parallel::Comm const&);
+#   endif
     typedef std::vector<TrajectoryIO*> IOarrayType;
     IOarrayType IOarray_;               ///< Input replica trajectories.
     File::NameArray replica_filenames_; ///< Replica traj file names.
     int debug_;
+};
+// ----- PRIVATE CLASSES -------------------------------------------------------
+/** Given lowest replica traj filename, split into components for search. */
+class TrajIOarray::RepName {
+  public:
+    RepName() : ExtWidth_(0), lowestRepnum_(-1) {}
+    RepName(FileName const&, int);
+    bool Error() const { return Prefix_.empty(); }
+    /// \return Replica file name for given replica number.
+    FileName RepFilename(int) const;
+    /// \return integer value of lowest replica traj filename extension.
+    int LowestRepNum() const { return lowestRepnum_; }
+  private:
+    std::string Prefix_;      ///< File name up to the numerical extension.
+    std::string ReplicaExt_;  ///< Numerical extension.
+    std::string CompressExt_; ///< Optional compression extension after numerical extension.
+    int ExtWidth_;            ///< Width of the numerical extension. TODO remove
+    int lowestRepnum_;        ///< Integer value of numerical extension.
 };
 #endif

--- a/src/TrajIOarray.h
+++ b/src/TrajIOarray.h
@@ -11,12 +11,15 @@ class TrajIOarray {
     void ClearIOarray();
     /// Set up replica file names from arguments or by searching.
     int SetupReplicaFilenames(FileName const&, ArgList&);
+    /// Setup TrajectoryIO classes for all file names.
+    int SetupIOarray(ArgList&, TrajFrameCounter&, CoordinateInfo&, Topology*);
 #   ifdef MPI
     int SetupReplicaFilenames(FileName const&, ArgList&, Parallel::Comm const&,
                               Parallel::Comm const&);
+    int SetupIOarray(ArgList& argIn, TrajFrameCounter& counter,
+                     CoordinateInfo& cInfo, Topology* trajParm,
+                     Parallel::Comm const&, Parallel::Comm const&);
 #   endif
-    /// Setup TrajectoryIO classes for all file names.
-    int SetupIOarray(ArgList&, TrajFrameCounter&, CoordinateInfo&, Topology*);
     /// Print file names and IO info to STDOUT
     void PrintIOinfo() const;
     /// Iterator over trajectories

--- a/src/TrajIOarray.h
+++ b/src/TrajIOarray.h
@@ -45,8 +45,9 @@ class TrajIOarray {
     /// Add the given file name and names from comma-separated list. 
     int AddReplicasFromArgs(FileName const&, std::string const&);
 #   ifdef MPI
-    int SearchForReplicas(FileName const&, Parallel::Comm const&);
-    int AddReplicasFromArgs(FileName const&, std::string const&, Parallel::Comm const&);
+    int SearchForReplicas(FileName const&, Parallel::Comm const&, Parallel::Comm const&);
+    int AddReplicasFromArgs(FileName const&, std::string const&, Parallel::Comm const&,
+                            Parallel::Comm const&);
 #   endif
     typedef std::vector<TrajectoryIO*> IOarrayType;
     IOarrayType IOarray_;               ///< Input replica trajectories.

--- a/src/TrajIOarray.h
+++ b/src/TrajIOarray.h
@@ -14,8 +14,10 @@ class TrajIOarray {
     /// Setup TrajectoryIO classes for all file names.
     int SetupIOarray(ArgList&, TrajFrameCounter&, CoordinateInfo&, Topology*);
 #   ifdef MPI
+    /// Set up replica filenames such that each ensemble rank checks 1 file
     int SetupReplicaFilenames(FileName const&, ArgList&, Parallel::Comm const&,
                               Parallel::Comm const&);
+    /// Each ensemble rank sets up TrajectoryIO class only for member it will process.
     int SetupIOarray(ArgList& argIn, TrajFrameCounter& counter,
                      CoordinateInfo& cInfo, Topology* trajParm,
                      Parallel::Comm const&, Parallel::Comm const&);
@@ -40,15 +42,14 @@ class TrajIOarray {
   private:
     /// Used for replica filename searching.
     class RepName;
-    /// Split given filename into components for searching for other replicas.
-    int GetRepPrefixAndExt(FileName const&, std::string&, std::string&, std::string&,
-                           int&, int&) const;
     /// Given lowest replica name, search for all other replicas.
     int SearchForReplicas(FileName const&);
     /// Add the given file name and names from comma-separated list. 
     int AddReplicasFromArgs(FileName const&, std::string const&);
 #   ifdef MPI
+    /// Given lowest replica name, ensemble rank searches for corresponding replica
     int SearchForReplicas(FileName const&, Parallel::Comm const&, Parallel::Comm const&);
+    /// Each rank searches for replica from given name + comma-separated list
     int AddReplicasFromArgs(FileName const&, std::string const&, Parallel::Comm const&,
                             Parallel::Comm const&);
 #   endif
@@ -64,7 +65,7 @@ class TrajIOarray::RepName {
     RepName() : ExtWidth_(0), lowestRepnum_(-1) {}
     RepName(FileName const&, int);
     bool Error() const { return Prefix_.empty(); }
-    /// \return Replica file name for given replica number.
+    /// \return Replica file name for given offset from lowest replica number.
     FileName RepFilename(int) const;
   private:
     std::string Prefix_;      ///< File name up to the numerical extension.


### PR DESCRIPTION
This PR covers various improvements, enhancements, and clean-ups.

First, configure now tests parallel NetCDF if one is specified. It also only uses the INCLUDE variable when testing instead of all flags (which should not be necessary).

Second, various kinds of output have been improved. The biggest change to output is that run timings have been made more uniform between the different run types and are reported at the end of a run (some timings like FPS are still reported within the run). Various debug and output messages have been cleaned up and improved, particularly during ensemble runs.

Third and probably most important, the efficiency of ensemble setup in parallel has been greatly improved. Previously all threads would all run the same setup on all files in the ensemble, even though they were only responsible for reading one. This became particularly inefficient when multiple threads per ensemble member were used. Now each member of the ensemble in parallel only sets up the member it is responsible for. This results in great speedup, particularly for large ensembles and high processor counts (on BW got 2 orders of magnitude speedup for ensemble setup this way).