### PR TITLE
Cluster ha

### DIFF
--- a/src/Analysis_Clustering.cpp
+++ b/src/Analysis_Clustering.cpp
@@ -67,7 +67,7 @@ void Analysis_Clustering::Help() const {
           "\t[summarysplit <splitfile>] [splitframe <comma-separated frame list>]\n"
           "\t[clustersvtime <filename> cvtwindow <window size>]\n"
           "\t[cpopvtime <file> [normpop | normframe]] [lifetime]\n"
-          "\t[sil <silhouette file prefix>]\n"
+          "\t[sil <silhouette file prefix>] [assignrefs [refcut <rms>] [refmask <mask>]]\n"
           "  Coordinate output options:\n"
           "\t[ clusterout <trajfileprefix> [clusterfmt <trajformat>] ]\n"
           "\t[ singlerepout <trajfilename> [singlerepfmt <trajformat>] ]\n"

--- a/src/Analysis_Clustering.cpp
+++ b/src/Analysis_Clustering.cpp
@@ -600,6 +600,7 @@ Analysis::RetType Analysis_Clustering::Analyze() {
   cluster_setup.WriteTiming(1,    "  Cluster Init. :", cluster_total.Total());
   cluster_pairwise.WriteTiming(1, "  Pairwise Calc.:", cluster_total.Total());
   cluster_cluster.WriteTiming(1,  "  Clustering    :", cluster_total.Total());
+  CList_->Timing( cluster_cluster.Total() );
   cluster_post.WriteTiming(1,     "  Cluster Post. :", cluster_total.Total());
   cluster_total.WriteTiming(1,    "Total:");
   return Analysis::OK;

--- a/src/Analysis_Clustering.cpp
+++ b/src/Analysis_Clustering.cpp
@@ -600,7 +600,9 @@ Analysis::RetType Analysis_Clustering::Analyze() {
   cluster_setup.WriteTiming(1,    "  Cluster Init. :", cluster_total.Total());
   cluster_pairwise.WriteTiming(1, "  Pairwise Calc.:", cluster_total.Total());
   cluster_cluster.WriteTiming(1,  "  Clustering    :", cluster_total.Total());
+# ifdef TIMER
   CList_->Timing( cluster_cluster.Total() );
+# endif
   cluster_post.WriteTiming(1,     "  Cluster Post. :", cluster_total.Total());
   cluster_total.WriteTiming(1,    "Total:");
   return Analysis::OK;

--- a/src/Analysis_Clustering.cpp
+++ b/src/Analysis_Clustering.cpp
@@ -41,6 +41,8 @@ Analysis_Clustering::Analysis_Clustering() :
   debug_(0)
 { } 
 
+const TrajectoryFile::TrajFormatType Analysis_Clustering::DEF_TRAJ_FMT_ = TrajectoryFile::AMBERTRAJ;
+
 // DESTRUCTOR
 Analysis_Clustering::~Analysis_Clustering() {
   if (CList_ != 0) delete CList_;
@@ -85,6 +87,20 @@ DataFile::DataFormatType Analysis_Clustering::PAIRDISTTYPE_ =
   DataFile::CMATRIX;
 # endif
 
+// Analysis_Clustering::GetClusterTrajArgs()
+void Analysis_Clustering::GetClusterTrajArgs(ArgList& argIn,
+                                             const char* trajKey, const char* fmtKey,
+                                             std::string& trajName,
+                                             TrajectoryFile::TrajFormatType& fmt) const
+{
+  trajName = argIn.GetStringKey( trajKey );
+  fmt = TrajectoryFile::GetFormatFromString( argIn.GetStringKey(fmtKey), fmt );
+  // If file name specified but not format, try to guess from name
+  if (!trajName.empty() && fmt == TrajectoryFile::UNKNOWN_TRAJ)
+    fmt = TrajectoryFile::GetTypeFromExtension( trajName, DEF_TRAJ_FMT_ );
+}
+
+// Analysis_Clustering::Setup()
 Analysis::RetType Analysis_Clustering::Setup(ArgList& analyzeArgs, AnalysisSetup& setup, int debugIn)
 {
   debug_ = debugIn;
@@ -273,15 +289,12 @@ Analysis::RetType Analysis_Clustering::Setup(ArgList& analyzeArgs, AnalysisSetup
   }
   // ---------------------------------------------
   // Output trajectory stuff
-  clusterfile_ = analyzeArgs.GetStringKey("clusterout");
-  clusterfmt_ = TrajectoryFile::GetFormatFromString( analyzeArgs.GetStringKey("clusterfmt") ); 
-  singlerepfile_ = analyzeArgs.GetStringKey("singlerepout");
-  singlerepfmt_ = TrajectoryFile::GetFormatFromString( analyzeArgs.GetStringKey("singlerepfmt") );
-  reptrajfile_ = analyzeArgs.GetStringKey("repout");
-  reptrajfmt_ = TrajectoryFile::GetFormatFromString( analyzeArgs.GetStringKey("repfmt") );
   writeRepFrameNum_ = analyzeArgs.hasKey("repframe");
-  avgfile_ = analyzeArgs.GetStringKey("avgout");
-  avgfmt_ = TrajectoryFile::GetFormatFromString( analyzeArgs.GetStringKey("avgfmt") );
+  GetClusterTrajArgs(analyzeArgs, "clusterout",   "clusterfmt",   clusterfile_,   clusterfmt_);
+  GetClusterTrajArgs(analyzeArgs, "singlerepout", "singlerepfmt", singlerepfile_, singlerepfmt_);
+  GetClusterTrajArgs(analyzeArgs, "repout",       "repfmt",       reptrajfile_,   reptrajfmt_);
+  GetClusterTrajArgs(analyzeArgs, "avgout",       "avgfmt",       avgfile_,       avgfmt_);
+
   // Get the mask string 
   maskexpr_ = analyzeArgs.GetMaskNext();
 

--- a/src/Analysis_Clustering.cpp
+++ b/src/Analysis_Clustering.cpp
@@ -551,7 +551,7 @@ Analysis::RetType Analysis_Clustering::Analyze() {
       mprintf("\nFINAL CLUSTERS:\n");
       CList_->PrintClusters();
     }
-    // Attempt to assign refernce names to clusters if any specified.
+    // Attempt to assign reference names to clusters if any specified.
     if (!refs_.empty()) {
       if (has_coords)
         AssignRefsToClusters( *CList_ );
@@ -688,12 +688,12 @@ void Analysis_Clustering::AssignRefsToClusters( ClusterList& CList ) const {
       }
     }
     if (minRms < refCut_) {
-      mprintf("DEBUG: Assigned cluster %i to reference \"%s\" (%g)\n", cidx,
-              refs_[minIdx]->Meta().Name().c_str(), minRms);
+      //mprintf("DEBUG: Assigned cluster %i to reference \"%s\" (%g)\n", cidx,
+      //        refs_[minIdx]->Meta().Name().c_str(), minRms);
       cluster->SetName( refs_[minIdx]->Meta().Name(), minRms );
     } else {
-      mprintf("DEBUG: Cluster %i was closest to reference \"(%s)\" (%g)\n", cidx,
-              refs_[minIdx]->Meta().Name().c_str(), minRms);
+      //mprintf("DEBUG: Cluster %i was closest to reference \"(%s)\" (%g)\n", cidx,
+      //        refs_[minIdx]->Meta().Name().c_str(), minRms);
       cluster->SetName( "(" + refs_[minIdx]->Meta().Name() + ")", minRms );
     }
   }

--- a/src/Analysis_Clustering.h
+++ b/src/Analysis_Clustering.h
@@ -18,6 +18,7 @@ class Analysis_Clustering: public Analysis {
   private:
     inline void GetClusterTrajArgs(ArgList&, const char*, const char*, std::string&,
                                    TrajectoryFile::TrajFormatType&) const;
+    void AssignRefsToClusters(ClusterList&) const;
     void CreateCnumvtime( ClusterList const&, unsigned int );
     void CreateCpopvtime( ClusterList const&, unsigned int );
     void ClusterLifetimes( ClusterList const&, unsigned int );
@@ -28,15 +29,18 @@ class Analysis_Clustering: public Analysis {
     void WriteRepTraj( ClusterList const& );
 
     DataSetList* masterDSL_;    ///< For Cluster pop v time DataSets.
+    DataSetList refs_;          ///< Hold references for cluster name assignment.
     DataSet_Coords* coords_;    ///< Hold coordinates of frames being clustered.
     ClusterList* CList_;        ///< Hold specified clustering algorithm.
     std::string maskexpr_;      ///< If RMSD, Atoms to cluster on
+    std::string refmaskexpr_;   ///< If assigning refs, atoms to calc RMSD to.
     int sieve_;                 ///< If > 1, frames to skip on initial clustering pass.
     int sieveSeed_;             ///< Used to seed random number gen for sieve
     int windowSize_;            ///< Window size for # clusters seen vs time.
     int drawGraph_;
     int draw_maxit_;
     double draw_tol_;
+    double refCut_;             ///< RMSD cutoff for assigning reference names to clusters.
     std::vector<int> splitFrames_; ///< Frames to split at when comparing parts.
     DataSet* cnumvtime_;        ///< Cluster vs time dataset.
     DataSet* clustersVtime_;    ///< # clusters seen vs time dataset.

--- a/src/Analysis_Clustering.h
+++ b/src/Analysis_Clustering.h
@@ -16,6 +16,8 @@ class Analysis_Clustering: public Analysis {
     Analysis::RetType Setup(ArgList&, AnalysisSetup&, int);
     Analysis::RetType Analyze();
   private:
+    inline void GetClusterTrajArgs(ArgList&, const char*, const char*, std::string&,
+                                   TrajectoryFile::TrajFormatType&) const;
     void CreateCnumvtime( ClusterList const&, unsigned int );
     void CreateCpopvtime( ClusterList const&, unsigned int );
     void ClusterLifetimes( ClusterList const&, unsigned int );
@@ -63,6 +65,7 @@ class Analysis_Clustering: public Analysis {
     TrajectoryFile::TrajFormatType singlerepfmt_; ///< Cluster all rep single trajectory format.
     TrajectoryFile::TrajFormatType reptrajfmt_;   ///< Cluster rep to separate trajectory format.
     TrajectoryFile::TrajFormatType avgfmt_;       ///< Cluster traj average structure file format.
+    static const TrajectoryFile::TrajFormatType DEF_TRAJ_FMT_;
     int debug_;
     static const char* PAIRDISTFILE_;              ///< Default pairwise dist file name.
     static DataFile::DataFormatType PAIRDISTTYPE_; ///< Default pairwise dist file type.

--- a/src/ClusterDist.h
+++ b/src/ClusterDist.h
@@ -57,10 +57,6 @@ class Centroid_Coord : public Centroid {
 };
 // -----------------------------------------------------------------------------
 /// Abstract Base Class for Cluster distance calc.
-/** The pairwise-distance calculation is here to make COORDS DataSet calcs 
-  * more efficient; otherwise they would have to copy frame1 coords each time 
-  * as well as always track memory for frame2.
-  */
 class ClusterDist {
   public:
     enum CentOpType { ADDFRAME=0, SUBTRACTFRAME };

--- a/src/ClusterList.h
+++ b/src/ClusterList.h
@@ -19,9 +19,9 @@ class ClusterList {
     void SetDebug(int);
     void Renumber(bool);
     void Summary(std::string const&,int) const;
-    void Summary_Part(std::string const&,int,std::vector<int> const&);
+    void Summary_Part(std::string const&,int,std::vector<int> const&) const;
     void PrintClustersToFile(std::string const&,int);
-    void PrintClusters();
+    void PrintClusters() const;
     /// Set up appropriate cluster distance calculation
     int SetupCdist( ClusterDist::DsArray const&, DistMetricType, bool, bool, std::string const&);
     /// Calculate distances between frames if necessary.
@@ -66,6 +66,8 @@ class ClusterList {
     int AddCluster(ClusterDist::Cframes const&);
   private:
     static const char* XMGRACE_COLOR[];
+    /// Determine max name width
+    unsigned int DetermineNameWidth() const;
     /// Calculate the Davies-Bouldin index of clusters.
     double ComputeDBI(CpptrajFile&);
     /// Calculate pseudo-F statistic.

--- a/src/ClusterList.h
+++ b/src/ClusterList.h
@@ -28,9 +28,11 @@ class ClusterList {
     int CalcFrameDistances(DataSet*, ClusterDist::DsArray const&, int, int);
     // Inherited by individual clustering methods
     virtual int SetupCluster(ArgList&) = 0;
-    virtual void ClusteringInfo() = 0;
+    virtual void ClusteringInfo() const = 0;
     virtual int Cluster() = 0;
-
+#   ifdef TIMER
+    virtual void Timing(double) const = 0;
+#   endif
     // Const Iterator over clusters
     typedef std::list<ClusterNode>::const_iterator cluster_iterator;
     const cluster_iterator begincluster() const { return clusters_.begin(); }

--- a/src/ClusterList.h
+++ b/src/ClusterList.h
@@ -18,7 +18,7 @@ class ClusterList {
 
     void SetDebug(int);
     void Renumber(bool);
-    void Summary(std::string const&,int);
+    void Summary(std::string const&,int) const;
     void Summary_Part(std::string const&,int,std::vector<int> const&);
     void PrintClustersToFile(std::string const&,int);
     void PrintClusters();
@@ -33,7 +33,11 @@ class ClusterList {
 #   ifdef TIMER
     virtual void Timing(double) const = 0;
 #   endif
-    // Const Iterator over clusters
+    /// Iterator over clusters
+    typedef std::list<ClusterNode>::iterator cluster_it;
+    cluster_it begin() { return clusters_.begin(); }
+    cluster_it end()   { return clusters_.end();   }
+    /// Const Iterator over clusters
     typedef std::list<ClusterNode>::const_iterator cluster_iterator;
     const cluster_iterator begincluster() const { return clusters_.begin(); }
     const cluster_iterator endcluster()   const { return clusters_.end();   }
@@ -51,8 +55,6 @@ class ClusterList {
 
     void AddSievedFramesByCentroid();
     DataSet_Cmatrix const& FrameDistances() const { return *frameDistances_; }
-    /// Iterator over clusters
-    typedef std::list<ClusterNode>::iterator cluster_it;
     int debug_;
     /// Store individual cluster info; frame numbers, centroid, etc.
     std::list<ClusterNode> clusters_;

--- a/src/ClusterMatrix.cpp
+++ b/src/ClusterMatrix.cpp
@@ -1,12 +1,54 @@
 #include <cfloat> // FLT_MAX
 #include "ClusterMatrix.h"
 #include "CpptrajStdio.h" // PrintElements
+#ifdef _OPENMP
+# include <omp.h>
+#endif
 
 // ClusterMatrix::FindMin()
 /** Find the minimum; set corresponding row and column. Cannot currently
   * be used for sieved frames.
   */
 double ClusterMatrix::FindMin(int& iOut, int& jOut) const {
+# ifdef _OPENMP
+  static int minRow_[128]; // FIXME should be allocd eventually
+  static int minCol_[128];
+  static float minVal_[128];
+  int row, mythread, numthreads;
+  int nrows = (int)Mat_.Nrows();
+# pragma omp parallel private(row, mythread)
+  {
+  mythread = omp_get_thread_num();
+  if (mythread == 0) numthreads = omp_get_num_threads();
+  minVal_[mythread] = FLT_MAX;
+# pragma omp for schedule(dynamic)
+  for (row = 0; row < nrows; row++) {
+    if (!ignore_[row]) {
+      int col = row + 1;
+      unsigned int idx = Mat_.CalcIndex(col, row); /// idx is start of this row
+      for (; col != nrows; col++, idx++) {
+        if (!ignore_[col]) {
+          if (Mat_[idx] < minVal_[mythread]) {
+            minVal_[mythread] = Mat_[idx];
+            minRow_[mythread] = row;
+            minCol_[mythread] = col;
+          }
+        }
+      }
+    }
+  }
+  } /* END pragma omp parallel */
+  float min = minVal_[0];
+  iOut = minRow_[0];
+  jOut = minCol_[0];
+  for (int idx = 1; idx != numthreads; idx++) {
+    if (minVal_[idx] < min) {
+      min = minVal_[idx];
+      iOut = minRow_[idx];
+      jOut = minCol_[idx];
+    }
+  }
+# else
   float min = FLT_MAX;
   for (unsigned int row = 0; row != Mat_.Nrows(); row++) {
     if (!ignore_[row]) {
@@ -21,6 +63,7 @@ double ClusterMatrix::FindMin(int& iOut, int& jOut) const {
       }
     }
   }
+# endif
   return (double)min;
 }
 
@@ -43,6 +86,19 @@ void ClusterMatrix::PrintElements() const {
 int ClusterMatrix::SetupMatrix(size_t sizeIn) {
   if (Mat_.resize( 0L, sizeIn )) return 1;
   ignore_.assign( sizeIn, false );
-  //sieve_ = 1;
+/*
+# ifdef _OPENMP
+  int n_threads = 0;
+# pragma omp parallel
+  {
+    if (omp_get_thread_num() == 0)
+      n_threads = omp_get_num_threads();
+  }
+  minRow_.resize( n_threads );
+  minCol_.resize( n_threads );
+  minVal_.resize( n_threads );
+  mprintf("DEBUG: ClusterMatrix: Using %i threads.\n", n_threads);
+# endif
+*/
   return 0;
 }

--- a/src/ClusterMatrix.cpp
+++ b/src/ClusterMatrix.cpp
@@ -95,7 +95,6 @@ int ClusterMatrix::SetupMatrix(size_t sizeIn) {
   minRow_.resize( n_threads );
   minCol_.resize( n_threads );
   minVal_.resize( n_threads );
-  mprintf("DEBUG: ClusterMatrix: Using %i threads.\n", n_threads);
 # endif
   return 0;
 }

--- a/src/ClusterMatrix.h
+++ b/src/ClusterMatrix.h
@@ -13,7 +13,11 @@ class ClusterMatrix {
     /// \return Original number of rows in matrix
     size_t Nrows()            const { return Mat_.Nrows();   }
     /// Set the row and column of the smallest element not being ignored.
+#   ifdef _OPENMP
+    double FindMin(int&, int&);
+#   else
     double FindMin(int&, int&) const;
+#   endif
     /// \return an element.
     inline double GetCdist(int c, int r) const { return Mat_.element(c,r); }
     /// Print all matrix elements to STDOUT
@@ -27,5 +31,10 @@ class ClusterMatrix {
   private:
     Matrix<float> Mat_;        ///< Upper-triangle matrix holding cluster distances.
     std::vector<bool> ignore_; ///< If true, ignore the row/col when printing/searching etc.
+#   ifdef _OPENMP
+    std::vector<int> minRow_;
+    std::vector<int> minCol_;
+    std::vector<float> minVal_;
+#   endif
 };
 #endif

--- a/src/ClusterNode.cpp
+++ b/src/ClusterNode.cpp
@@ -126,8 +126,8 @@ void ClusterNode::SortFrameList() {
 }
 
 // ClusterNode::HasFrame()
-bool ClusterNode::HasFrame(int frame) {
-  ClusterDist::Cframes::iterator it = std::find(frameList_.begin(), frameList_.end(), frame);
+bool ClusterNode::HasFrame(int frame) const {
+  ClusterDist::Cframes::const_iterator it = std::find(frameList_.begin(), frameList_.end(), frame);
   return !(it == frameList_.end());
 }
 

--- a/src/ClusterNode.h
+++ b/src/ClusterNode.h
@@ -32,30 +32,41 @@ class ClusterNode {
     typedef ClusterDist::Cframes::const_iterator frame_iterator;
     frame_iterator beginframe() const { return frameList_.begin(); }
     frame_iterator endframe()   const { return frameList_.end();   }
-    int ClusterFrame(int idx)         const { return frameList_[idx];    } 
+    /// \return Frame number at given index.
+    int ClusterFrame(int idx)   const { return frameList_[idx];    }
     // Return internal variables
-    inline double AvgDist()      const { return avgClusterDist_;        }
-    inline double Eccentricity() const { return eccentricity_;          }
-    inline int Num()             const { return num_;                   }
-    inline int Nframes()         const { return (int)frameList_.size(); }
-    inline int BestRepFrame()   const  { return repFrame_;              }
-    inline Centroid* Cent()            { return centroid_;              }
+    double AvgDist()           const { return avgClusterDist_;        }
+    double Eccentricity()      const { return eccentricity_;          }
+    int Num()                  const { return num_;                   }
+    int Nframes()              const { return (int)frameList_.size(); }
+    int BestRepFrame()         const { return repFrame_;              }
+    Centroid* Cent()           const { return centroid_;              }
+    std::string const& Cname() const { return name_;                  }
+    double RefRms()            const { return refRms_;                }
     // Set internal variables 
     void SetAvgDist(double avg)        { avgClusterDist_ = avg;         }
     void AddFrameToCluster(int fnum)   { frameList_.push_back( fnum );  }
     void SetNum(int numIn)             { num_ = numIn;                  }
+    inline void SetName(std::string const&, double);
+    /// Sort internal frame list
     void SortFrameList();
-    bool HasFrame(int);
+    /// \return true if given frame is in this cluster.
+    bool HasFrame(int) const;
+    /// Remove specified frame from cluster if present.
     void RemoveFrameFromCluster(int);
+    /// Remove specified frame from cluster and update centroid.
     void RemoveFrameUpdateCentroid(ClusterDist*, int);
+    /// Add specified fram to cluster and update centroid.
     void AddFrameUpdateCentroid(ClusterDist*, int);
   private:
     double avgClusterDist_;           ///< Avg distance of this cluster to all other clusters.
     double eccentricity_;             ///< Maximum distance between any 2 frames.
+    double refRms_;                   ///< Cluster rms to reference (if assigned)
     int num_;                         ///< Cluster number.
     int repFrame_;                    ///< Frame number with lowest dist. to all other frames.
     ClusterDist::Cframes frameList_;  ///< List of frames belonging to this cluster.
-    Centroid* centroid_;              ///< Centroid of all frames in this cluster. 
+    Centroid* centroid_;              ///< Centroid of all frames in this cluster.
+    std::string name_;                ///< Cluster name assigned from reference.
 };
 // ----- INLINE FUNCTIONS ------------------------------------------------------
 /** Use > since we give higher priority to larger clusters. */
@@ -65,5 +76,10 @@ bool ClusterNode::operator<(const ClusterNode& rhs) const {
 /** Frames from rhs go to this cluster. */
 void ClusterNode::MergeFrames( ClusterNode const& rhs) {
   frameList_.insert(frameList_.end(), rhs.frameList_.begin(), rhs.frameList_.end());
+}
+
+void ClusterNode::SetName(std::string const& nameIn, double rmsIn) {
+  name_ = nameIn;
+  refRms_ = rmsIn;
 }
 #endif

--- a/src/Cluster_DBSCAN.cpp
+++ b/src/Cluster_DBSCAN.cpp
@@ -48,7 +48,7 @@ int Cluster_DBSCAN::SetupCluster(ArgList& analyzeArgs) {
 }
 
 // Cluster_DBSCAN::ClusteringInfo()
-void Cluster_DBSCAN::ClusteringInfo() {
+void Cluster_DBSCAN::ClusteringInfo() const {
   mprintf("\tDBSCAN:\n");
   if (!kdist_.Empty()) {
     mprintf("\t\tOnly calculating Kdist graph for K=%s\n", kdist_.RangeArg());

--- a/src/Cluster_DBSCAN.h
+++ b/src/Cluster_DBSCAN.h
@@ -9,8 +9,11 @@ class Cluster_DBSCAN : public ClusterList {
     Cluster_DBSCAN();
     static void Help();
     int SetupCluster(ArgList&);
-    void ClusteringInfo();
+    void ClusteringInfo() const;
     int Cluster();
+#   ifdef TIMER
+    void Timing(double) const {}
+#   endif
     void AddSievedFrames();
     void ClusterResults(CpptrajFile&) const;
   private:

--- a/src/Cluster_DPeaks.cpp
+++ b/src/Cluster_DPeaks.cpp
@@ -62,7 +62,7 @@ int Cluster_DPeaks::SetupCluster(ArgList& analyzeArgs) {
   return 0;
 }
 
-void Cluster_DPeaks::ClusteringInfo() {
+void Cluster_DPeaks::ClusteringInfo() const {
   mprintf("---------------------------------------------------------------------------\n"
           "Warning: The dpeaks algorithm is still under development. USE WITH CAUTION!\n"
           "---------------------------------------------------------------------------\n");

--- a/src/Cluster_DPeaks.h
+++ b/src/Cluster_DPeaks.h
@@ -6,8 +6,11 @@ class Cluster_DPeaks : public ClusterList {
     Cluster_DPeaks();
     static void Help();
     int SetupCluster(ArgList&);
-    void ClusteringInfo();
+    void ClusteringInfo() const;
     int Cluster();
+#   ifdef TIMER
+    void Timing(double) const {}
+#   endif
     void AddSievedFrames();
     void ClusterResults(CpptrajFile&) const;
   private:

--- a/src/Cluster_HierAgglo.cpp
+++ b/src/Cluster_HierAgglo.cpp
@@ -39,7 +39,7 @@ int Cluster_HierAgglo::SetupCluster(ArgList& analyzeArgs) {
   return 0;
 }
 
-void Cluster_HierAgglo::ClusteringInfo() {
+void Cluster_HierAgglo::ClusteringInfo() const {
   mprintf("\tHierarchical Agglomerative:");
   if (nclusters_ != -1)
     mprintf(" %i clusters,",nclusters_);
@@ -144,12 +144,15 @@ int Cluster_HierAgglo::Cluster() {
 void Cluster_HierAgglo::ClusterResults(CpptrajFile& outfile) const {
   outfile.Printf("#Algorithm: HierAgglo linkage %s nclusters %i epsilon %g\n",
                  LinkageString[linkage_], nclusters_, epsilon_);
-# ifdef TIMER
-  time_findMin_.WriteTiming(2, "Find min distance");
-  time_mergeFrames_.WriteTiming(2, "Merge cluster frames");
-  time_calcLinkage_.WriteTiming(2, "Calculate new linkage");
-# endif
 }
+
+#ifdef TIMER
+void Cluster_HierAgglo::Timing(double total) const {
+  time_findMin_.WriteTiming(2, "Find min distance", total);
+  time_mergeFrames_.WriteTiming(2, "Merge cluster frames", total);
+  time_calcLinkage_.WriteTiming(2, "Calculate new linkage", total);
+}
+#endif
 
 /** Find and merge the two closest clusters. */
 int Cluster_HierAgglo::MergeClosest() {

--- a/src/Cluster_HierAgglo.cpp
+++ b/src/Cluster_HierAgglo.cpp
@@ -56,39 +56,15 @@ void Cluster_HierAgglo::ClusteringInfo() const {
 void Cluster_HierAgglo::InitializeClusterDistances() {
   // Sets up matrix and ignore array
   ClusterDistances_.SetupMatrix( clusters_.size() );
-  // Build initial cluster distances
-  if (linkage_==AVERAGELINK) {
-#   ifdef NEWCODE
-    // Set up matrix to hold sums of distances to clusters.
-    SumDistToCluster_.resize(0, clusters_.size());
-    for (cluster_iterator C1 = clusters_.begin(); C1 != clusters_.end(); ++C1) {
-      for (cluster_iterator C2 = C1; C2 != clusters_.end(); ++C2) {
-        if (C1 != C2) {
-          double sum = 0.0;
-          for (ClusterNode::frame_iterator F1 = C1->beginframe();
-                                           F1 != C1->endframe(); ++F1)
-            for (ClusterNode::frame_iterator F2 = C2->beginframe();
-                                             F2 != C2->endframe(); ++F2)
-              sum += FrameDistances().GetFdist( *F1, *F2 );
-          SumDistToCluster_.setElement( C1->Num(), C2->Num(), sum );
-          double total = (double)(C1->Nframes() * C2->Nframes());
-          ClusterDistances_.SetElement( C1->Num(), C2->Num(), sum / total );
-        }
-      }
+  // Build initial cluster distances. Take advantage of the fact that
+  // the initial cluster layout is the same as the pairwise array.
+  unsigned int total_frames = FrameDistances().FramesToCluster().size();
+  for (unsigned int idx1 = 0; idx1 != total_frames; idx1++) {
+    int f1 = FrameDistances().FramesToCluster()[ idx1 ];
+    for (unsigned int idx2 = idx1 + 1; idx2 != total_frames; idx2++) {
+      int f2 = FrameDistances().FramesToCluster()[ idx2 ];
+      ClusterDistances_.SetCdist( idx1, idx2, FrameDistances().GetFdist(f1, f2) );
     }
-#   else
-    for (cluster_it C1_it = clusters_.begin();
-                    C1_it != clusters_.end(); C1_it++)
-      calcAvgDist(C1_it);
-#   endif
-  } else if (linkage_==SINGLELINK) {
-    for (cluster_it C1_it = clusters_.begin();
-                    C1_it != clusters_.end(); C1_it++)
-      calcMinDist(C1_it);
-  } else if (linkage_==COMPLETELINK) {
-    for (cluster_it C1_it = clusters_.begin();
-                    C1_it != clusters_.end(); C1_it++)
-      calcMaxDist(C1_it);
   }
   if (debug_ > 1) {
     mprintf("CLUSTER: INITIAL CLUSTER DISTANCES:\n");

--- a/src/Cluster_HierAgglo.h
+++ b/src/Cluster_HierAgglo.h
@@ -6,8 +6,6 @@
 #endif
 class Cluster_HierAgglo : public ClusterList {
   public:
-    /// Type of distance calculation between clusters.
-    enum LINKAGETYPE  { SINGLELINK = 0, AVERAGELINK, COMPLETELINK };
     Cluster_HierAgglo();
     static void Help();
     int SetupCluster(ArgList&);
@@ -19,6 +17,14 @@ class Cluster_HierAgglo : public ClusterList {
     void AddSievedFrames() { AddSievedFramesByCentroid(); }
     void ClusterResults(CpptrajFile&) const;
   private:
+    void InitializeClusterDistances();
+    int MergeClosest();
+    void calcMinDist(cluster_it&);
+    void calcMaxDist(cluster_it&);
+    void calcAvgDist(cluster_it&);
+
+    /// Type of distance calculation between clusters.
+    enum LINKAGETYPE  { SINGLELINK = 0, AVERAGELINK, COMPLETELINK };
     int nclusters_;       ///< Target # of clusters.
     double epsilon_;      ///< Once the min distance between clusters is > epsilon, stop.
     LINKAGETYPE linkage_; ///< Cluster Linkage type.
@@ -33,10 +39,5 @@ class Cluster_HierAgglo : public ClusterList {
     Timer time_mergeFrames_;
     Timer time_calcLinkage_;
 #   endif
-    void InitializeClusterDistances();
-    int MergeClosest();
-    void calcMinDist(cluster_it&);
-    void calcMaxDist(cluster_it&);
-    void calcAvgDist(cluster_it&);
 };
 #endif

--- a/src/Cluster_HierAgglo.h
+++ b/src/Cluster_HierAgglo.h
@@ -11,8 +11,11 @@ class Cluster_HierAgglo : public ClusterList {
     Cluster_HierAgglo();
     static void Help();
     int SetupCluster(ArgList&);
-    void ClusteringInfo();
+    void ClusteringInfo() const;
     int Cluster();
+#   ifdef TIMER
+    void Timing(double) const;
+#   endif
     void AddSievedFrames() { AddSievedFramesByCentroid(); }
     void ClusterResults(CpptrajFile&) const;
   private:

--- a/src/Cluster_Kmeans.cpp
+++ b/src/Cluster_Kmeans.cpp
@@ -54,15 +54,15 @@ void Cluster_Kmeans::ClusterResults(CpptrajFile& outfile) const {
 // Cluster_Kmeans::Cluster()
 int Cluster_Kmeans::Cluster() {
   // First determine which frames are being clustered.
-  FramesToCluster_ = FrameDistances().FramesToCluster();
+  Iarray const& FramesToCluster = FrameDistances().FramesToCluster();
 
   // Determine seeds
-  FindKmeansSeeds();
+  FindKmeansSeeds( FramesToCluster );
 
   if (mode_ == RANDOM)
     RN_.rn_set( kseed_ );
 
-  int pointCount = (int)FramesToCluster_.size();
+  int pointCount = (int)FramesToCluster.size();
 
   // This array will hold the indices of the points to process each iteration.
   // If sequential this is just 0 -> pointCount. If random this will be 
@@ -76,7 +76,7 @@ int Cluster_Kmeans::Cluster() {
   for (Iarray::const_iterator seedIdx = SeedIndices_.begin();
                               seedIdx != SeedIndices_.end(); ++seedIdx)
   {
-    int seedFrame = FramesToCluster_[ *seedIdx ];
+    int seedFrame = FramesToCluster[ *seedIdx ];
     // A centroid is created for new clusters.
     AddCluster( ClusterDist::Cframes(1, seedFrame) );
     // NOTE: No need to calc best rep frame, only 1 frame.
@@ -103,7 +103,7 @@ int Cluster_Kmeans::Cluster() {
       int oldClusterIdx = -1;
 //      if ( iteration != 0 || mode_ != SEQUENTIAL) // FIXME: Should this really happen for RANDOM
 //      {
-        int pointFrame = FramesToCluster_[ *pointIdx ];
+        int pointFrame = FramesToCluster[ *pointIdx ];
         if (debug_ > 0)
           mprintf("DEBUG: Processing frame %i (index %i)\n", pointFrame, *pointIdx);
         bool pointWasYanked = true;
@@ -203,18 +203,18 @@ int Cluster_Kmeans::Cluster() {
   * arbitrary first choice.  Then, at each iteration, add the point whose total
   * distance from our set of seeds is as large as possible.
   */
-int Cluster_Kmeans::FindKmeansSeeds() {
-  // SeedIndices will hold indices into FramesToCluster_
+int Cluster_Kmeans::FindKmeansSeeds(Iarray const& FramesToCluster) {
+  // SeedIndices will hold indices into FramesToCluster
   SeedIndices_.resize( nclusters_, 1 ); // 1 used to be consistent with ptraj
 
   double bestDistance = 0.0;
-  int frameCount = (int)FramesToCluster_.size();
+  int frameCount = (int)FramesToCluster.size();
   for (int frameIdx = 0; frameIdx != frameCount; frameIdx++)
   {
-    int seedFrame = FramesToCluster_[ frameIdx ];
+    int seedFrame = FramesToCluster[ frameIdx ];
     for (int candidateIdx = frameIdx; candidateIdx < frameCount; candidateIdx++)
     {
-      int candidateFrame = FramesToCluster_[ candidateIdx ];
+      int candidateFrame = FramesToCluster[ candidateIdx ];
       double dist = FrameDistances().GetFdist( seedFrame, candidateFrame );
       if (dist > bestDistance)
       {
@@ -242,11 +242,11 @@ int Cluster_Kmeans::FindKmeansSeeds() {
       }
       if (!skipCandidate) {
         // Get the closest distance from this candidate to a current seed
-        int candidateFrame = FramesToCluster_[ candidateIdx ];
+        int candidateFrame = FramesToCluster[ candidateIdx ];
         double nearestDist = -1.0;
         for (int checkIdx = 0; checkIdx != seedIdx; checkIdx++)
         {
-          int seedFrame = FramesToCluster_[ SeedIndices_[checkIdx] ];
+          int seedFrame = FramesToCluster[ SeedIndices_[checkIdx] ];
           double dist = FrameDistances().GetFdist( candidateFrame, seedFrame );
           if (dist < nearestDist || nearestDist < 0.0)
             nearestDist = dist;

--- a/src/Cluster_Kmeans.cpp
+++ b/src/Cluster_Kmeans.cpp
@@ -31,7 +31,7 @@ int Cluster_Kmeans::SetupCluster(ArgList& analyzeArgs) {
 }
 
 // Cluster_Kmeans::ClusteringInfo()
-void Cluster_Kmeans::ClusteringInfo() {
+void Cluster_Kmeans::ClusteringInfo() const {
   mprintf("\tK-MEANS: Looking for %i clusters.\n", nclusters_);
   if (mode_ == SEQUENTIAL)
     mprintf("\t\tSequentially modify each point.\n");

--- a/src/Cluster_Kmeans.h
+++ b/src/Cluster_Kmeans.h
@@ -7,8 +7,11 @@ class Cluster_Kmeans : public ClusterList {
     Cluster_Kmeans();
     static void Help();
     int SetupCluster(ArgList&);
-    void ClusteringInfo();
+    void ClusteringInfo() const;
     int Cluster();
+#   ifdef TIMER
+    void Timing(double) const {}
+#   endif
     void AddSievedFrames() { AddSievedFramesByCentroid(); }
     void ClusterResults(CpptrajFile&) const;
   private:

--- a/src/Cluster_Kmeans.h
+++ b/src/Cluster_Kmeans.h
@@ -18,7 +18,7 @@ class Cluster_Kmeans : public ClusterList {
     typedef std::vector<int> Iarray;
     enum KmeansModeType { SEQUENTIAL, RANDOM };
 
-    int FindKmeansSeeds();
+    int FindKmeansSeeds(Iarray const&);
     void ShufflePoints(Iarray&);
 
     Random_Number RN_;
@@ -26,7 +26,6 @@ class Cluster_Kmeans : public ClusterList {
     int kseed_;
     int maxIt_;
     Iarray SeedIndices_;
-    Iarray FramesToCluster_;
     KmeansModeType mode_;
     bool clusterToClusterCentroid_;
 };

--- a/src/Cluster_ReadInfo.cpp
+++ b/src/Cluster_ReadInfo.cpp
@@ -17,7 +17,7 @@ int Cluster_ReadInfo::SetupCluster(ArgList& analyzeArgs) {
   return 0;
 }
 
-void Cluster_ReadInfo::ClusteringInfo() {
+void Cluster_ReadInfo::ClusteringInfo() const {
   mprintf("\tREADINFO: Reading cluster information from previous run, file %s.\n",
           filename_.c_str());
 }

--- a/src/Cluster_ReadInfo.h
+++ b/src/Cluster_ReadInfo.h
@@ -7,8 +7,11 @@ class Cluster_ReadInfo : public ClusterList {
     Cluster_ReadInfo();
     static void Help();
     int SetupCluster(ArgList&);
-    void ClusteringInfo();
+    void ClusteringInfo() const;
     int Cluster();
+#   ifdef TIMER
+    void Timing(double) const {}
+#   endif
     void AddSievedFrames() { }
     void ClusterResults(CpptrajFile&) const;
   private:

--- a/src/TrajectoryFile.h
+++ b/src/TrajectoryFile.h
@@ -34,9 +34,13 @@ class TrajectoryFile {
     static TrajFormatType GetFormatFromArg(ArgList& a) {
       return (TrajFormatType)FileTypes::GetFormatFromArg(TF_KeyArray, a, UNKNOWN_TRAJ);
     }
-    /// \return format type from keyword.
+    /// \return format type from keyword. Default to Amber trajectory.
     static TrajFormatType GetFormatFromString(std::string const& s) {
       return (TrajFormatType)FileTypes::GetFormatFromString(TF_KeyArray, s, AMBERTRAJ);
+    }
+    /// \return format type from keyword, or given default if keyword is empty.
+    static TrajFormatType GetFormatFromString(std::string const& s, TrajFormatType def) {
+      return (TrajFormatType)FileTypes::GetFormatFromString(TF_KeyArray, s, def);
     }
     /// \return standard file extension for trajectory format.
     static std::string GetExtensionForType(TrajFormatType t) {
@@ -45,6 +49,10 @@ class TrajectoryFile {
     /// \return type from extension.
     static TrajFormatType GetTypeFromExtension(std::string const& e) {
       return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_KeyArray, e, UNKNOWN_TRAJ);
+    }
+    /// \return type from extension. Default to given format if unknown.
+    static TrajFormatType GetTypeFromExtension(FileName const& f, TrajFormatType def) {
+      return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_KeyArray, f.Ext(), def);
     }
     /// \return string corresponding to given format.
     static const char* FormatString( TrajFormatType tt ) { return 


### PR DESCRIPTION
Various clustering improvements

* Adds new functionality to cluster: [assignrefs [refcut <rms>] [refmask <mask>]].  This allows users to attempt to assign names to found clusters based on their RMS similiarity to any loaded reference structure. The name along with the RMSD will be output in both 'summary' and 'summarysplit' files. For each cluster, the minimum RMSD to a loaded reference is determined. If the minimum RMSD is less than 'refcut' then the name is assigned. If the minimum RMSD is greater the name is assigned but put in parentheses, e.g.
```
#Cluster   Frames     Frac  AvgDist    Stdev Centroid AvgCDist                        Name      RMS
       0  1476018    0.243    1.830    0.667   402991    4.501            A-form-minor_NMR    0.389
       1  1085022    0.179    1.536    0.616  1870117    4.055          Intercalcated-anti    0.248
       2   962156    0.159    1.518    0.718   397840    4.465            A-form-major-NMR    0.481
       3   314041    0.052    0.898    0.297   871732    4.390                Inverted-syn    0.345
       4   255760    0.042    1.081    0.341   740533    3.953            Intercalated-syn    0.519
       5   247508    0.041    0.935    0.186  2707003    4.740          (A-form-major-NMR)    2.052
```

* The hierarchical agglomerative algorithm has been sped up a bit via OpenMP by parallelizing finding the minimum distance between 2 clusters, which was the bottleneck.

* Cluster trajectory output will now determine format based on file name if format is not specified.

* Various fixes for 'const' (iterators and functions), code cleanup, code documentation.