### PR TITLE
Attempt to fix pytraj on OS X.

### DIFF
--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -26,8 +26,7 @@ install: cpptraj$(SFX) ambpdb$(SFX)
 	/bin/mv cpptraj$(SFX) $(BINDIR)/
 	/bin/mv ambpdb$(SFX) $(BINDIR)/
 
-libcpptraj: libcpptraj$(SHARED_SUFFIX)
-	/bin/mv libcpptraj$(SHARED_SUFFIX) $(LIBDIR)/
+libcpptraj: $(LIBDIR)/libcpptraj$(SHARED_SUFFIX)
 
 install_openmp: cpptraj$(SFX)
 	/bin/mv cpptraj$(SFX) $(BINDIR)/cpptraj.OMP$(SFX)
@@ -53,7 +52,7 @@ ambpdb$(SFX): $(AMBPDB_OBJECTS)
 	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o ambpdb$(SFX) $(AMBPDB_OBJECTS) \
                -L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB)
 
-libcpptraj$(SHARED_SUFFIX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS)
+$(LIBDIR)/libcpptraj$(SHARED_SUFFIX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS)
 	$(CXX) $(MAKE_SHARED) $(WARNFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) pub_fft.o \
 		-L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB) $(FLIBS_PTRAJ) $(READLINE)
 


### PR DESCRIPTION
Building directly into $(LIBDIR) can be considered a temporary hack until we get
the install_name_tool working correctly. However, this has no effect on the
standalone configure script, and is useful for AmberTools since pytraj is
currently the only user of the cpptraj API.  This is needed to work toward
getting pytraj to work on Macs.

With just this change, pytraj works using the GNU compilers from MacPorts with a conda Python.