### PR TITLE
Add 'ensemblesize' command

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -204,10 +204,11 @@ void Command::Init() {
   Command::AddCmd( new Exec_LoadTraj(),         Cmd::EXE, 1, "loadtraj" );
   Command::AddCmd( new Exec_PermuteDihedrals(), Cmd::EXE, 1, "permutedihedrals" );
   // TRAJECTORY
-  Command::AddCmd( new Exec_Ensemble(),  Cmd::EXE, 1, "ensemble" );
-  Command::AddCmd( new Exec_Reference(), Cmd::EXE, 1, "reference" );
-  Command::AddCmd( new Exec_Trajin(),    Cmd::EXE, 1, "trajin" );
-  Command::AddCmd( new Exec_Trajout(),   Cmd::EXE, 1, "trajout" );
+  Command::AddCmd( new Exec_Ensemble(),     Cmd::EXE, 1, "ensemble" );
+  Command::AddCmd( new Exec_EnsembleSize(), Cmd::EXE, 1, "ensemblesize" );
+  Command::AddCmd( new Exec_Reference(),    Cmd::EXE, 1, "reference" );
+  Command::AddCmd( new Exec_Trajin(),       Cmd::EXE, 1, "trajin" );
+  Command::AddCmd( new Exec_Trajout(),      Cmd::EXE, 1, "trajout" );
   // TOPOLOGY COMMANDS
   Command::AddCmd( new Exec_AngleInfo(),     Cmd::EXE, 3, "angles", "angleinfo", "printangles" );
   Command::AddCmd( new Exec_AtomInfo(),      Cmd::EXE, 3, "atoms", "atominfo", "printatoms" );

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -32,7 +32,7 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
                                            Parallel::TrajComm() );
   else {
     mprintf("Warning: Ensemble setup efficiency in parallel is greatly\n"
-            "Warning:   improved via the 'ensembleSize' command.\n");
+            "Warning:   improved via the 'ensemblesize' command.\n");
     err = REMDtraj_.SetupReplicaFilenames( tnameIn, argIn );
   }
   if (Parallel::World().CheckError( err )) return 1;

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -19,14 +19,6 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
   double remlog_nstlim    = argIn.getKeyDouble("nstlim", 1.0);
   double remlog_ntwx      = argIn.getKeyDouble("ntwx",   1.0);
   bool no_sort = argIn.hasKey("nosort");
-  int eSize = argIn.getKeyInt("size", -1);
-# ifdef MPI
-  // If a size was specified set up comms now.
-  if (Parallel::SetupComms( eSize )) return 1;
-# else
-  if (eSize != -1)
-    mprintf("Warning: The 'size' keyword only matters when running in parallel.\n");
-# endif
   // CRDIDXARG: Parse out 'crdidx <indices list>' now so it is not processed
   //            by SetupTrajIO.
   ArgList crdidxarg;
@@ -35,11 +27,12 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
   // Set up replica file names.
 # ifdef MPI
   int err = 0;
-  if (eSize != -1)
+  if (!Parallel::EnsembleComm().IsNull())
     err = REMDtraj_.SetupReplicaFilenames( tnameIn, argIn, Parallel::EnsembleComm(),
                                            Parallel::TrajComm() );
   else {
-    mprintf("Warning: Ensemble setup in parallel is more efficient when 'size' specified.\n");
+    mprintf("Warning: Ensemble setup efficiency in parallel is greatly\n"
+            "Warning:   improved via the 'ensembleSize' command.\n");
     err = REMDtraj_.SetupReplicaFilenames( tnameIn, argIn );
   }
   if (Parallel::World().CheckError( err )) return 1;
@@ -48,14 +41,14 @@ int EnsembleIn_Multi::SetupEnsembleRead(FileName const& tnameIn, ArgList& argIn,
 # endif
   // Set up TrajectoryIO classes for all file names.
 # ifdef MPI
-  if (eSize != -1)
+  if (!Parallel::EnsembleComm().IsNull())
     err = REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm(),
                                  Parallel::EnsembleComm(), Parallel::TrajComm() );
   else
     err = REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm());
   if (Parallel::World().CheckError( err )) return 1;
   // Set up communicators if not already done
