### PR TITLE
When reading 2d matrices, detect symmetric matrices and allocate appropriately

### DIFF
--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -242,14 +242,35 @@ int DataIO_Std::Read_2D(std::string const& fname,
   }
   DataSet* ds = datasetlist.AddSet(DataSet::MATRIX_DBL, dsname, "Mat");
   if (ds == 0) return 1;
-  //ds->SetupMeta().SetScalarType( MetaData::DIST ); // TODO: FIXME Allow type keywords
-  DataSet::SizeArray dims(2);
-  dims[0] = ncols;
-  dims[1] = nrows;
-  ds->Allocate( dims );
   DataSet_MatrixDbl& Mat = static_cast<DataSet_MatrixDbl&>( *ds );
-  std::copy( matrixArray.begin(), matrixArray.end(), Mat.begin() );
-
+  //ds->SetupMeta().SetScalarType( MetaData::DIST ); // TODO: FIXME Allow type keywords
+  bool isSymmetric = false;
+  if (ncols == nrows) {
+    isSymmetric = true;
+    // Check if matrix is symmetric
+    for (int row = 0; row < nrows; row++) {
+      for (int col = row + 1; col < ncols; col++) {
+        if ( matrixArray[ (row * ncols) + col ] != matrixArray[ (col * ncols) + row ] ) {
+          isSymmetric = false;
+          break;
+        }
+      }
+      if (!isSymmetric) break;
+    }
+  }
+  if (isSymmetric) {
+    mprintf("\tSymmetric matrix detected.\n");
+    if (Mat.AllocateHalf(ncols)) return 1;
+    for (int row = 0; row < nrows; row++)
+      for (int col = row; col < ncols; col++)
+        Mat.AddElement( matrixArray[ (row * ncols) + col ] );
+  } else {
+    DataSet::SizeArray dims(2);
+    dims[0] = ncols;
+    dims[1] = nrows;
+    ds->Allocate( dims );
+    std::copy( matrixArray.begin(), matrixArray.end(), Mat.begin() );
+  }
   return 0;
 }
 


### PR DESCRIPTION
This _actually_ fixes the issue of not being able to run `diagmatrix` on a read-in matrix data set.