### PR TITLE
Fix compile with old Intel MPI version

### DIFF
--- a/src/FileIO_Mpi.cpp
+++ b/src/FileIO_Mpi.cpp
@@ -1,5 +1,9 @@
 #include "FileIO_Mpi.h"
 #ifdef MPI
+#ifdef MPICH_IGNORE_CXX_SEEK
+// Needed on some old Intel MPI platforms
+# include <cstdio>
+#endif
 // FileIO_Mpi::Open()
 int FileIO_Mpi::Open(const char *filename, const char *mode) {
   if (comm_.IsNull()) return 1;


### PR DESCRIPTION
In order to compile with older versions of Intel MPI, MPICH_IGNORE_CXX_SEEK needs to be defined, see:

https://software.intel.com/en-us/articles/intel-mpi-library-for-linux-running-list-of-known-issues#A3

When this is defined <cstdio> needs to be explicitly included in FileIO_MPI.cpp.