### PR TITLE
Fix for libcpptraj

### DIFF
--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -146,7 +146,6 @@ COMMON_SOURCES=ActionFrameCounter.cpp \
         Cmd.cpp \
         CmdInput.cpp \
         CmdList.cpp \
-        Command.cpp \
         ComplexArray.cpp \
         CoordinateInfo.cpp \
         Corr.cpp \
@@ -314,6 +313,7 @@ CSOURCES= molsurf.c
 # differently for libcpptraj.
 SOURCES=$(COMMON_SOURCES) \
         Action_Esander.cpp \
+        Command.cpp \
         Cpptraj.cpp \
         Energy_Sander.cpp \
         ReadLine.cpp \
@@ -324,6 +324,7 @@ SOURCES=$(COMMON_SOURCES) \
 # extension.
 LIBCPPTRAJ_OBJECTS=$(COMMON_SOURCES:.cpp=.o) $(CSOURCES:.c=.o) \
         Action_Esander.LIBCPPTRAJ.o \
+        Command.LIBCPPTRAJ.o \
         Cpptraj.LIBCPPTRAJ.o \
         Energy_Sander.LIBCPPTRAJ.o \
         ReadLine.LIBCPPTRAJ.o


### PR DESCRIPTION
Command.cpp needs to be compiled differently for cpptraj and libcpptraj since it includes files that are also different. Should address the following error:
```
In file included from Command.cpp:118:
In file included from ./Action_Esander.h:5:
./Energy_Sander.h:6:10: fatal error: 'sander.h' file not found
#include "sander.h"
         ^
1 error generated.
```
Related to #220.