### PR TITLE
Improvements to sander API use by CPPTRAJ

### DIFF
--- a/Makefile_at
+++ b/Makefile_at
@@ -1,15 +1,13 @@
-# CPPTRAJ - Main Makefile
+# CPPTRAJ - AmberTools Makefile
 # Daniel R. Roe
 # 2010-11-18
-# Revised 2015-03-09
+# Revised 2016-02-11
+include ../config.h
 
 # Create standalone cpptraj binary in ./src/
-all:
-	cd src && $(MAKE)
+all: install
 
-# Create standalone cpptraj binary
-install_local:
-	cd src && $(MAKE) install
+install: $(INSTALLTYPE)
 
 # Create cpptraj/ambpdb binaries within AmberTools
 serial:
@@ -29,17 +27,10 @@ libcpptraj:
 
 # Run Tests
 check:
-	cd ../../test/cpptraj/ && $(MAKE) test
-
-check_local:
-	cd ../../test/cpptraj/ && $(MAKE) test.standalone
+	cd test && $(MAKE) test
 
 docs: src/cpptraj.Doxyfile
 	cd src && doxygen cpptraj.Doxyfile
-
-# Clean up for standalone
-clean_local:
-	cd src && $(MAKE) clean
 
 # Clean up for AmberTools
 clean:

--- a/configure
+++ b/configure
@@ -40,17 +40,17 @@ UsageFull() {
   echo "    --with-fftw3=<DIR>"
   echo "    --with-readline=<DIR>"
 #  echo "   --with-hdf5=<DIR>"
-  echo "    -static     : Use static linking."
-  echo "    -amberlib   : Use BLAS/ARPACK/LAPACK/NetCDF libraries from \$AMBERHOME"
-  echo "    -nobzlib    : Do not use libbz2 (bzip2)"
-  echo "    -nozlib     : Do not use zlib (gzip/zip)"
-  echo "    -nonetcdf   : Do not use NetCDF"
-  echo "    -nomathlib  : Do not include routines which require LAPACK or BLAS"
-  echo "    -noarpack   : Do not include routines which require ARPACK"
-  echo "    -noreadline : Do not include support for readline in the interpreter"
-  echo "    -openblas   : Use OpenBLAS (with LAPACK) instead of separate BLAS/LAPACK"
-  echo "    -libsci     : Use Cray LibSci for BLAS/LAPACK"
-  echo "    -sanderlib  : Link to sander API (requires AMBERHOME set)."
+  echo "    -static      : Use static linking."
+  echo "    -amberlib    : Use BLAS/ARPACK/LAPACK/NetCDF libraries from \$AMBERHOME"
+  echo "    -nobzlib     : Do not use libbz2 (bzip2)"
+  echo "    -nozlib      : Do not use zlib (gzip/zip)"
+  echo "    -nonetcdf    : Do not use NetCDF"
+  echo "    -nomathlib   : Do not include routines which require LAPACK or BLAS"
+  echo "    -noarpack    : Do not include routines which require ARPACK"
+  echo "    -noreadline  : Do not include support for readline in the interpreter"
+  echo "    -nosanderlib : Do not try to link to the sander API even if present"
+  echo "    -openblas    : Use OpenBLAS (with LAPACK) instead of separate BLAS/LAPACK"
+  echo "    -libsci      : Use Cray LibSci for BLAS/LAPACK"
   echo ""
   echo "  ENVIRONMENT VARIABLES (can also be passed to configure as <VAR>=<VALUE>):"
   echo "    CXX        : Name of the C++ compiler."
@@ -210,9 +210,24 @@ EOF
   fi
 }
 
