### PR TITLE
Flags to avoid some math issues from aggressive optimizaitons from Intel compilers

### DIFF
--- a/configure
+++ b/configure
@@ -388,7 +388,7 @@ SetCompilerOptions() {
       if [ -z "$CC" ]; then CC=icc; fi
       if [ -z "$CXX" ]; then CXX=icpc; fi
       if [ -z "$FC" ]; then FC=ifort; fi
-      OPTFLAGS="-O3 -Wall"
+      OPTFLAGS="-O3 -Wall -fp-model precise -fp-model source"
       OMPFLAGS="-openmp"
       FFLAGS="-FR"
       FOPTFLAGS="-ip -O3"

--- a/test/Test_CurveFit/RunTest.sh
+++ b/test/Test_CurveFit/RunTest.sh
@@ -32,7 +32,7 @@ runanalysis curvefit Data.dat nexp 2 name PKFitY form mexpk_penalty \
 EOF
 RunCpptraj "Curve fitting multi-exponential tests."
 DoTest curve.dat.save curve1.dat
-DoTest Kcurve.dat.save Kcurve.dat -r 0.0002
+DoTest Kcurve.dat.save Kcurve.dat -r 0.0009
 # Differences in windows seem like round-off
 DoTest PKcurve.dat.save PKcurve.dat -r 0.0003
 DoTest Results.dat.save Results.dat -r 0.006


### PR DESCRIPTION
Adds two flags to improve reliability of math operations with Intel compilers. Also relaxes tolerance on one test slightly.