-  if (eSize == -1) {
+  if (Parallel::EnsembleComm().IsNull()) {
     if (Parallel::SetupComms( REMDtraj_.size() )) return 1;
   } else
     mprintf("\tAll ranks set up total of %zu replicas.\n", REMDtraj_.size());

--- a/src/Exec_Traj.cpp
+++ b/src/Exec_Traj.cpp
@@ -14,11 +14,11 @@ void Exec_Trajin::Help() const {
 void Exec_Ensemble::Help() const {
   mprintf("\t<file0> {[<start>] [<stop> | last] [offset]} | lastframe\n"
           "\t        [%s]\n", DataSetList::TopArgs);
-  mprintf("\t        [trajnames <file1>,<file2>,...,<fileN>] [size <# members>]\n"
+  mprintf("\t        [trajnames <file1>,<file2>,...,<fileN>]\n"
           "\t        [remlog <remlogfile> [nstlim <nstlim> ntwx <ntwx>]]\n"
           "  Load an ensemble of trajectories starting with <file0> that will be\n"
           "  processed together as an ensemble.\n"
-          "  When running in parallel, the 'size' keyword can be used to specify\n"
+          "  When running in parallel, the 'ensemblesize' command can be used to specify\n"
           "  the number of members in the ensemble, which may improve set-up performance.\n");
 }
 // -----------------------------------------------------------------------------
@@ -38,4 +38,20 @@ void Exec_Trajout::Help() const {
           "  Write frames after all actions have been processed to output trajectory\n"
           "  specified by <filename>.\n");
   TrajectoryFile::WriteOptions();
+}
+// -----------------------------------------------------------------------------
+void Exec_EnsembleSize::Help() const {
+  mprintf("  Set expected ensemble size to improve ensemble setup efficiency in parallel.\n");
+}
+
+Exec::RetType Exec_EnsembleSize::Execute(CpptrajState& State, ArgList& argIn) {
+  int eSize = argIn.getNextInteger(-1);
+  if (eSize > 0)
+# ifdef MPI
+    mprintf("\tSetting expected ensemble size to %i\n", eSize);
+  if (Parallel::SetupComms( eSize )) return CpptrajState::ERR;
+# else
+    mprintf("Warning: This command has no effect when not running in parallel.\n");
+# endif
+  return CpptrajState::OK;
 }

--- a/src/Exec_Traj.h
+++ b/src/Exec_Traj.h
@@ -44,4 +44,13 @@ class Exec_Trajout : public Exec {
       return (RetType)State.AddOutputTrajectory( argIn );
     }
 };
+
+/// Set expected ensemble size to improve ensemble setup efficiency in parallel.
+class Exec_EnsembleSize : public Exec {
+  public:
+    Exec_EnsembleSize() : Exec(TRAJ) {}
+    void Help() const;
+    DispatchObject* Alloc() const { return (DispatchObject*)new Exec_EnsembleSize(); }
+    RetType Execute(CpptrajState&, ArgList&);
+};
 #endif

--- a/src/readline/search.c
+++ b/src/readline/search.c
@@ -211,7 +211,7 @@ _rl_nsearch_init (dir, pchar)
   rl_end = rl_point = 0;
 
   p = _rl_make_prompt_for_search (pchar ? pchar : ':');
-  rl_message ("%s", p, 0);
+  rl_message ("%s", p);
   free (p);
 
   RL_SETSTATE(RL_STATE_NSEARCH);

--- a/test/Test_Ensemble_MREMD/RunTest.sh
+++ b/test/Test_Ensemble_MREMD/RunTest.sh
@@ -15,6 +15,7 @@ TrajSort() {
   cat > mremd.in <<EOF
 noprogress
 parm rGACC.nowat.parm7
+ensemblesize 8
 ensemble rGACC.nowat.001
 trajout Strip.sorted.crd
 EOF
@@ -30,6 +31,7 @@ ActionsTest() {
   cat > mremd.in <<EOF
 noprogress
 parm rGACC.nowat.parm7
+ensemblesize 8
 ensemble rGACC.nowat.001
 hbond HB :1-4 solventdonor :Na+ solventacceptor :Na+ \
       out nhbond.dat avgout hbavg.dat
@@ -54,6 +56,7 @@ EOF
 RunAvgTest() {
   cat > mremd.in <<EOF
 parm rGACC.nowat.parm7
+ensemblesize 8
 ensemble rGACC.nowat.001 nosort
 runavg window 3
 rms RA first :1-4&!@H= out RA.dat
@@ -71,6 +74,7 @@ OuttrajTest() {
   cat > mremd.in <<EOF
 noprogress
 parm rGACC.nowat.parm7
+ensemblesize 8
 ensemble rGACC.nowat.001 nosort
 outtraj Outtraj.crd onlymembers 0,1
 EOF


### PR DESCRIPTION
In order for ensemble setup to be efficient in parallel the total ensemble size needs to be known beforehand. Previously this was accomplished via the `size` keyword of the `ensemble` command. It is now accomplished via the `ensemblesize` command; this way the ensemble size only needs to be specified once for multiple `ensemble` commands. Also adds this command to the tests (will have no effect if not parallel).