+# This test is different than the others in that it is used to dynamically
+# check whether the library is usable and set flags accordingly.
 TestSanderlib() {
-  if [[ ! -z $SANDERLIB ]] ; then
-    cat > testp.cpp <<EOF
+  SL_ERR=0
+  if [[ $USE_SANDERLIB -eq 1 ]] ; then
+    echo "Checking availability of the SANDER API from AmberTools"
+    if [[ -z $AMBERHOME ]] ; then
+      echo "  Warning: Compilation with the SANDER API requires AMBERHOME to be set."
+      SL_ERR=1
+    elif [[ ! -f "$AMBERHOME/lib/libsander.so" ]] ; then
+      echo "  Warning: $AMBERHOME/lib/libsander.so not present."
+      SL_ERR=1
+    else
+      SANDERINC="-I$AMBERHOME/include"
+      SANDERLIB="-L$AMBERHOME/lib -lsander"
+      echo "  Using SANDER API from $AMBERHOME"
+      # Test that libsander can be linked
+      cat > testp.cpp <<EOF
 #include <cstdio>
 #include "sander.h"
 int main() {
@@ -220,7 +235,27 @@ int main() {
   printf("Testing\n"); return 0;
 }
 EOF
-    TestCxxProgram "Checking SANDER API" "$SANDERLIB"
+      $CXX $SANDERINC -o testp testp.cpp $SANDERLIB > /dev/null 2> compile.err
+      SL_ERR=$?
+      if [[ $SL_ERR -eq 0 ]] ; then
+        ./testp | grep "Testing" > /dev/null 2>> compile.err
+        SL_ERR=$?
+      fi
+      if [[ $SL_ERR -ne 0 ]] ; then
+        echo "  Warning: Compilation with the SANDER API failed. Error follows:"
+        echo "  --------------------"
+        cat compile.err
+        echo "  --------------------"
+      else
+        echo "  OK"
+        CPPTRAJ_LIB=$CPPTRAJ_LIB" $SANDERLIB"
+        CXXFLAGS=$CXXFLAGS" $SANDERINC -DUSE_SANDERLIB"
+      fi
+      /bin/rm -f testp.cpp testp
+    fi
+  fi
+  if [[ $SL_ERR -ne 0 ]] ; then
+    echo "  Warning: CPPTRAJ will be built without the SANDER API."
   fi
 }
 
@@ -416,7 +451,7 @@ FFT_LIB="pub_fft.o"
 FFT_LIBDIR=""
 FFT_DEPEND=$FFT_LIB
 LIBCPPTRAJ="nolibcpptraj" # Set to libcpptraj.so if library will be built
-SANDERLIB=""
+USE_SANDERLIB=1
 READLINE=$READLINE_TARGET
 USE_AMBER_LIB=0
 USEMKL=0
@@ -524,15 +559,7 @@ while [[ ! -z $1 ]] ; do
       echo "Using BLAS/LAPACK/ARPACK/NetCDF libraries in $AMBERHOME"
       USE_AMBER_LIB=1
       ;;
-    "-sanderlib"    )
-      if [[ -z $AMBERHOME ]] ; then
-        echo "Error: '-sanderlib' requires AMBERHOME is set."
-        exit 1
-      fi
-      INCLUDE="$INCLUDE -I$AMBERHOME/include"
-      SANDERLIB="-L$AMBERHOME/lib -lsander"
-      echo "Using SANDER API from $AMBERHOME"
-      ;;
+    "-nosanderlib"    ) USE_SANDERLIB=0 ;;
     "-fftw3" )
       echo "Using FFTW for FFT."
       FFT_LIB="-lfftw3"
@@ -666,6 +693,12 @@ while [[ ! -z $1 ]] ; do
   esac
   shift
 done
+
+if [[ $USE_SANDERLIB -eq 1 ]] ; then
+  echo "SANDER API will be used if found."
+else
+  echo "CPPTRAJ will be compiled without the SANDER API."
+fi
 
 # For external readline, we need to link libtermcap for windows and libncurses
 # for Linux
@@ -902,12 +935,6 @@ if [[ $COMPILERS = "cray" && $USEOPENMP -eq 0 ]] ; then
   DIRECTIVES="-h noomp "$DIRECTIVES
 fi
 
