### PR TITLE
Add 'bigendian' option to TRR trajectory output

### DIFF
--- a/src/ByteRoutines.cpp
+++ b/src/ByteRoutines.cpp
@@ -49,3 +49,11 @@ void endian_swap8(void *x, long nswap) {
   }
 }
 
+bool IsBigEndian() {
+  union {
+      unsigned int i;
+      char c[4];
+  } bint = {0x01020304};
+
+  return ( bint.c[0] == 1 );
+}

--- a/src/ByteRoutines.h
+++ b/src/ByteRoutines.h
@@ -13,4 +13,6 @@ union byte8 {
 void endian_swap(void *, long);
 /// Perform byte swaps on 8-byte segments.
 void endian_swap8(void *, long);
+/// \return true if underlying architecture is big endian
+bool IsBigEndian();
 #endif

--- a/src/Traj_GmxTrX.cpp
+++ b/src/Traj_GmxTrX.cpp
@@ -474,7 +474,8 @@ int Traj_GmxTrX::readVelocity(int set, Frame& frameIn) {
 int Traj_GmxTrX::writeFrame(int set, Frame const& frameOut) {
   int tsize;
   // Write header
-  file_.Write( &Magic_, 4 );
+  tsize = 1993;
+  write_int( tsize ); //file_.Write( &Magic_, 4 );
   tsize = (int)Title().size() + 1;
   write_int( tsize ); //file_.Write( &tsize, 4);
   tsize = (int)Title().size(); //--tsize;
@@ -532,7 +533,7 @@ int Traj_GmxTrX::writeFrame(int set, Frame const& frameOut) {
     if (v_size_ > 0)
       for (int iv = 0; iv < natom3_; iv++, ix++)
         farray_[ix] = (float)(Vptr[iv] * 0.1);
-    if (isBigEndian_) endian_swap( farray_, x_size_ + v_size_ );
+    if (isBigEndian_) endian_swap( farray_, natom3_ );
     file_.Write( farray_, x_size_ + v_size_ );
   } else { // double
     for (; ix < natom3_; ix++)
@@ -540,7 +541,7 @@ int Traj_GmxTrX::writeFrame(int set, Frame const& frameOut) {
     if (v_size_ > 0)
       for (int iv = 0; iv < natom3_; iv++, ix++)
         darray_[ix] = (Vptr[iv] * 0.1);
-    if (isBigEndian_) endian_swap8( darray_, x_size_ + v_size_ );
+    if (isBigEndian_) endian_swap8( darray_, natom3_ );
     file_.Write( darray_, x_size_ + v_size_ );
   }
   

--- a/src/Traj_GmxTrX.cpp
+++ b/src/Traj_GmxTrX.cpp
@@ -489,29 +489,28 @@ int Traj_GmxTrX::readVelocity(int set, Frame& frameIn) {
 int Traj_GmxTrX::writeFrame(int set, Frame const& frameOut) {
   int tsize;
   // Write header
-  tsize = 1993;
-  write_int( tsize ); //file_.Write( &Magic_, 4 );
+  write_int( Magic_ );
   tsize = (int)Title().size() + 1;
-  write_int( tsize ); //file_.Write( &tsize, 4);
-  tsize = (int)Title().size(); //--tsize;
-  write_int( tsize ); //file_.Write( &tsize, 4);
+  write_int( tsize );
+  tsize = (int)Title().size();
+  write_int( tsize );
   file_.Write( Title().c_str(), Title().size() );
-  write_int( ir_size_ ); //file_.Write( &ir_size_, 4 );
-  write_int( e_size_ ); //file_.Write( &e_size_, 4 );
-  write_int( box_size_ ); //file_.Write( &box_size_, 4 );
-  write_int( vir_size_ ); //file_.Write( &vir_size_, 4 );
-  write_int( pres_size_ ); //file_.Write( &pres_size_, 4 );
-  write_int( top_size_ ); //file_.Write( &top_size_, 4 );
-  write_int( sym_size_ ); //file_.Write( &sym_size_, 4 );
-  write_int( x_size_ ); //file_.Write( &x_size_, 4 );
-  write_int( v_size_ ); //file_.Write( &v_size_, 4 );
-  write_int( f_size_ ); //file_.Write( &f_size_, 4 );
-  write_int( natoms_ ); //file_.Write( &natoms_, 4 );
-  write_int( step_ ); //file_.Write( &step_, 4 );
-  write_int( nre_ ); //file_.Write( &nre_, 4 );
+  write_int( ir_size_ );
+  write_int( e_size_ );
+  write_int( box_size_ );
+  write_int( vir_size_ );
+  write_int( pres_size_ );
+  write_int( top_size_ );
+  write_int( sym_size_ );
+  write_int( x_size_ );
+  write_int( v_size_ );
+  write_int( f_size_ );
+  write_int( natoms_ );
+  write_int( step_ );
+  write_int( nre_ );
   float time = (float)(dt_ * (double)set);
-  write_real( time ); //file_.Write( &dt_, 4 ); // TODO: Write actual time
-  write_real( lambda_ ); //file_.Write( &lambda_, 4 );
+  write_real( time ); // TODO: Write actual time
+  write_real( lambda_ );
   // Write box
   // NOTE: GROMACS units are nm
   if (box_size_ > 0) {
@@ -561,7 +560,6 @@ int Traj_GmxTrX::writeFrame(int set, Frame const& frameOut) {
     if (isBigEndian_) endian_swap8( darray_, arraySize_ );
     file_.Write( darray_, x_size_ + v_size_ );
   }
-  
   return 0;
 }
 

--- a/src/Traj_GmxTrX.cpp
+++ b/src/Traj_GmxTrX.cpp
@@ -8,6 +8,7 @@
 Traj_GmxTrX::Traj_GmxTrX() :
   isBigEndian_(false),
   format_(TRR),
+  dt_(1.0),
   ir_size_(0),
   e_size_(0),
   box_size_(0),

--- a/src/Traj_GmxTrX.h
+++ b/src/Traj_GmxTrX.h
@@ -34,15 +34,16 @@ class Traj_GmxTrX : public TrajectoryIO {
     float lambda_;
     size_t frameSize_;
     size_t headerBytes_;
+    size_t arraySize_;
     float* farray_;
     double* darray_;
 
     void GmxInfo();
     bool IsTRX(CpptrajFile&);
     int read_int(int&);
-    int write_int(int&);
+    int write_int(int);
     int read_real(float&);
-    int write_real(float&);
+    int write_real(float);
     std::string read_string();
     int ReadBox(double*);
     int ReadTrxHeader();
@@ -60,7 +61,7 @@ class Traj_GmxTrX : public TrajectoryIO {
     void Info();
     int readVelocity(int, Frame&);
     int readForce(int, Frame&)     { return 1; }  // TODO support this
-    int processWriteArgs(ArgList&) { return 0; }
+    int processWriteArgs(ArgList&);
     int processReadArgs(ArgList&)  { return 0; }
 #   ifdef MPI
     // Parallel functions

--- a/src/Traj_GmxTrX.h
+++ b/src/Traj_GmxTrX.h
@@ -7,6 +7,7 @@ class Traj_GmxTrX : public TrajectoryIO {
     Traj_GmxTrX();
     ~Traj_GmxTrX();
     static BaseIOtype* Alloc() { return (BaseIOtype*)new Traj_GmxTrX(); }
+    static void WriteHelp();
   private:
     enum FormatType { TRR = 0, TRJ };
     static const int Magic_;
@@ -15,6 +16,7 @@ class Traj_GmxTrX : public TrajectoryIO {
     CpptrajFile file_;
     FormatType format_;
 
+    double dt_;
     int ir_size_;
     int e_size_;
     int box_size_;
@@ -30,7 +32,7 @@ class Traj_GmxTrX : public TrajectoryIO {
     int step_;
     int nre_;
     int precision_;
-    float dt_;
+    float timestep_;
     float lambda_;
     size_t frameSize_;
     size_t headerBytes_;

--- a/src/Traj_GmxTrX.h
+++ b/src/Traj_GmxTrX.h
@@ -40,7 +40,9 @@ class Traj_GmxTrX : public TrajectoryIO {
     void GmxInfo();
     bool IsTRX(CpptrajFile&);
     int read_int(int&);
+    int write_int(int&);
     int read_real(float&);
+    int write_real(float&);
     std::string read_string();
     int ReadBox(double*);
     int ReadTrxHeader();

--- a/src/TrajectoryFile.cpp
+++ b/src/TrajectoryFile.cpp
@@ -40,7 +40,7 @@ const FileTypes::AllocToken TrajectoryFile::TF_AllocArray[] = {
   { "Mol2",               0, Traj_Mol2File::WriteHelp, Traj_Mol2File::Alloc       },
   { "CIF",                0, 0, Traj_CIF::Alloc            },
   { "Charmm DCD",         0, Traj_CharmmDcd::WriteHelp, Traj_CharmmDcd::Alloc      },
-  { "Gromacs TRX",        0, 0, Traj_GmxTrX::Alloc         },
+  { "Gromacs TRX",        0, Traj_GmxTrX::WriteHelp, Traj_GmxTrX::Alloc         },
   { "BINPOS",             0, 0, Traj_Binpos::Alloc         },
   { "Amber Restart",      Traj_AmberRestart::ReadHelp, Traj_AmberRestart::WriteHelp, Traj_AmberRestart::Alloc   },
   { "GRO file",           0, 0, Traj_Gro::Alloc            },


### PR DESCRIPTION
Gromacs analysis tools appear to require TRR files be written big-endian, so add `bigendian` option to TRR trajectory output to force big-endian. Also adds a `dt` option for setting time step factor.