### PR TITLE
Improve Charmm COR detection.

### DIFF
--- a/src/Traj_CharmmCor.cpp
+++ b/src/Traj_CharmmCor.cpp
@@ -6,13 +6,22 @@
 bool Traj_CharmmCor::ID_TrajFormat(CpptrajFile& fileIn) {
   // File must already be set up for read.
   if (fileIn.OpenFile()) return false;
-  std::string buffer = fileIn.GetLine();
-  fileIn.CloseFile();
-  if (buffer.size() > 1) {
-    if (buffer[0] == '*' && buffer[1] == ' ') // FIXME: OK to check for space?
-      return true;
+  bool isCor = false;
+  const char* ptr = fileIn.NextLine();
+  // Must be at least 1 title line denoted with '*'
+  if (ptr != 0 && *ptr == '*') {
+    // Scan past all title lines
+    while (ptr != 0 && *ptr == '*') ptr = fileIn.NextLine();
+    if (ptr != 0) {
+      // Next line must be # atoms ONLY
+      int ibuf[2];
+      if (sscanf(ptr, "%i %i", ibuf) == 1)
+        // make sure it was a valid integer
+        isCor = (ibuf[0] > 0);
+    }
   }
-  return false;
+  fileIn.CloseFile();
+  return isCor;
 }
 
 int Traj_CharmmCor::setupTrajin(FileName const& fname, Topology* trajParm)


### PR DESCRIPTION
Make Charmm COR file detection more robust so that Amber trajectory files with titles that begin "* " are not incorrectly identified as Charmm COR.