-# Flags for libsander
-if [[ ! -z $SANDERLIB ]] ; then
-  DIRECTIVES=$DIRECTIVES" -DUSE_SANDERLIB"
-  CPPTRAJ_LIB=$CPPTRAJ_LIB" $SANDERLIB"
-fi
-
 # Change to MPI compiler wrappers if specified
 if [[ $USEMPI -eq 1 ]] ; then
   if [[ "$WINDOWS" = "yes" ]]; then
@@ -1036,5 +1063,6 @@ if [[ ! -e $CPPTRAJLIB ]] ; then
   mkdir $CPPTRAJLIB
 fi
 
+echo "CPPTRAJ configuration complete."
 echo ""
 exit 0

--- a/configure
+++ b/configure
@@ -39,6 +39,7 @@ UsageFull() {
   echo "    --with-arpack=<DIR>"
   echo "    --with-fftw3=<DIR>"
   echo "    --with-readline=<DIR>"
+  echo "    --with-sanderlib=<DIR>"
 #  echo "   --with-hdf5=<DIR>"
   echo "    -static      : Use static linking."
   echo "    -amberlib    : Use BLAS/ARPACK/LAPACK/NetCDF libraries from \$AMBERHOME"
@@ -216,18 +217,25 @@ TestSanderlib() {
   SL_ERR=0
   if [[ $USE_SANDERLIB -eq 1 ]] ; then
     echo "Checking availability of the SANDER API from AmberTools"
-    if [[ -z $AMBERHOME ]] ; then
-      echo "  Warning: Compilation with the SANDER API requires AMBERHOME to be set."
-      SL_ERR=1
-    elif [[ ! -f "$AMBERHOME/lib/libsander.so" ]] ; then
-      echo "  Warning: $AMBERHOME/lib/libsander.so not present."
-      SL_ERR=1
-    else
-      SANDERINC="-I$AMBERHOME/include"
-      SANDERLIB="-L$AMBERHOME/lib -lsander"
-      echo "  Using SANDER API from $AMBERHOME"
-      # Test that libsander can be linked
-      cat > testp.cpp <<EOF
+    if [[ -z $SANDERLIB_HOME ]] ; then
+      if [[ -z $AMBERHOME ]] ; then
+        echo "  Warning: Compilation with the SANDER API requires AMBERHOME to be set"
+        echo "           if '--with-sanderlib' not specified."
+        SL_ERR=1
+      else
+        SANDERLIB_HOME=$AMBERHOME
+      fi
+    fi
+    if [[ $SL_ERR -eq 0 ]] ; then
+      if [[ ! -f "$SANDERLIB_HOME/lib/libsander.so" ]] ; then
+        echo "  Warning: $SANDERLIB_HOME/lib/libsander.so not present."
+        SL_ERR=1
+      else
+        SANDERINC="-I$SANDERLIB_HOME/include"
+        SANDERLIB="-L$SANDERLIB_HOME/lib -lsander"
+        echo "  Using SANDER API from $SANDERLIB_HOME"
+        # Test that libsander can be linked
+        cat > testp.cpp <<EOF
 #include <cstdio>
 #include "sander.h"
 int main() {
@@ -235,23 +243,24 @@ int main() {
   printf("Testing\n"); return 0;
 }
 EOF
-      $CXX $SANDERINC -o testp testp.cpp $SANDERLIB > /dev/null 2> compile.err
-      SL_ERR=$?
-      if [[ $SL_ERR -eq 0 ]] ; then
-        ./testp | grep "Testing" > /dev/null 2>> compile.err
+        $CXX $SANDERINC -o testp testp.cpp $SANDERLIB > /dev/null 2> compile.err
         SL_ERR=$?
+        if [[ $SL_ERR -eq 0 ]] ; then
+          ./testp | grep "Testing" > /dev/null 2>> compile.err
+          SL_ERR=$?
+        fi
+        if [[ $SL_ERR -ne 0 ]] ; then
+          echo "  Warning: Compilation with the SANDER API failed. Error follows:"
+          echo "  --------------------"
+          cat compile.err
+          echo "  --------------------"
+        else
+          echo "  OK"
+          CPPTRAJ_LIB=$CPPTRAJ_LIB" $SANDERLIB"
+          CXXFLAGS=$CXXFLAGS" $SANDERINC -DUSE_SANDERLIB"
+        fi
+        /bin/rm -f testp.cpp testp
       fi
-      if [[ $SL_ERR -ne 0 ]] ; then
-        echo "  Warning: Compilation with the SANDER API failed. Error follows:"
-        echo "  --------------------"
-        cat compile.err
-        echo "  --------------------"
-      else
-        echo "  OK"
-        CPPTRAJ_LIB=$CPPTRAJ_LIB" $SANDERLIB"
-        CXXFLAGS=$CXXFLAGS" $SANDERINC -DUSE_SANDERLIB"
-      fi
-      /bin/rm -f testp.cpp testp
     fi
   fi
   if [[ $SL_ERR -ne 0 ]] ; then
@@ -452,6 +461,7 @@ FFT_LIBDIR=""
 FFT_DEPEND=$FFT_LIB
 LIBCPPTRAJ="nolibcpptraj" # Set to libcpptraj.so if library will be built
 USE_SANDERLIB=1
+SANDERLIB_HOME=""
 READLINE=$READLINE_TARGET
 USE_AMBER_LIB=0
 USEMKL=0
@@ -559,7 +569,6 @@ while [[ ! -z $1 ]] ; do
       echo "Using BLAS/LAPACK/ARPACK/NetCDF libraries in $AMBERHOME"
       USE_AMBER_LIB=1
       ;;
-    "-nosanderlib"    ) USE_SANDERLIB=0 ;;
     "-fftw3" )
       echo "Using FFTW for FFT."
       FFT_LIB="-lfftw3"
@@ -577,6 +586,7 @@ while [[ ! -z $1 ]] ; do
       echo "Using MKL for BLAS/LAPACK in $MKLROOT"
       USEMKL=1
       ;;
+    "-nosanderlib"  ) USE_SANDERLIB=0 ;;
     "-nobzlib"      )
       echo "Not using bzip2"
       BZLIB=""
