### PR TITLE
Improve data set sync

### DIFF
--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -916,7 +916,8 @@ int CpptrajState::RunParaEnsemble() {
   // Sync Actions to master thread
   actionList_.SyncActions();
   // Sync data sets to master thread
-  if (DSL_.SynchronizeData( NAV.IDX().MaxFrames(), rank_frames, TrajComm )) return 1;
+  //if (DSL_.SynchronizeData( NAV.IDX().MaxFrames(), rank_frames, TrajComm )) return 1;
+  if (DSL_.SynchronizeData( TrajComm )) return 1;
   sync_time_.Stop();
   mprintf("\nACTION OUTPUT:\n");
   post_time_.Start();
@@ -1053,7 +1054,8 @@ int CpptrajState::RunParallel() {
   // Sync Actions to master thread
   actionList_.SyncActions();
   // Sync data sets to master thread
-  if (DSL_.SynchronizeData( input_traj.Size(), rank_frames, TrajComm )) return 1;
+  //if (DSL_.SynchronizeData( input_traj.Size(), rank_frames, TrajComm )) return 1;
+  if (DSL_.SynchronizeData( TrajComm )) return 1;
   sync_time_.Stop();
   post_time_.Start();
   mprintf("\nACTION OUTPUT:\n");

--- a/src/CpptrajState.h
+++ b/src/CpptrajState.h
@@ -78,7 +78,7 @@ class CpptrajState {
     int RunNormal();
     int RunEnsemble();
 #   ifdef MPI
-    std::vector<int> DivideFramesAmongThreads(int&, int&, int&, int, Parallel::Comm const&) const;
+    void DivideFramesAmongThreads(int&, int&, int&, int, Parallel::Comm const&) const;
     int PreloadCheck(int, int, int&, int&) const;
     int RunParallel();
     int RunParaEnsemble();

--- a/src/DataSetList.h
+++ b/src/DataSetList.h
@@ -105,7 +105,7 @@ class DataSetList {
     /// Indicate whether sets added to the list need to be synced
     void SetNewSetsNeedSync(bool b) { newSetsNeedSync_ = b; }
     /// Call sync for DataSets in the list (MPI only)
-    int SynchronizeData(size_t, std::vector<int> const&, Parallel::Comm const&);
+    int SynchronizeData(Parallel::Comm const&);
 #   endif
 
     // REF_COORDS functions ----------------------


### PR DESCRIPTION
This improves synchronization of time-series data sets by not assuming that sets are the same size as the number of frames read on every rank (which is no the case if e.g. `check skipbadframes` or `filter` is used). It has been implemented via one extra MPI `gather` call to master, in which every rank reports the size of all sets to be synced. This appears to have a negligible affect on data set synchronization time. The diffusion calculation test shown below (numbers are total sync times in seconds) generates a lot of data sets that need to be synced (75120) so it is a decent test of the sync framework.
```
System: Ftu FabI 49209 atoms, 15292 res, box: Trunc. Oct., 15025 mol, 15022 solvent
Command: diffusion separateout Diff :WAT@O WAT individual
(local)
10 frames:
  New: <0.0253 + 0.0254 + 0.0247> = 0.025133
  Old: <0.0235 + 0.0241 + 0.0237> = 0.023767
  Delta = 0.001366
(local)
100 frames:
  New: <0.0358 + 0.0356 + 0.0353> = 0.035567
  Old: <0.0340 + 0.0342 + 0.0332> = 0.033800
  Delta = 0.001767
(ember 2 nodes)
2000 frames:
  New: <0.2297 + 0.2283 + 0.2284> = 0.228800
  Old: <0.2310 + 0.2284 + 0.2291> = 0.229500
  Delta = -0.000700
```
In one case the sync time even improves, so this seems like all  upside.