### PR TITLE
Ensure libsander.so not included in libcpptraj.so

### DIFF
--- a/Makefile_at
+++ b/Makefile_at
@@ -21,9 +21,12 @@ openmp:
 parallel:
 	cd src && $(MAKE) -f Makefile_at install_mpi
 
-# Create libcpptraj within AmberTools 
+# Create libcpptraj within AmberTools. Since we do not want to include
+# the sander API, delete any objects that may have used it and explicitly
+# blank the SANDERAPI_DEF define variable.
 libcpptraj:
-	cd src && $(MAKE) -f Makefile_at libcpptraj
+	/bin/rm -f src/Action_Esander.o src/Cpptraj.o src/Energy_Sander.o
+	cd src && $(MAKE) -f Makefile_at libcpptraj SANDERAPI_DEF=""
 
 # Run Tests
 check:

--- a/configure
+++ b/configure
@@ -25,7 +25,7 @@ UsageFull() {
   echo "    -timer     : Enable additional timing info."
   echo "    -debugon   : Add -DDEBUG flag to activate additional internal debugging."
   echo "    -nolfs     : Do not enable large file support."
-  echo "    -shared    : Enable position-independent code for generating shared library."
+  echo "    -shared    : Configure for generating libcpptraj.so (implies -nosanderlib)."
   echo "    -fftw3     : Use FFTW instead of pubfft for FFT."
   echo "    -windows   : Set up for use with MinGW compilers for a native Windows build"
   echo ""
@@ -558,6 +558,7 @@ while [[ ! -z $1 ]] ; do
     "-shared"       )
       echo "Enabling position-independent code for generating shared library."
       USESHARED=1
+      USE_SANDERLIB=0
       LIBCPPTRAJ="libcpptraj.so"
       ;;
     "-amberlib"     )
@@ -1075,6 +1076,12 @@ if [[ ! -e $CPPTRAJBIN ]] ; then
 fi
 if [[ ! -e $CPPTRAJLIB ]] ; then
   mkdir $CPPTRAJLIB
+fi
+
+# Clean the source directory if necessary.
+if [[ -f "src/main.o" ]] ; then
+  echo "Cleaning previous compile."
+  cd src && make clean > /dev/null 2> /dev/null
 fi
 
 echo "CPPTRAJ configuration complete."

--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -84,11 +84,9 @@ ReadLine.o: ReadLine.cpp
 .cpp.o:
 	$(CXX) $(WARNFLAGS) -c $(CPPTRAJ_FLAGS) -o $@ $<
 
-# Always remove readline library with AT to avoid issues with PIC
 clean:
 	/bin/rm -f $(OBJECTS) pub_fft.o cpptraj$(SFX) AmbPDB.o ambpdb$(SFX)
 	cd readline && $(MAKE) -f Makefile_at clean
-	/bin/rm -f $(READLINE)
 
 uninstall:
 	/bin/rm -f $(BINDIR)/cpptraj$(SFX) $(BINDIR)/cpptraj.OMP$(SFX) $(BINDIR)/cpptraj.MPI$(SFX)

--- a/src/readline/Makefile_main
+++ b/src/readline/Makefile_main
@@ -607,13 +607,12 @@ xmalloc.o: xmalloc.c config.h \
 
 install:   FORCE
 
-uninstall:   FORCE
-	-rm -f $(TARGET)
+uninstall: clean
 
 FORCE:
 
 ####### Clean
 
 clean:
-	/bin/rm -f *.o
+	/bin/rm -f *.o $(TARGET)
 


### PR DESCRIPTION
This is done via `configure` for standalone cpptraj and via a modified Makefile rule under AmberTools. The source directory is also now cleaned after configure if needed (including libreadline.a) to avoid any compile issues with e.g. PIC compiled code with non-PIC code etc.