@@ -669,6 +679,10 @@ while [[ ! -z $1 ]] ; do
        FFT_LIB="-lfftw3"
        FFT_DEPEND=""
        DIRECTIVES="$DIRECTIVES -DFFTW_FFT"
+       ;;
+     "--with-sanderlib" )
+       SANDERLIB_HOME=$VALUE
+       USE_SANDERLIB=1
        ;;
 #    "--with-hdf5" )
 #      INCLUDE="$INCLUDE -I$VALUE/include"

--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -35,11 +35,6 @@ install_openmp: cpptraj$(SFX)
 install_mpi: cpptraj$(SFX)
 	/bin/mv cpptraj$(SFX) $(BINDIR)/cpptraj.MPI$(SFX)
 
-install_libsander:
-	/bin/rm -f Action_Esander.o Cpptraj.o Energy_Sander.o
-	$(MAKE) -f Makefile_at cpptraj.sander$(SFX) AMBERBUILDFLAGS=-DUSE_SANDERLIB
-	/bin/mv cpptraj.sander$(SFX) $(BINDIR)/
-
 findDepend: FindDepend.o
 	$(CXX) -o findDepend FindDepend.o
 
@@ -57,11 +52,6 @@ cpptraj$(SFX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS)
 ambpdb$(SFX): $(AMBPDB_OBJECTS)
 	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o ambpdb$(SFX) $(AMBPDB_OBJECTS) \
                -L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB)
-
-cpptraj.sander$(SFX): $(OBJECTS) $(EXTERNAL_LIBS) $(LIBDIR)/libsander.so
-	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o cpptraj.sander$(SFX) $(OBJECTS) \
-	       -L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB) $(FLIBS_PTRAJ) $(READLINE)  \
-	       -lsander
 
 libcpptraj$(SHARED_SUFFIX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS)
 	$(CXX) $(MAKE_SHARED) $(WARNFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) pub_fft.o \

--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -1,7 +1,7 @@
 # CPPTRAJ - AmberTools Makefile
 include ../../config.h
 
