### PR TITLE
Hide commands not ready for general use and add warnings about using them.

### DIFF
--- a/src/Action_NMRrst.cpp
+++ b/src/Action_NMRrst.cpp
@@ -9,7 +9,7 @@
 #include "AtomMap.h"
 
 // CONSTRUCTOR
-Action_NMRrst::Action_NMRrst() :
+Action_NMRrst::Action_NMRrst() : Action(HIDDEN),
    findOutput_(0), specOutput_(0), masterDSL_(0), numNoePairs_(0), max_cut_(6.0),
    strong_cut_(2.9), medium_cut_(3.5), weak_cut_(5.0),
    resOffset_(0), debug_(0), nframes_(0), useMass_(false),

--- a/src/Action_NMRrst.cpp
+++ b/src/Action_NMRrst.cpp
@@ -117,6 +117,7 @@ Action::RetType Action_NMRrst::Init(ArgList& actionArgs, ActionInit& init, int d
 
   masterDSL_ = init.DslPtr();
  
+  mprintf("Warning: *** THIS ACTION IS EXPERIMENTAL. ***\n");
   mprintf("    NMRRST: %zu NOEs from NMR restraint file.\n", NOEs_.size());
   mprintf("\tShifting residue numbers in restraint file by %i\n", resOffset_);
   // DEBUG - print NOEs

--- a/src/Exec_CompareTop.cpp
+++ b/src/Exec_CompareTop.cpp
@@ -164,6 +164,7 @@ static void PrintLJatom(CpptrajFile& output, Topology const& parm,
 /// Compare two topologies, find differences
 Exec::RetType Exec_CompareTop::Execute(CpptrajState& State, ArgList& argIn)
 {
+  mprintf("Warning: THIS COMMAND IS NOT FULLY IMPLEMENTED.\n");
   Topology* parm1 = State.DSL().GetTopology( argIn );
   Topology* parm2 = State.DSL().GetTopology( argIn );
   if (parm1 == 0 || parm2 == 0) {

--- a/src/Exec_SequenceAlign.cpp
+++ b/src/Exec_SequenceAlign.cpp
@@ -23,6 +23,7 @@ void Exec_SequenceAlign::Help() const {
 }
     
 Exec::RetType Exec_SequenceAlign::Execute(CpptrajState& State, ArgList& argIn) {
+  mprintf("Warning: THIS COMMAND IS NOT FULLY IMPLEMENTED.\n");
   std::string blastfile = argIn.GetStringKey("blastfile");
   if (blastfile.empty()) {
     mprinterr("Error: 'blastfile' must be specified.\n");


### PR DESCRIPTION
nmrrst hasn't been tested enough to be considered ready to go. However, leave it usable, just in case people feel adventurous. 