### PR TITLE
Add ability to read in additional SYBYL atom type maps for cpptraj/ambpdb mol2 output

### DIFF
--- a/src/AmbPDB.cpp
+++ b/src/AmbPDB.cpp
@@ -30,6 +30,8 @@ static void Help(const char* prgname, bool showAdditional) {
             "                      (default: use prmtop title)\n"
             "    -aatm         Left-justified Amber atom names.\n"
             "    -sybyl        (MOL2 format only) Convert Amber atom types to SYBYL.\n"
+            "    -ac <file>    (Implies '-sybyl') Atom type corresponding file (optional).\n"
+            "    -bc <file>    (Implies '-sybyl') Bond type corresponding file (optional).\n"
             "    -conect       Write CONECT records for all bonds.\n"
             "    -ep           Include extra points if present.\n"
             "    -bres         Brookhaven Residue names (HIE->HIS, etc.).\n"
@@ -63,7 +65,7 @@ static void WriteVersion() {
 // ----- M A I N ---------------------------------------------------------------
 int main(int argc, char** argv) {
   SetWorldSilent(true); // No STDOUT output from cpptraj routines.
-  std::string topname, crdname, title, bres, pqr, sybyltype, writeconect;
+  std::string topname, crdname, title, bres, pqr, sybyltype, sybylfile, writeconect;
   std::string aatm(" pdbatom"), ter_opt(" terbyres"), box(" sg \"P 1\"");
   TrajectoryFile::TrajFormatType fmt = TrajectoryFile::PDBFILE;
   bool ctr_origin = false;
@@ -83,6 +85,10 @@ int main(int argc, char** argv) {
       res_offset = convertToInteger( argv[++i] );
     else if ((arg == "-d" || arg == "--debug") && i+1 != argc) // Debug level
       debug = convertToInteger( argv[++i] );
+    else if (arg == "-ac" && i+1 != argc) // Amber->Sybyl atom map
+      sybylfile.append(" sybylatom " + std::string(argv[++i]));
+    else if (arg == "-bc" && i+1 != argc) // Amber->Sybyl bond map
+      sybylfile.append(" sybylbond " + std::string(argv[++i]));
     else if (arg == "-h" || arg == "--help") { // Help
       Help(argv[0], true);
       return 0;
@@ -133,10 +139,15 @@ int main(int argc, char** argv) {
     Help(argv[0], true);
     return 1;
   }
+  // Check SYBYL atom type args, Mol2 only
+  if (sybyltype.empty() && !sybylfile.empty())
+    sybyltype.assign(" sybyltype");
   if (!sybyltype.empty() && fmt != TrajectoryFile::MOL2FILE) {
     mprinterr("Warning: -sybyl is only valid for MOL2 file output.\n");
     sybyltype.clear();
+    sybylfile.clear();
   }
+  sybyltype.append(sybylfile);
   if (debug > 0) {
     mprinterr("Warning: debug is %i; debug info will be written to STDOUT.\n", debug);
     SetWorldSilent(false);

--- a/src/Mol2File.cpp
+++ b/src/Mol2File.cpp
@@ -208,10 +208,13 @@ void Mol2File::WriteMol2Substructure(int rnum, const char* rname, int firstatom)
   Printf("%7d %4s %14d ****               0 ****  **** \n", rnum, rname, firstatom);
 }
 
-int Mol2File::ReadAmberMapping(FileName const& AtomFile, FileName const& BondFile, int debug)
-{
+void Mol2File::ClearAmberMapping() {
   Atype_to_Sybyl_.clear();
   Apair_to_Bond_.clear();
+}
+
+int Mol2File::ReadAmberMapping(FileName const& AtomFile, FileName const& BondFile, int debug)
+{
   CpptrajFile infile;
   // Expected format: <Amber Atom Type> <SYBYL Atom Type>
   if (infile.OpenRead( AtomFile )) return 1;

--- a/src/Mol2File.cpp
+++ b/src/Mol2File.cpp
@@ -216,84 +216,89 @@ void Mol2File::ClearAmberMapping() {
 int Mol2File::ReadAmberMapping(FileName const& AtomFile, FileName const& BondFile, int debug)
 {
   CpptrajFile infile;
-  // Expected format: <Amber Atom Type> <SYBYL Atom Type>
-  if (infile.OpenRead( AtomFile )) return 1;
-  const char* ptr = infile.NextLine();
+  const char* ptr = 0;
   char Atype[6]; // Amber Atom type: Max 2 letters
   char Stype[6]; // SYBYL Atom type: Max 5 letters
-  std::pair<AtypeMap::iterator, bool> ret;
-  typedef std::pair<NameType, NameType> Mpair;
-  while (ptr != 0) {
-    sscanf(ptr, "%s %s", Atype, Stype);
-    NameType amber_type(Atype);
-    NameType sybyl_type(Stype);
-    ret = Atype_to_Sybyl_.insert( Mpair(amber_type, sybyl_type) );
-    if (!ret.second) {
-      if (sybyl_type != ret.first->second) {
-        mprinterr("Error: Duplicate Amber atom type '%s' in '%s' has different SYBYL\n"
-                  "Error:   has different SYBYL type '%s' than previous '%s'\n",
-                  *amber_type, AtomFile.full(), *sybyl_type, *(ret.first->second));
+  if (!AtomFile.empty()) {
+    // Expected format: <Amber Atom Type> <SYBYL Atom Type>
+    if (infile.OpenRead( AtomFile )) return 1;
+    ptr = infile.NextLine();
+    std::pair<AtypeMap::iterator, bool> ret;
+    typedef std::pair<NameType, NameType> Mpair;
+    while (ptr != 0) {
+      sscanf(ptr, "%s %s", Atype, Stype);
+      NameType amber_type(Atype);
+      NameType sybyl_type(Stype);
+      ret = Atype_to_Sybyl_.insert( Mpair(amber_type, sybyl_type) );
+      if (!ret.second) {
+        if (sybyl_type != ret.first->second) {
+          mprinterr("Error: Duplicate Amber atom type '%s' in '%s' has different SYBYL\n"
+                    "Error:   has different SYBYL type '%s' than previous '%s'\n",
+                    *amber_type, AtomFile.full(), *sybyl_type, *(ret.first->second));
+          return 1;
+        }
+        mprintf("Warning: Duplicate Amber atom type '%s' in '%s'\n", *amber_type, AtomFile.full());
+      }
+      ptr = infile.NextLine();
+    }
+    infile.CloseFile();
+    if (debug > 0) {
+      mprintf("DEBUG: Atype_to_Sybyl has %zu values:\n", Atype_to_Sybyl_.size());
+      for (AtypeMap::const_iterator ix = Atype_to_Sybyl_.begin(); ix != Atype_to_Sybyl_.end(); ++ix)
+        mprintf("\t'%s' => '%s'\n", *(ix->first), *(ix->second));
+    }
+  }
+  if (!BondFile.empty()) {
+    // Expected format: <Amber Atom1 Type> <Amber Atom2 Type> <SYBYL Bond Type>
+    if (infile.OpenRead( BondFile )) return 1;
+    ptr = infile.NextLine();
+    char Atype2[6]; // Amber Atom type: Max 2 letters
+    std::pair<BndMap::iterator, bool> bret;
+    typedef std::pair<AtomPair, int> Bpair;
+    while (ptr != 0) {
+      sscanf(ptr, "%s %s %s", Atype, Atype2, Stype);
+      NameType a1(Atype);
+      NameType a2(Atype2);
+      // Always order the pair so first < second
+      AtomPair bp;
+      if (a1 < a2)
+        bp = AtomPair(a1, a2);
+      else
+        bp = AtomPair(a2, a1);
+      // Determine SYBYL bond type
+      int btype = -1;
+      if      (Stype[0] == '1') btype = 0;
+      else if (Stype[0] == '2') btype = 1;
+      else if (Stype[0] == '3') btype = 2;
+      else if (Stype[0] == 'a') {
+        if      (Stype[1] == 'm') btype = 3;
+        else if (Stype[1] == 'r') btype = 4;
+      }
+      if (btype < 0) {
+        mprinterr("Error: File '%s' contains unsupported SYBYL bond type '%s'\n",
+                  BondFile.full(), Stype);
         return 1;
       }
-      mprintf("Warning: Duplicate Amber atom type '%s' in '%s'\n", *amber_type, AtomFile.full());
-    }
-    ptr = infile.NextLine();
-  }
-  infile.CloseFile();
-  if (debug > 0) {
-    mprintf("DEBUG: Atype_to_Sybyl has %zu values:\n", Atype_to_Sybyl_.size());
-    for (AtypeMap::const_iterator ix = Atype_to_Sybyl_.begin(); ix != Atype_to_Sybyl_.end(); ++ix)
-      mprintf("\t'%s' => '%s'\n", *(ix->first), *(ix->second));
-  }
-  // Expected format: <Amber Atom1 Type> <Amber Atom2 Type> <SYBYL Bond Type>
-  if (infile.OpenRead( BondFile )) return 1;
-  ptr = infile.NextLine();
-  char Atype2[6]; // Amber Atom type: Max 2 letters
-  std::pair<BndMap::iterator, bool> bret;
-  typedef std::pair<AtomPair, int> Bpair;
-  while (ptr != 0) {
-    sscanf(ptr, "%s %s %s", Atype, Atype2, Stype);
-    NameType a1(Atype);
-    NameType a2(Atype2);
-    // Always order the pair so first < second
-    AtomPair bp;
-    if (a1 < a2)
-      bp = AtomPair(a1, a2);
-    else
-      bp = AtomPair(a2, a1);
-    // Determine SYBYL bond type
-    int btype = -1;
-    if      (Stype[0] == '1') btype = 0;
-    else if (Stype[0] == '2') btype = 1;
-    else if (Stype[0] == '3') btype = 2;
-    else if (Stype[0] == 'a') {
-      if      (Stype[1] == 'm') btype = 3;
-      else if (Stype[1] == 'r') btype = 4;
-    }
-    if (btype < 0) {
-      mprinterr("Error: File '%s' contains unsupported SYBYL bond type '%s'\n",
-                BondFile.full(), Stype);
-      return 1;
-    }
-    bret = Apair_to_Bond_.insert( Bpair(bp, btype) );
-    if (!bret.second) {
-      // Only make this an error if the type does not match.
-      if (btype != bret.first->second) {
-        mprinterr("Error: Duplicate bond '%s'-'%s' in '%s'\n"
-                  "Error:   has different type %i than previous %i\n",
-                  *a1, *a2, BondFile.full(), btype, bret.first->second);
-        return 1;
+      bret = Apair_to_Bond_.insert( Bpair(bp, btype) );
+      if (!bret.second) {
+        // Only make this an error if the type does not match.
+        if (btype != bret.first->second) {
+          mprinterr("Error: Duplicate bond '%s'-'%s' in '%s'\n"
+                    "Error:   has different type %i than previous %i\n",
+                    *a1, *a2, BondFile.full(), btype, bret.first->second);
+          return 1;
+        }
+        mprintf("Warning: Duplicate bond '%s'-'%s' in '%s'\n", *a1, *a2, BondFile.full());
       }
-      mprintf("Warning: Duplicate bond '%s'-'%s' in '%s'\n", *a1, *a2, BondFile.full());
+      ptr = infile.NextLine();
     }
-    ptr = infile.NextLine();
-  }
-  infile.CloseFile();
-  if (debug > 0) {
-    mprintf("DEBUG: Apair_to_Bond has %zu values:\n", Apair_to_Bond_.size());
-    for (BndMap::const_iterator ib = Apair_to_Bond_.begin(); ib != Apair_to_Bond_.end(); ++ib)
-      mprintf("'%s'--'%s' => %s\n", *(ib->first.first), *(ib->first.second),
-              SYBYL_BOND_[ib->second]);
+    infile.CloseFile();
+    if (debug > 0) {
+      mprintf("DEBUG: Apair_to_Bond has %zu values:\n", Apair_to_Bond_.size());
+      for (BndMap::const_iterator ib = Apair_to_Bond_.begin(); ib != Apair_to_Bond_.end(); ++ib)
+        mprintf("'%s'--'%s' => %s\n", *(ib->first.first), *(ib->first.second),
+                SYBYL_BOND_[ib->second]);
+    }
   }
   return 0;
 }

--- a/src/Mol2File.h
+++ b/src/Mol2File.h
@@ -35,6 +35,8 @@ class Mol2File : private CpptrajFile {
     void WriteMol2Bond(int, int, int, NameType const&, NameType const&);
     /// Write mol2 substructure line; res#, resname, firstatom
     void WriteMol2Substructure(int, const char*, int);
+    /// Clear any existing atom mapping
+    void ClearAmberMapping();
     /// Read in mapping from Amber to SYBYL
     int ReadAmberMapping(FileName const&, FileName const&, int);
 

--- a/src/Traj_Mol2File.cpp
+++ b/src/Traj_Mol2File.cpp
@@ -161,6 +161,7 @@ int Traj_Mol2File::setupTrajout(FileName const& fname, Topology* trajParm,
         mprinterr("Error: Amber to SYBYL atom type conversion requires AMBERHOME be set.\n");
         return 1;
       }
+      file_.ClearAmberMapping();
       std::string pathname(AMBERHOME);
       if (file_.ReadAmberMapping(pathname+"/dat/antechamber/ATOMTYPE_CHECK.TAB",
                                  pathname+"/dat/antechamber/BONDTYPE_CHECK.TAB", debug_))

--- a/src/Traj_Mol2File.cpp
+++ b/src/Traj_Mol2File.cpp
@@ -92,6 +92,8 @@ void Traj_Mol2File::WriteHelp() {
   mprintf("\tsingle   : Write to a single file.\n"
           "\tmulti    : Write each frame to a separate file.\n"
           "\tsybyltype: Convert Amber atom types (if present) to SYBYL types.\n"
+          "\tsybylatom: Amber to SYBYL atom type corresponding file (optional).\n"
+          "\tsybylbond: Amber to SYBYL bond type corresponding file (optional).\n"
           "\tkeepext  : Keep filename extension; write '<name>.<num>.<ext>' instead (implies 'multi').\n");
 }
 
@@ -101,6 +103,10 @@ int Traj_Mol2File::processWriteArgs(ArgList& argIn) {
   if (argIn.hasKey("single")) mol2WriteMode_ = MOL;
   if (argIn.hasKey("multi"))  mol2WriteMode_ = MULTI;
   useSybylTypes_ = argIn.hasKey("sybyltype");
+  ac_filename_ = argIn.GetStringKey("sybylatom");
+  bc_filename_ = argIn.GetStringKey("sybylbond");
+  if (!ac_filename_.empty() || !bc_filename_.empty())
+    useSybylTypes_ = true;
   prependExt_ = argIn.hasKey("keepext"); // Implies MULTI
   if (prependExt_) mol2WriteMode_ = MULTI;
   return 0;
@@ -168,6 +174,12 @@ int Traj_Mol2File::setupTrajout(FileName const& fname, Topology* trajParm,
       {
         mprinterr("Error: Loading Amber -> SYBYL type maps failed.\n");
         return 1;
+      }
+      if (!ac_filename_.empty() || !bc_filename_.empty()) {
+        if (file_.ReadAmberMapping(ac_filename_, bc_filename_, debug_)) {
+          mprinterr("Error: Loading custom Amber -> SYBYL type maps failed.\n");
+          return 1;
+        }
       }
     }
   }

--- a/src/Traj_Mol2File.h
+++ b/src/Traj_Mol2File.h
@@ -17,14 +17,6 @@ class Traj_Mol2File : public TrajectoryIO {
     static BaseIOtype* Alloc() { return (BaseIOtype*)new Traj_Mol2File(); }
     static void WriteHelp();
   private:
-    MOL2WRITEMODE mol2WriteMode_;
-    Topology* mol2Top_;
-    int currentSet_;
-    bool hasCharges_;
-    bool useSybylTypes_;
-    bool prependExt_;
-    Mol2File file_; 
-
     // Inherited functions
     bool ID_TrajFormat(CpptrajFile&);
     int setupTrajin(FileName const&, Topology*);
@@ -46,5 +38,14 @@ class Traj_Mol2File : public TrajectoryIO {
     int parallelWriteFrame(int, Frame const&);
     void parallelCloseTraj() {}
 #   endif
+    MOL2WRITEMODE mol2WriteMode_;
+    Topology* mol2Top_;
+    std::string ac_filename_;
+    std::string bc_filename_;
+    int currentSet_;
+    bool hasCharges_;
+    bool useSybylTypes_;
+    bool prependExt_;
+    Mol2File file_; 
 };
 #endif


### PR DESCRIPTION
Adds the following keywords to mol2 `trajout`:
```
sybylatom: Amber to SYBYL atom type corresponding file (optional).
sybylbond: Amber to SYBYL bond type corresponding file (optional).
```
Adds the following command line args to amdpdb (same as old `top2mol2` program):
```
-ac <file>    (Implies '-sybyl') Atom type corresponding file (optional).
-bc <file>    (Implies '-sybyl') Bond type corresponding file (optional).
```