-CPPTRAJ_FLAGS= -I$(INCDIR) $(COPTFLAGS) $(CFLAGS) $(NETCDFINC) $(PNETCDFINC) $(PNETCDFDEF)
+CPPTRAJ_FLAGS= -I$(INCDIR) $(COPTFLAGS) $(CFLAGS) $(NETCDFINC) $(PNETCDFINC) $(PNETCDFDEF) $(SANDERAPI_DEF)
 # The EXTERNAL_LIBS line is used for triggering dependencies. It contains the
 # actual locations of the arpack, lapack, blas, and netcdf libraries as 
 # installed by AmberTools. Since the NETCDFLIB / FLIBS_PTRAJ vars can now just
@@ -44,10 +44,10 @@ depend: findDepend
 dependclean:
 	/bin/rm -f FindDepend.o findDepend
 
-cpptraj$(SFX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS) 
+cpptraj$(SFX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS) $(SANDERAPI_DEP) 
 	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o cpptraj$(SFX) $(OBJECTS) pub_fft.o \
                -L$(LIBDIR) $(NETCDFLIB) $(PNETCDFLIB) $(ZLIB) $(BZLIB) \
-               $(FLIBS_PTRAJ) $(READLINE)
+               $(FLIBS_PTRAJ) $(READLINE) $(SANDERAPI_LIB)
 
 ambpdb$(SFX): $(AMBPDB_OBJECTS)
 	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o ambpdb$(SFX) $(AMBPDB_OBJECTS) \
@@ -65,6 +65,9 @@ $(LIBDIR)/liblapack.a:
 
 $(LIBDIR)/libblas.a:
 	cd ../../blas && $(MAKE) $(BLAS)
+
+$(SANDERAPI_DEP):
+	cd ../../sander && $(MAKE) $(SANDERAPI_DEP)
 
 $(READLINE_HOME)/libreadline.a:
 	cd $(READLINE_HOME) && $(MAKE) -f Makefile_at 

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -269,7 +269,7 @@ CheckSanderlib() {
       DESCRIP="This test"
     fi
     echo "$DESCRIP requires compilation with the Sander API from AmberTools."
-    echo "Re-compile with '-libsander' to enable this functionality. Skipping test."
+    echo "Skipping test."
     return 1
   fi
   return 0

--- a/test/Test_Esander/RunTest.sh
+++ b/test/Test_Esander/RunTest.sh
@@ -13,15 +13,18 @@ fi
 INPUT="-i ene.in"
 
 TestPME() {
-  cat > ene.in <<EOF
+  CheckPnetcdf "SANDER energy test, PME"
+  if [[ $? -eq 0 ]] ; then
+    cat > ene.in <<EOF
 parm ../tz2.truncoct.parm7
 trajin ../tz2.truncoct.nc
 esander S out Esander.dat saveforces
 trajout force.nc
 EOF
-  RunCpptraj "SANDER energy test, PME."
-  DoTest Esander.dat.save Esander.dat
-  NcTest force.nc.save force.nc
+    RunCpptraj "SANDER energy test, PME."
+    DoTest Esander.dat.save Esander.dat
+    NcTest force.nc.save force.nc
+  fi
 }
 
 TestGB() {


### PR DESCRIPTION
This PR changes cpptraj's standalone configure so it automatically tries to use the sander API if it is specified with `--with-sanderlib` or is present in `$AMBERHOME`. This can be disabled via the `-nolibsander` flag. If the sander API cannot be used a warning is issued but configuration is allowed to complete.

This also changes the AmberTools Makefile so it makes use of new variables related to the sander API that will be introduced to Amber's config.h:

- SANDERAPI_LIB: The sander API library
- SANDERAPI_DEF: The sander API define
- SANDERAPI_DEP: The sander API dependency

These will automatically be set by AmberTools configure for all builds except parallel. In parallel, configure will check that `libsander.so` is present and can be linked to; if not, linking to the sander API is disabled and a warning is issued but configuration is allowed to complete.