### PR TITLE
Switch to checking the error/fail bits of stringstreams

### DIFF
--- a/src/RPNcalc.cpp
+++ b/src/RPNcalc.cpp
@@ -91,7 +91,8 @@ int RPNcalc::ProcessExpression(std::string const& expression) {
       if (debug_ > 0) mprintf("Number detected: %s\n", number.c_str());
       std::istringstream iss(number);
       double val;
-      if (!(iss >> val)) {
+      iss >> val;
+      if (iss.fail()) {
         mprinterr("Error: Invalid number: %s\n", number.c_str());
         return 1;
       }
@@ -104,7 +105,8 @@ int RPNcalc::ProcessExpression(std::string const& expression) {
         if (debug_ > 0) mprintf("Exponent detected: %s\n", exponent.c_str());
         double eval;
         std::istringstream iss2(exponent);
-        if (!(iss2 >> eval)) {
+        iss2 >> eval;
+        if (iss2.fail()) {
           mprinterr("Error: Invalid exponent: %s\n", exponent.c_str());
           return 1;
         }
@@ -868,7 +870,8 @@ int RPNcalc::Nparams() const {
       {
         std::istringstream iss( T->Name().substr(1) );      
         int pnum;
-        if (!(iss >> pnum)) {
+        iss >> pnum;
+        if (iss.fail()) {
           mprinterr("Error: Invalid parameter number: %s\n", T->Name().substr(1).c_str());
           return 1;
         }
@@ -917,7 +920,8 @@ int RPNcalc::Evaluate(Darray const& Params, double X, double& Result) const {
           // Find parameter An, where n is parameter position.
           std::istringstream iss( T->Name().substr(1) );
           int nparam;
-          if (!(iss >> nparam)) {
+          iss >> nparam;
+          if (iss.fail()) {
             mprinterr("Error: Invalid parameter number: %s\n", T->Name().substr(1).c_str());
             return 1;
           }

--- a/src/StringRoutines.cpp
+++ b/src/StringRoutines.cpp
@@ -107,7 +107,8 @@ public:
 int convertToInteger(std::string const &s) {
   std::istringstream iss(s);
   long int i;
-  if (!(iss >> i))
+  iss >> i;
+  if (iss.fail())
     throw BadConversion("convertToInteger(\"" + s + "\")");
   return (int)i;
 }
@@ -117,7 +118,8 @@ int convertToInteger(std::string const &s) {
 double convertToDouble(std::string const &s) {
   std::istringstream iss(s);
   double d;
-  if (!(iss >> d))
+  iss >> d;
+  if (iss.fail())
     throw BadConversion("convertToDouble(\"" + s + "\")");
   return d;
 }
@@ -180,7 +182,8 @@ bool validDouble(std::string const& argument) {
   if (argument.empty()) return false;
   std::istringstream iss(argument);
   double val;
-  return (iss >> val);
+  iss >> val;
+  return !(iss.fail());
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Do this instead of implicitly converting the conversion itself to bool. Although the latter has worked fine for years, bleeding-edge compilers will choke on it.

Fixes errors of the type:
```
StringRoutines.cpp: In function ‘bool validDouble(const string&)’:
StringRoutines.cpp:183:21: error: cannot convert
‘std::basic_istream<char>::__istream_type {aka std::basic_istream<char>}’ to
‘bool’ in return
   return (iss >> val);
```