### PR TITLE
Incorporate changes for AmberTools libcpptraj build

### DIFF
--- a/Makefile_at
+++ b/Makefile_at
@@ -27,12 +27,9 @@ openmp:
 parallel:
 	cd src && $(MAKE) -f Makefile_at install_mpi
 
-# Create libcpptraj within AmberTools. Since we do not want to include
-# the sander API, delete any objects that may have used it and explicitly
-# blank the SANDERAPI_DEF define variable.
+# Create libcpptraj within AmberTools.
 libcpptraj:
-	/bin/rm -f src/Action_Esander.o src/Cpptraj.o src/Energy_Sander.o
-	cd src && $(MAKE) -f Makefile_at libcpptraj SANDERAPI_DEF=""
+	cd src && $(MAKE) -f Makefile_at libcpptraj
 
 # Run Tests
 check:

--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -26,7 +26,6 @@ install: cpptraj$(SFX) ambpdb$(SFX)
 	/bin/mv cpptraj$(SFX) $(BINDIR)/
 	/bin/mv ambpdb$(SFX) $(BINDIR)/
 
-libcpptraj: $(LIBDIR)/libcpptraj$(SHARED_SUFFIX)
 
 install_openmp: cpptraj$(SFX)
 	/bin/mv cpptraj$(SFX) $(BINDIR)/cpptraj.OMP$(SFX)
@@ -45,17 +44,24 @@ dependclean:
 
 cpptraj$(SFX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS) $(SANDERAPI_DEP) 
 	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o cpptraj$(SFX) $(OBJECTS) pub_fft.o \
-               -L$(LIBDIR) $(NETCDFLIB) $(PNETCDFLIB) $(ZLIB) $(BZLIB) \
+               $(AMBERLDFLAGS) -L$(LIBDIR) $(NETCDFLIB) $(PNETCDFLIB) $(ZLIB) $(BZLIB) \
                $(FLIBS_PTRAJ) $(READLINE) $(SANDERAPI_LIB)
 
 ambpdb$(SFX): $(AMBPDB_OBJECTS)
 	$(CXX) $(WARNFLAGS) $(LDFLAGS) -o ambpdb$(SFX) $(AMBPDB_OBJECTS) \
-               -L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB)
+               $(AMBERLDFLAGS) -L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB)
 
-$(LIBDIR)/libcpptraj$(SHARED_SUFFIX): $(OBJECTS) pub_fft.o $(EXTERNAL_LIBS)
-	$(CXX) $(MAKE_SHARED) $(WARNFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) pub_fft.o \
-		-L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB) $(FLIBS_PTRAJ) $(READLINE)
+# libcpptraj -------------------------------------
+# Rule to make libcpptraj-specific objects
+%.LIBCPPTRAJ.o : %.cpp
 
+libcpptraj: $(LIBDIR)/libcpptraj$(SHARED_SUFFIX)
+
+$(LIBDIR)/libcpptraj$(SHARED_SUFFIX): $(LIBCPPTRAJ_OBJECTS) pub_fft.o $(EXTERNAL_LIBS)
+	$(CXX) $(MAKE_SHARED) $(WARNFLAGS) $(LDFLAGS) -o $@ $(LIBCPPTRAJ_OBJECTS) pub_fft.o \
+		$(AMBERLDFLAGS) -L$(LIBDIR) $(NETCDFLIB) $(ZLIB) $(BZLIB) $(FLIBS_PTRAJ)
+
+# ------------------------------------------------
 $(LIBDIR)/libarpack.a:
 	cd ../../arpack && $(MAKE) install
 
@@ -84,7 +90,7 @@ ReadLine.o: ReadLine.cpp
 	$(CXX) $(WARNFLAGS) -c $(CPPTRAJ_FLAGS) -o $@ $<
 
 clean:
-	/bin/rm -f $(OBJECTS) pub_fft.o cpptraj$(SFX) AmbPDB.o ambpdb$(SFX)
+	/bin/rm -f $(OBJECTS) pub_fft.o cpptraj$(SFX) AmbPDB.o ambpdb$(SFX) *.LIBCPPTRAJ.o
 	cd readline && $(MAKE) -f Makefile_at clean
 
 uninstall:

--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -54,6 +54,7 @@ ambpdb$(SFX): $(AMBPDB_OBJECTS)
 # libcpptraj -------------------------------------
 # Rule to make libcpptraj-specific objects
 %.LIBCPPTRAJ.o : %.cpp
+	$(CXX) $(WARNFLAGS) -c $(CPPTRAJ_FLAGS) -DLIBCPPTRAJ -o $@ $<
 
 libcpptraj: $(LIBDIR)/libcpptraj$(SHARED_SUFFIX)
 


### PR DESCRIPTION
Parallels #336. Also adds AMBERLDFLAGS to Makefile_at linking steps. Should hopefully address #327, at least partially.