### PR TITLE
Fix test comparisons on OSX under AmberTools

### DIFF
--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -52,10 +52,22 @@ SANDERLIB=""
 #   <OS>. The remaining args can be used to pass options to DIFFCMD.
 DoTest() {
   if [[ ! -z $DACDIF ]] ; then
-    # AmberTools - will use dacdif.
-    $DACDIF $1 $2
+    # AmberTools - will use dacdif. Use any '-r <X>' or '-a <X>' args found.
+    # Ignore the rest.
+    DIFFARGS="$1 $2"
+    shift # Save file
+    shift # Test file
+    # Process remaining args
+    while [[ ! -z $1 ]] ; do
+      case "$1" in
+        "-r" ) shift ; DIFFARGS=$DIFFARGS" -r $1" ;;
+        "-a" ) shift ; DIFFARGS=$DIFFARGS" -a $1" ;;
+      esac
+      shift
+    done
+    $DACDIF $DIFFARGS
   else
-    # Standalone - will use diff.
+    # Standalone - will use diff. Skip any dacdif args.
     ((NUMTEST++))
     DIFFARGS="--strip-trailing-cr"
     # First two arguments are files to compare.
@@ -68,6 +80,8 @@ DoTest() {
       case "$1" in
         "allowfail"    ) ALLOW_FAIL=1 ; shift ; FAIL_OS=$1 ;;
         "parallelfail" ) ALLOW_FAIL=2 ;;
+        "-r"           ) shift ;;
+        "-a"           ) shift ;;
         *              ) DIFFARGS=$DIFFARGS" $1" ;;
       esac
       shift

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -60,8 +60,8 @@ DoTest() {
     # Process remaining args
     while [[ ! -z $1 ]] ; do
       case "$1" in
-        "-r" ) shift ; DIFFARGS=$DIFFARGS" -r $1" ;;
-        "-a" ) shift ; DIFFARGS=$DIFFARGS" -a $1" ;;
+        "-r" ) shift ; DIFFARGS=" -r $1 "$DIFFARGS ;;
+        "-a" ) shift ; DIFFARGS=" -a $1 "$DIFFARGS ;;
       esac
       shift
     done
@@ -143,16 +143,31 @@ NcTest() {
     echo "ncdump missing." > /dev/stderr
     exit 1
   fi
+  # Save remaining args for DoTest
+  F1=$1
+  F2=$2
+  shift
+  shift
+  DIFFARGS="nc0.save nc0"
+  while [[ ! -z $1 ]] ; do
+    DIFFARGS=$DIFFARGS" $1"
+    shift
+  done
   # Prepare files.
-  if [[ ! -e $1 ]] ; then
-    echo "Error: $1 missing." >> $TEST_ERROR
-  elif [[ ! -e $2 ]] ; then
-    echo "Error: $2 missing." >> $TEST_ERROR
+  if [[ ! -e $F1 ]] ; then
+    echo "Error: $F1 missing." >> $TEST_ERROR
+  elif [[ ! -e $F2 ]] ; then
+    echo "Error: $F2 missing." >> $TEST_ERROR
   else
-    $NCDUMP -n nctest $1 | grep -v "==>\|:programVersion" > nc0
-    $NCDUMP -n nctest $2 | grep -v "==>\|:programVersion" > nc1
-    DoTest nc0 nc1
-    $REMOVE nc0 nc1
+    if [[ ! -z $DACDIF ]] ; then
+      $NCDUMP -n nctest $F1 | grep -v "==>\|:programVersion" | sed 's/,/ /g' > nc0.save
+      $NCDUMP -n nctest $F2 | grep -v "==>\|:programVersion" | sed 's/,/ /g' > nc0
+    else
+      $NCDUMP -n nctest $F1 | grep -v "==>\|:programVersion" > nc0.save
+      $NCDUMP -n nctest $F2 | grep -v "==>\|:programVersion" > nc0
+    fi
+    DoTest $DIFFARGS 
+    $REMOVE nc0.save nc0
   fi
 }
 

--- a/test/Test_CurveFit/RunTest.sh
+++ b/test/Test_CurveFit/RunTest.sh
@@ -32,10 +32,10 @@ runanalysis curvefit Data.dat nexp 2 name PKFitY form mexpk_penalty \
 EOF
 RunCpptraj "Curve fitting multi-exponential tests."
 DoTest curve.dat.save curve1.dat
-DoTest Kcurve.dat.save Kcurve.dat
+DoTest Kcurve.dat.save Kcurve.dat -r 0.0002
 # Differences in windows seem like round-off
-DoTest PKcurve.dat.save PKcurve.dat allowfail windows
-DoTest Results.dat.save Results.dat allowfail windows
+DoTest PKcurve.dat.save PKcurve.dat allowfail windows -r 0.0003
+DoTest Results.dat.save Results.dat allowfail windows -r 0.006
 
 # Custom X output range.
 cat > cf.in <<EOF

--- a/test/Test_Esander/RunTest.sh
+++ b/test/Test_Esander/RunTest.sh
@@ -23,7 +23,7 @@ trajout force.nc
 EOF
     RunCpptraj "SANDER energy test, PME."
     DoTest Esander.dat.save Esander.dat
-    NcTest force.nc.save force.nc
+    NcTest force.nc.save force.nc -a 0.000001
   fi
 }
 

--- a/test/Test_GIST/RunTest.sh
+++ b/test/Test_GIST/RunTest.sh
@@ -40,7 +40,7 @@ DoTest gist-neighbor-norm.dx.save gist-neighbor-norm.dx
 DoTest gist-order-norm.dx.save gist-order-norm.dx
 # NOTE: gist.out allowed to fail on windows; differences due to slightly
 #       difference implementation of printf '%g' (manifests as round-off).
-DoTest gist.out.save gist.out allowfail windows
+DoTest gist.out.save gist.out allowfail windows -r 0.0001
 
 EndTest
 exit 0


### PR DESCRIPTION
This PR allows certain tests to pass with absolute or relative errors under a given tolerance when using the 'dacdif' program from AmberTools.