### PR TITLE
Improve 'trajout' options

### DIFF
--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -9,7 +9,7 @@
 class CoordinateInfo {
   public:
     /// CONSTRUCTOR
-    CoordinateInfo() : ensembleSize_(0), hasVel_(false), hasTemp_(false), hasTime_(false), hasFrc_(false) {}
+    CoordinateInfo() : ensembleSize_(0), hasCrd_(true), hasVel_(false), hasTemp_(false), hasTime_(false), hasFrc_(false) {}
     /// CONSTRUCTOR - box, velocity, temperature, time
     CoordinateInfo(Box const& b, bool v, bool t, bool m) :
       box_(b), ensembleSize_(0), hasVel_(v), hasTemp_(t), hasTime_(m), hasFrc_(false) {}
@@ -30,6 +30,7 @@ class CoordinateInfo {
     ReplicaDimArray const& ReplicaDimensions() const { return remdDim_; }
     void SetTime(bool m)        { hasTime_ = m; }
     void SetTemperature(bool t) { hasTemp_ = t; }
+    void SetCrd(bool c)         { hasCrd_ = c;  }
     void SetVelocity(bool v)    { hasVel_ = v;  }
     void SetForce(bool f)       { hasFrc_ = f;  }
     void SetEnsembleSize(int s) { ensembleSize_ = s; }
@@ -50,6 +51,7 @@ class CoordinateInfo {
     ReplicaDimArray remdDim_; ///< Hold info on any replica dimensions.
     Box box_;                 ///< Hold box information.
     int ensembleSize_;        ///< If coordinate ensemble, total # of replicas.
+    bool hasCrd_;             ///< True if coords present. Now only relevant for NetCDF traj.
     bool hasVel_;             ///< True if coords have associated velocities.
     bool hasTemp_;            ///< True if coords include temp info.
     bool hasTime_;            ///< True if coords include time info.

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -9,19 +9,24 @@
 class CoordinateInfo {
   public:
     /// CONSTRUCTOR
-    CoordinateInfo() : ensembleSize_(0), hasCrd_(true), hasVel_(false), hasTemp_(false), hasTime_(false), hasFrc_(false) {}
+    CoordinateInfo() : ensembleSize_(0), hasCrd_(true), hasVel_(false),
+                       hasTemp_(false), hasTime_(false), hasFrc_(false) {}
     /// CONSTRUCTOR - box, velocity, temperature, time
     CoordinateInfo(Box const& b, bool v, bool t, bool m) :
-      box_(b), ensembleSize_(0), hasVel_(v), hasTemp_(t), hasTime_(m), hasFrc_(false) {}
+      box_(b), ensembleSize_(0), hasCrd_(true), hasVel_(v),
+      hasTemp_(t), hasTime_(m), hasFrc_(false) {}
     /// CONSTRUCTOR - all except ensemble size
     CoordinateInfo(ReplicaDimArray const& r, Box const& b, bool v, bool t, bool m, bool f) :
-      remdDim_(r), box_(b), ensembleSize_(0), hasVel_(v), hasTemp_(t), hasTime_(m), hasFrc_(f) {}
+      remdDim_(r), box_(b), ensembleSize_(0), hasCrd_(true), hasVel_(v),
+      hasTemp_(t), hasTime_(m), hasFrc_(f) {}
     /// CONSTRUCTOR - All
     CoordinateInfo(int e, ReplicaDimArray const& r, Box const& b, bool v, bool t, bool m, bool f) :
-      remdDim_(r), box_(b), ensembleSize_(e), hasVel_(v), hasTemp_(t), hasTime_(m), hasFrc_(f) {}
+      remdDim_(r), box_(b), ensembleSize_(e), hasCrd_(true), hasVel_(v),
+      hasTemp_(t), hasTime_(m), hasFrc_(f) {}
     bool HasBox()              const { return box_.HasBox();            }
     const Box& TrajBox()       const { return box_;                     }
     int EnsembleSize()         const { return ensembleSize_;            }
+    bool HasCrd()              const { return hasCrd_;                  }
     bool HasVel()              const { return hasVel_;                  }
     bool HasTemp()             const { return hasTemp_;                 }
     bool HasTime()             const { return hasTime_;                 }

--- a/src/Exec_Traj.cpp
+++ b/src/Exec_Traj.cpp
@@ -31,7 +31,8 @@ void Exec_Reference::Help() const {
 }
 // -----------------------------------------------------------------------------
 void Exec_Trajout::Help() const {
-  mprintf("\t<filename> [<fileformat>] [append] [nobox]\n"
+  mprintf("\t<filename> [<fileformat>] [append] [nobox] [novelocity]\n"
+          "\t           [notemperature] [notime] [noforce] [noreplicadim]\n"
           "\t           [%s] [onlyframes <range>] [title <title>]\n"
           "\t           [onlymembers <memberlist>]\n", DataSetList::TopArgs);
   mprintf("\t           %s\n", ActionFrameCounter::HelpText);

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -554,13 +554,15 @@ int NetcdfFile::NC_create(std::string const& Name, NCTYPE type, int natomIn,
     dimensionID[1] = spatialDID_;
   }
   // Coord variable
-  if ( NC::CheckErr( nc_def_var( ncid_, NCCOORDS, dataType, NDIM, dimensionID, &coordVID_)) ) {
-    mprinterr("Error: Defining coordinates variable.\n");
-    return 1;
-  }
-  if ( NC::CheckErr( nc_put_att_text( ncid_, coordVID_, "units", 8, "angstrom")) ) {
-    mprinterr("Error: Writing coordinates variable units.\n");
-    return 1;
+  if (coordInfo.HasCrd()) {
+    if ( NC::CheckErr( nc_def_var( ncid_, NCCOORDS, dataType, NDIM, dimensionID, &coordVID_)) ) {
+      mprinterr("Error: Defining coordinates variable.\n");
+      return 1;
+    }
+    if ( NC::CheckErr( nc_put_att_text( ncid_, coordVID_, "units", 8, "angstrom")) ) {
+      mprinterr("Error: Writing coordinates variable units.\n");
+      return 1;
+    }
   }
   // Velocity variable
   if (coordInfo.HasVel()) {

--- a/src/OutputTrajCommon.cpp
+++ b/src/OutputTrajCommon.cpp
@@ -8,7 +8,12 @@ OutputTrajCommon::OutputTrajCommon() :
   NframesToWrite_(-1),
   numFramesWritten_(0),
   writeFormat_(TrajectoryFile::UNKNOWN_TRAJ),
-  nobox_(false),
+  noBox_(false),
+  noVel_(false),
+  noTemp_(false),
+  noTime_(false),
+  noFrc_(false),
+  noReps_(false),
   append_(false),
   hasRange_(false)
 {}
@@ -22,9 +27,13 @@ int OutputTrajCommon::CommonTrajoutSetup(FileName const& tnameIn, ArgList& argIn
   append_ = argIn.hasKey("append");
   // Get specified title if any.
   title_ = argIn.GetStringKey("title");
-  // Check for nobox argument - will override any box info present in parm
-  // when trajectory IO is set up.
-  nobox_ = argIn.hasKey("nobox");
+  // Check for noX arguments - will override info in given CoordinateInfo.
+  noBox_ = argIn.hasKey("nobox");
+  noVel_ = argIn.hasKey("novelocity");
+  noTemp_ = argIn.hasKey("notemperature");
+  noTime_ = argIn.hasKey("notime");
+  noFrc_ = argIn.hasKey("noforce");
+  noReps_ = argIn.hasKey("noreplicadim");
   // If a write format was not specified (UNKNOWN_TRAJ) check the argument
   // list to see if format was specified there.
   writeFormat_ = fmtIn;
@@ -95,12 +104,14 @@ int OutputTrajCommon::SetupCoordInfo(Topology* tparmIn, int nFrames, CoordinateI
 {
   if (tparmIn == 0) return 1;
   trajParm_ = tparmIn;
-  // Use parm to set up coord info for the traj. If 'nobox' was specified
-  // remove any box info.
+  // Set coordinate info. Remove box, velocities, etc if specified.
   cInfo_ = cInfoIn;
-  if (nobox_)
-    cInfo_.SetBox( Box() );
-  // TODO velocity, temperature, time etc
+  if (noBox_ ) cInfo_.SetBox( Box() );
+  if (noVel_ ) cInfo_.SetVelocity( false );
+  if (noTemp_) cInfo_.SetTemperature( false );
+  if (noTime_) cInfo_.SetTime( false );
+  if (noFrc_ ) cInfo_.SetForce( false );
+  if (noReps_) cInfo_.SetReplicaDims( ReplicaDimArray() );
   // Determine how many frames will be written
   NframesToWrite_ = nFrames;
   if (hasRange_)
@@ -115,7 +126,7 @@ int OutputTrajCommon::SetupCoordInfo(Topology* tparmIn, int nFrames, CoordinateI
 
 void OutputTrajCommon::CommonInfo() const {
   if (trajParm_ != 0) mprintf(", Parm %s", trajParm_->c_str());
-  if (nobox_) mprintf(" (no box info)");
+  if (noBox_) mprintf(" (no box info)");
   if (hasRange_)
     FrameRange_.PrintRange(": Writing frames", 1);
   else if (NframesToWrite_ > 0) {

--- a/src/OutputTrajCommon.cpp
+++ b/src/OutputTrajCommon.cpp
@@ -126,7 +126,12 @@ int OutputTrajCommon::SetupCoordInfo(Topology* tparmIn, int nFrames, CoordinateI
 
 void OutputTrajCommon::CommonInfo() const {
   if (trajParm_ != 0) mprintf(", Parm %s", trajParm_->c_str());
-  if (noBox_) mprintf(" (no box info)");
+  if (noBox_) mprintf(" no box info,");
+  if (noVel_) mprintf(" no velocities,");
+  if (noTemp_) mprintf(" no temperatures,");
+  if (noTime_) mprintf(" no times,");
+  if (noFrc_) mprintf(" no forces,");
+  if (noReps_) mprintf(" no replica dimensions,");
   if (hasRange_)
     FrameRange_.PrintRange(": Writing frames", 1);
   else if (NframesToWrite_ > 0) {

--- a/src/OutputTrajCommon.h
+++ b/src/OutputTrajCommon.h
@@ -53,7 +53,12 @@ class OutputTrajCommon {
     // Trajout arguments
     TrajectoryFile::TrajFormatType writeFormat_;
     std::string title_;                ///< Output traj title.
-    bool nobox_;                       ///< If true do not put box information in output traj
+    bool noBox_;                       ///< If true do not put box information in output traj
+    bool noVel_;
+    bool noTemp_;
+    bool noTime_;
+    bool noFrc_;
+    bool noReps_;
     bool append_;                      ///< If true, append to this file.
     bool hasRange_;                    ///< If true a frame range is defined.
 };

--- a/src/TrajIOarray.cpp
+++ b/src/TrajIOarray.cpp
@@ -135,6 +135,11 @@ int TrajIOarray::SetupIOarray(ArgList& argIn, TrajFrameCounter& counter,
       mprinterr("Error: Could not set up %s for reading.\n", repfile->full());
       return 1;
     }
+    // Coordinates must be present.
+    if (!replica0->CoordInfo().HasCrd()) {
+      mprinterr("Error: No coordinates present in trajectory '%s'\n", repfile->full());
+      return 1;
+    }
     // TODO: Do not allow unknown number of frames?
     if (lowestRep) {
       cInfo = replica0->CoordInfo();
@@ -307,6 +312,11 @@ int TrajIOarray::SetupIOarray(ArgList& argIn, TrajFrameCounter& counter,
   int nframes = replica0->setupTrajin( repFname, trajParm );
   if (nframes == TrajectoryIO::TRAJIN_ERR) {
     mprinterr("Error: Could not set up %s for reading.\n", repFname.full());
+    return 1;
+  }
+  // Coordinates must be present.
+  if (!replica0->CoordInfo().HasCrd()) {
+    mprinterr("Error: No coordinates present in trajectory '%s'\n", repFname.full());
     return 1;
   }
   // Set coordinate info

--- a/src/Traj_AmberCoord.cpp
+++ b/src/Traj_AmberCoord.cpp
@@ -297,7 +297,7 @@ int Traj_AmberCoord::setupTrajin(FileName const& fname, Topology* trajParm)
 }
 
 void Traj_AmberCoord::WriteHelp() {
-  mprintf("\tremdtraj:      Write temperature to trajectory (makes REMD trajectory).\n"
+  mprintf("\tremdtraj     : Write temperature to trajectory (makes REMD trajectory).\n"
           "\thighprecision: (ADVANCED USE ONLY) Write 8.6 instead of 8.3 format.\n");
 }
 

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -131,7 +131,7 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
 void Traj_AmberNetcdf::WriteHelp() {
   mprintf("\tremdtraj: Write temperature to trajectory (makes REMD trajectory).\n"
           "\tvelocity: Write velocities to trajectory.\n"
-          "\tforce: Write forces to trajectory.\n");
+          "\tforce   : Write forces to trajectory.\n");
 }
 
 // Traj_AmberNetcdf::processWriteArgs()

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -337,8 +337,8 @@ int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
     return 1;
   }
 
-  // Write velocity. FIXME: Should check in setup
-  if (CoordInfo().HasVel() && frameOut.HasVelocity()) {
+  // Write velocity.
+  if (velocityVID_ != -1) {
     DoubleToFloat(Coord_, frameOut.vAddress());
     if (NC::CheckErr(nc_put_vara_float(ncid_, velocityVID_, start_, count_, Coord_)) ) {
       mprinterr("Error: Netcdf writing velocity frame %i\n", set+1);
@@ -346,8 +346,8 @@ int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
     }
   }
 
-  // Write forces. FIXME: Should check in setup
-  if (CoordInfo().HasForce() && frameOut.HasForce()) {
+  // Write forces.
+  if (frcVID_ != -1) {
     DoubleToFloat(Coord_, frameOut.fAddress());
     if (NC::CheckErr(nc_put_vara_float(ncid_, frcVID_, start_, count_, Coord_)) ) {
       mprinterr("Error: Netcdf writing force frame %i\n", set+1);
@@ -374,7 +374,7 @@ int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
   }
 
   // Write temperature
-  if (TempVID_!=-1) {
+  if (TempVID_ != -1) {
     if ( NC::CheckErr( nc_put_vara_double(ncid_,TempVID_,start_,count_,frameOut.tAddress())) ) {
       mprinterr("Error: Writing temperature frame %i.\n", set+1);
       return 1;
@@ -461,7 +461,7 @@ int Traj_AmberNetcdf::writeReservoir(int set, Frame const& frame, double energy,
   return 0;
 }
   
-// Traj_AmberNetcdf::info()
+// Traj_AmberNetcdf::Info()
 void Traj_AmberNetcdf::Info() {
   mprintf("is a NetCDF AMBER trajectory");
   if (readAccess_ && !HasCoords()) mprintf(" (no coordinates)");

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -140,8 +140,12 @@ void Traj_AmberNetcdf::WriteHelp() {
 int Traj_AmberNetcdf::processWriteArgs(ArgList& argIn) {
   outputTemp_ = argIn.hasKey("remdtraj");
   write_mdcrd_ = argIn.hasKey("mdcrd");
-  write_mdvel_ = argIn.hasKey("mdvel") || argIn.hasKey("velocity");
-  write_mdfrc_ = argIn.hasKey("mdfrc") || argIn.hasKey("force");
+  if (argIn.hasKey("velocity"))
+    mprintf("Warning: The 'velocity' keyword is no longer necessary and has been deprecated.\n");
+  if (argIn.hasKey("force"))
+    mprintf("Warning: The 'force' keyword is no longer necessary and has been deprecated.\n");
+  write_mdvel_ = argIn.hasKey("mdvel");
+  write_mdfrc_ = argIn.hasKey("mdfrc");
   return 0;
 }
 

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -20,9 +20,10 @@ Traj_AmberNetcdf::Traj_AmberNetcdf() :
   useFrcAsCoords_(false),
   readAccess_(false),
   outputTemp_(false),
-  outputVel_(false),
-  outputFrc_(false)
-{ }
+  write_mdcrd_(false),
+  write_mdvel_(false),
+  write_mdfrc_(false)
+{}
 
 // DESTRUCTOR
 Traj_AmberNetcdf::~Traj_AmberNetcdf() {
@@ -130,15 +131,17 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
 
 void Traj_AmberNetcdf::WriteHelp() {
   mprintf("\tremdtraj: Write temperature to trajectory (makes REMD trajectory).\n"
-          "\tvelocity: Write velocities to trajectory.\n"
-          "\tforce   : Write forces to trajectory.\n");
+          "\tmdvel   : Write only velocities to trajectory.\n"
+          "\tmdfrc   : Write only forces to trajectory.\n"
+          "\tmdcrd   : Write coordinates to trajectory (only required with mdvel/mdfrc).\n");
 }
 
 // Traj_AmberNetcdf::processWriteArgs()
 int Traj_AmberNetcdf::processWriteArgs(ArgList& argIn) {
   outputTemp_ = argIn.hasKey("remdtraj");
-  outputVel_ = argIn.hasKey("velocity");
-  outputFrc_ = argIn.hasKey("force");
+  write_mdcrd_ = argIn.hasKey("mdcrd");
+  write_mdvel_ = argIn.hasKey("mdvel") || argIn.hasKey("velocity");
+  write_mdfrc_ = argIn.hasKey("mdfrc") || argIn.hasKey("force");
   return 0;
 }
 
@@ -156,9 +159,25 @@ int Traj_AmberNetcdf::setupTrajout(FileName const& fname, Topology* trajParm,
     // Deal with output options
     // For backwards compatibility always write temperature if remdtraj is true.
     if (outputTemp_ && !cInfo.HasTemp()) cInfo.SetTemperature(true);
-    // Explicitly write velocity - initial frames may not have velocity info.
-    if (outputVel_ && !cInfo.HasVel()) cInfo.SetVelocity(true);
-    if (outputFrc_ && !cInfo.HasForce()) cInfo.SetForce(true);
+    // Determine what kind of trajectory to write based on options/coordinate info.
+    if (write_mdcrd_ || write_mdvel_ || write_mdfrc_) {
+      // If an option was specified, check that CoordinateInfo has requested info.
+      if (write_mdcrd_ && !cInfoIn.HasCrd()) { // SANITY CHECK
+        mprinterr("Error: 'mdcrd' specified but no coordinate info present.\n");
+        return 1;
+      }
+      if (write_mdvel_ && !cInfoIn.HasVel()) {
+        mprinterr("Error: 'mdvel' specified but no velocity info present.\n");
+        return 1;
+      }
+      if (write_mdfrc_ && !cInfoIn.HasForce()) {
+        mprinterr("Error: 'mdfrc' specified but no force info present.\n");
+        return 1;
+      }
+      cInfo.SetCrd( write_mdcrd_ );
+      cInfo.SetVelocity( write_mdvel_ );
+      cInfo.SetForce( write_mdfrc_ );
+    }
     SetCoordInfo( cInfo );
     filename_ = fname;
     // Set up title
@@ -178,13 +197,16 @@ int Traj_AmberNetcdf::setupTrajout(FileName const& fname, Topology* trajParm,
     // memory for coords.
     if (setupTrajin(fname, trajParm) == TRAJIN_ERR) return 1;
     // Check output options.
-    if (outputTemp_ && !CoordInfo().HasTemp())
+    if (write_mdcrd_ || write_mdvel_ || write_mdfrc_)
+      mprintf("Warning: 'mdcrd', 'mdvel', and 'mdfrc' are ignored for appending.\n");
+    // Check that CoordinateInfo matches file we are appending to.
+    if ((outputTemp_ || cInfoIn.HasTemp()) && !CoordInfo().HasTemp())
       mprintf("Warning: Cannot append temperature data to NetCDF file '%s'; no temperature dimension.\n",
               filename_.base());
-    if (outputVel_ && !CoordInfo().HasVel())
+    if (cInfoIn.HasVel() && !CoordInfo().HasVel())
       mprintf("Warning: Cannot append velocity data to NetCDF file '%s'; no velocity dimension.\n",
               filename_.base());
-    if (outputFrc_ && !CoordInfo().HasForce())
+    if (cInfoIn.HasForce() && !CoordInfo().HasForce())
       mprintf("Warning: Cannot append force data to NetCDF file '%s'; no force dimension.\n",
               filename_.base());
     if (debug_ > 0)
@@ -325,25 +347,28 @@ int Traj_AmberNetcdf::readForce(int set, Frame& frameIn) {
 
 // Traj_AmberNetcdf::writeFrame() 
 int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
-  DoubleToFloat(Coord_, frameOut.xAddress());
-
-  // Write coords
+  // Set indices for coords/velocities/forces
   start_[0] = ncframe_;
   start_[1] = 0;
   start_[2] = 0;
   count_[0] = 1;
   count_[1] = Ncatom();
   count_[2] = 3;
-  if (NC::CheckErr(nc_put_vara_float(ncid_,coordVID_,start_,count_,Coord_)) ) {
-    mprinterr("Error: Netcdf Writing coords frame %i\n", set+1);
-    return 1;
+
+  // Write coords.
+  if (coordVID_ != -1) {
+    DoubleToFloat(Coord_, frameOut.xAddress());
+    if (NC::CheckErr(nc_put_vara_float(ncid_,coordVID_,start_,count_,Coord_)) ) {
+      mprinterr("Error: NetCDF writing coordinates frame %i\n", set+1);
+      return 1;
+    }
   }
 
   // Write velocity.
   if (velocityVID_ != -1) {
     DoubleToFloat(Coord_, frameOut.vAddress());
     if (NC::CheckErr(nc_put_vara_float(ncid_, velocityVID_, start_, count_, Coord_)) ) {
-      mprinterr("Error: Netcdf writing velocity frame %i\n", set+1);
+      mprinterr("Error: NetCDF writing velocity frame %i\n", set+1);
       return 1;
     }
   }
@@ -352,7 +377,7 @@ int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
   if (frcVID_ != -1) {
     DoubleToFloat(Coord_, frameOut.fAddress());
     if (NC::CheckErr(nc_put_vara_float(ncid_, frcVID_, start_, count_, Coord_)) ) {
-      mprinterr("Error: Netcdf writing force frame %i\n", set+1);
+      mprinterr("Error: NetCDF writing force frame %i\n", set+1);
       return 1;
     }
   }
@@ -466,11 +491,27 @@ int Traj_AmberNetcdf::writeReservoir(int set, Frame const& frame, double energy,
 // Traj_AmberNetcdf::Info()
 void Traj_AmberNetcdf::Info() {
   mprintf("is a NetCDF AMBER trajectory");
-  if (readAccess_ && !HasCoords()) mprintf(" (no coordinates)");
-  if (CoordInfo().HasVel()) mprintf(" containing velocities");
-  if (CoordInfo().HasForce()) mprintf(" containing forces");
-  if (CoordInfo().HasTemp()) mprintf(" with replica temperatures");
-  if (remd_dimension_ > 0) mprintf(", with %i dimensions", remd_dimension_);
+  if (readAccess_) {
+    if (!HasCoords()) mprintf(" (no coordinates)");
+    if (useVelAsCoords_) mprintf(" (using velocities as coordinates)");
+    if (useFrcAsCoords_) mprintf(" (using forces as coordinates)");
+    if (HasVelocities() || HasForces() || HasTemperatures()) {
+      mprintf(" with");
+      if (HasVelocities()) mprintf(" velocities");
+      if (HasForces()) mprintf(" forces");
+      if (HasTemperatures()) mprintf(" temperatures");
+    }
+    if (remd_dimension_ > 0) mprintf(" %i replica dimensions", remd_dimension_);
+  } else {
+    if ( !(write_mdcrd_ && write_mdvel_ && write_mdfrc_) ) {
+      if (write_mdcrd_ || write_mdvel_ || write_mdfrc_) {
+        mprintf(" with");
+        if (write_mdcrd_) mprintf(" coordinates");
+        if (write_mdvel_) mprintf(" velocities");
+        if (write_mdfrc_) mprintf(" forces");
+      }
+    }
+  }
 }
 #ifdef MPI
 #ifdef HAS_PNETCDF

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -111,8 +111,10 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
   // Replica Dimensions
   ReplicaDimArray remdDim;
   if ( SetupMultiD(remdDim) == -1 ) return TRAJIN_ERR;
-  SetCoordInfo( CoordinateInfo(remdDim, nc_box, HasVelocities(),
-                               HasTemperatures(), HasTimes(), HasForces()) ); 
+  CoordinateInfo ncCoordInfo(remdDim, nc_box, HasVelocities(),
+                             HasTemperatures(), HasTimes(), HasForces());
+  ncCoordInfo.SetCrd( HasCoords() );
+  SetCoordInfo( ncCoordInfo ); 
   // NOTE: TO BE ADDED
   // labelDID;
   //int cell_spatialDID, cell_angularDID;

--- a/src/Traj_AmberNetcdf.h
+++ b/src/Traj_AmberNetcdf.h
@@ -46,8 +46,9 @@ class Traj_AmberNetcdf : public TrajectoryIO, private NetcdfFile {
     bool useFrcAsCoords_;
     bool readAccess_;
     bool outputTemp_;
-    bool outputVel_;
-    bool outputFrc_;
+    bool write_mdcrd_;
+    bool write_mdvel_;
+    bool write_mdfrc_;
 };
 // ----- INLINE FUNCTIONS ------------------------------------------------------
 int Traj_AmberNetcdf::createReservoir(bool hasBins, double reservoirT, int iseed) {

--- a/src/Traj_AmberRestart.cpp
+++ b/src/Traj_AmberRestart.cpp
@@ -56,10 +56,10 @@ void Traj_AmberRestart::closeTraj() {
 int Traj_AmberRestart::openTrajin() { return 0; }
 
 void Traj_AmberRestart::WriteHelp() {
-  mprintf("\tremdtraj  : Write temperature to restart file (will also write time).\n"
-          "\ttime0     : Time for first frame (if not specified time is not written).\n"
-          "\tdt        : Time step for subsequent frames, t=(time0+frame)*dt; (default 1.0)\n"
-          "\tkeepext   : Keep filename extension; write '<name>.<num>.<ext>' instead.\n");
+  mprintf("\tremdtraj: Write temperature to restart file (will also write time).\n"
+          "\ttime0   : Time for first frame (if not specified time is not written).\n"
+          "\tdt      : Time step for subsequent frames, t=(time0+frame)*dt; (default 1.0)\n"
+          "\tkeepext : Keep filename extension; write '<name>.<num>.<ext>' instead.\n");
 }
 
 // Traj_AmberRestart::processWriteArgs()

--- a/src/Traj_AmberRestart.cpp
+++ b/src/Traj_AmberRestart.cpp
@@ -16,8 +16,7 @@ Traj_AmberRestart::Traj_AmberRestart() :
   readAccess_(false),
   useVelAsCoords_(false),
   outputTemp_(false),
-  outputVel_(false),
-  outputTime_(false),
+  outputTime_(true), // For backwards compat.
   prependExt_(false)
 {}
 
@@ -57,9 +56,7 @@ void Traj_AmberRestart::closeTraj() {
 int Traj_AmberRestart::openTrajin() { return 0; }
 
 void Traj_AmberRestart::WriteHelp() {
-  mprintf("\tnovelocity: Do not write velocities to restart file.\n"
-          "\tnotime    : Do not write time to restart file.\n"
-          "\tremdtraj  : Write temperature to restart file (will also write time).\n"
+  mprintf("\tremdtraj  : Write temperature to restart file (will also write time).\n"
           "\ttime0     : Time for first frame (if not specified time is not written).\n"
           "\tdt        : Time step for subsequent frames, t=(time0+frame)*dt; (default 1.0)\n"
           "\tkeepext   : Keep filename extension; write '<name>.<num>.<ext>' instead.\n");
@@ -67,9 +64,6 @@ void Traj_AmberRestart::WriteHelp() {
 
 // Traj_AmberRestart::processWriteArgs()
 int Traj_AmberRestart::processWriteArgs(ArgList& argIn) {
-  // For write, assume we want velocities unless specified
-  outputVel_ = !argIn.hasKey("novelocity");
-  outputTime_ = !argIn.hasKey("notime");
   outputTemp_ = argIn.hasKey("remdtraj");
   time0_ = argIn.getKeyDouble("time0", -1.0);
   dt_ = argIn.getKeyDouble("dt",1.0);
@@ -97,7 +91,6 @@ int Traj_AmberRestart::setupTrajout(FileName const& fname, Topology* trajParm,
     outputTime_ = true;
     if (!cInfo.HasTime() && time0_ < 0.0) time0_ = 1.0;
   }
-  if (cInfo.HasVel() && !outputVel_) cInfo.SetVelocity(false);
   if (outputTime_) {
     if (!cInfo.HasTime() && time0_ >= 0) cInfo.SetTime(true);
   } else
@@ -386,12 +379,6 @@ void Traj_AmberRestart::Info() {
     else
       mprintf(", no velocities");
     if (useVelAsCoords_) mprintf(" (using velocities as coords)");
-  } else {
-    // If write, not sure yet whether velocities will be written since
-    // it also depends on if the frame has velocity info, so only state
-    // if novelocity was specified.
-    if (!outputVel_) mprintf(", no velocities");
-    if (!outputTime_) mprintf(", no time");
   }
 }
 #ifdef MPI

--- a/src/Traj_AmberRestart.h
+++ b/src/Traj_AmberRestart.h
@@ -48,7 +48,6 @@ class Traj_AmberRestart : public TrajectoryIO {
     bool readAccess_;      ///< If true, presence/absence of velocity info is known
     bool useVelAsCoords_;  ///< If true read velocities in as coordinates.
     bool outputTemp_;
-    bool outputVel_;
     bool outputTime_;
     bool prependExt_;    ///< If true prepend extension with # on write instead of append
     BufferedFrame file_; ///< Only needed for writes.

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -18,8 +18,6 @@ Traj_AmberRestartNC::Traj_AmberRestartNC() :
   useVelAsCoords_(false),
   useFrcAsCoords_(false),
   outputTemp_(false),
-  outputVel_(false),
-  outputTime_(false),
   readAccess_(false),
   prependExt_(false)
 {}
@@ -115,9 +113,7 @@ int Traj_AmberRestartNC::setupTrajin(FileName const& fname, Topology* trajParm)
 }
 
 void Traj_AmberRestartNC::WriteHelp() {
-  mprintf("\tnovelocity: Do not write velocities to restart file.\n"
-          "\tnotime    : Do not write time to restart file.\n"
-          "\tremdtraj  : Write temperature to restart file.\n"
+  mprintf("\tremdtraj  : Write temperature to restart file.\n"
           "\ttime0     : Time for first frame (default 1.0).\n"
           "\tdt        : Time step for subsequent frames, t=(time0+frame)*dt; (default 1.0)\n"
           "\tkeepext   : Keep filename extension; write '<name>.<num>.<ext>' instead.\n");
@@ -125,9 +121,6 @@ void Traj_AmberRestartNC::WriteHelp() {
 
 // Traj_AmberRestartNC::processWriteArgs()
 int Traj_AmberRestartNC::processWriteArgs(ArgList& argIn) {
-  // For write, assume we want velocities unless specified
-  outputVel_ = !argIn.hasKey("novelocity");
-  outputTime_ = !argIn.hasKey("notime");
   outputTemp_ = argIn.hasKey("remdtraj");
   prependExt_ = argIn.hasKey("keepext");
   time0_ = argIn.getKeyDouble("time0", -1.0);
@@ -148,11 +141,7 @@ int Traj_AmberRestartNC::setupTrajout(FileName const& fname, Topology* trajParm,
   readAccess_ = false;
   CoordinateInfo cInfo = cInfoIn;
   if (!cInfo.HasTemp() && outputTemp_) cInfo.SetTemperature(true);
-  if (cInfo.HasVel() && !outputVel_) cInfo.SetVelocity(false);
-  if (outputTime_) {
-    if (!cInfo.HasTime() && time0_ >= 0) cInfo.SetTime(true);
-  } else
-    cInfo.SetTime(false);
+  if (!cInfo.HasTime() && time0_ >= 0) cInfo.SetTime(true);
   SetCoordInfo( cInfo );
   filename_ = fname;
   n_atoms_ = trajParm->Natom();
@@ -322,8 +311,6 @@ void Traj_AmberRestartNC::Info() {
     if (remd_dimension_ > 0) mprintf(", with %i dimensions", remd_dimension_);
   } else {
     if (outputTemp_) mprintf(", with temperature");
-    if (!outputVel_) mprintf(", no velocities");
-    if (!outputTime_) mprintf(", no time");
   }
 }
 #ifdef MPI

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -113,10 +113,10 @@ int Traj_AmberRestartNC::setupTrajin(FileName const& fname, Topology* trajParm)
 }
 
 void Traj_AmberRestartNC::WriteHelp() {
-  mprintf("\tremdtraj  : Write temperature to restart file.\n"
-          "\ttime0     : Time for first frame (default 1.0).\n"
-          "\tdt        : Time step for subsequent frames, t=(time0+frame)*dt; (default 1.0)\n"
-          "\tkeepext   : Keep filename extension; write '<name>.<num>.<ext>' instead.\n");
+  mprintf("\tremdtraj: Write temperature to restart file.\n"
+          "\ttime0   : Time for first frame (default 1.0).\n"
+          "\tdt      : Time step for subsequent frames, t=(time0+frame)*dt; (default 1.0)\n"
+          "\tkeepext : Keep filename extension; write '<name>.<num>.<ext>' instead.\n");
 }
 
 // Traj_AmberRestartNC::processWriteArgs()

--- a/src/Traj_AmberRestartNC.h
+++ b/src/Traj_AmberRestartNC.h
@@ -40,8 +40,6 @@ class Traj_AmberRestartNC : public TrajectoryIO, private NetcdfFile {
     bool useVelAsCoords_;
     bool useFrcAsCoords_;
     bool outputTemp_;
-    bool outputVel_;
-    bool outputTime_;
     bool readAccess_;
     bool prependExt_;
     FileName filename_;

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -403,7 +403,7 @@ int Traj_NcEnsemble::writeArray(int set, FramePtrArray const& Farray) {
       return 1;
     }
     // Write velocity.
-    if (CoordInfo().HasVel() && frm->HasVelocity()) { // TODO: Determine V beforehand
+    if (velocityVID_ != -1) {
       DoubleToFloat(Coord_, frm->vAddress());
 #     ifdef HAS_PNETCDF
       if (ncmpi_put_vara_float_all(ncid_, velocityVID_, start_, count_, Coord_))

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -32,7 +32,8 @@ void Traj_NcEnsemble::WriteHelp() {
 }
 
 void Traj_NcEnsemble::ReadHelp() {
-  mprintf("\t[usevelascoords]\n");
+  mprintf("\tusevelascoords: Use velocities instead of coordinates if present.\n"
+          "\tusefrcascoords: Use forces instead of coordinates if present.\n");
 }
 
 // Traj_NcEnsemble::processWriteArgs()

--- a/src/Traj_SQM.cpp
+++ b/src/Traj_SQM.cpp
@@ -3,8 +3,7 @@
 #include "StringRoutines.h" // integerToString
 
 void Traj_SQM::WriteHelp() {
-  mprintf("\tcharge <c>: Set total integer charge. If not specified it will be calculated from"
-          " atomic charges.\n");
+  mprintf("\tcharge <c>: Specify total integer charge\n");
 }
 
 // Traj_SQM::processWriteArgs()

--- a/src/Trajin_Single.cpp
+++ b/src/Trajin_Single.cpp
@@ -42,8 +42,7 @@ TrajectoryIO* Trajin_Single::SetupSeparateTraj(FileName const& fname, const char
   return tio;
 }
 
-
-// TODO: Should this take a FileName instead of string?
+// Trajin_Single::SetupTrajRead()
 int Trajin_Single::SetupTrajRead(FileName const& tnameIn, ArgList& argIn, 
                                  Topology* tparmIn)
 {
@@ -65,7 +64,12 @@ int Trajin_Single::SetupTrajRead(FileName const& tnameIn, ArgList& argIn,
   // Set up the format for reading and get the number of frames.
   int nframes = trajio_->setupTrajin(Traj().Filename(), Traj().Parm());
   if (nframes == TrajectoryIO::TRAJIN_ERR) {
-    mprinterr("Error: Could not set up %s for reading.\n", Traj().Filename().full());
+    mprinterr("Error: Could not set up '%s' for reading.\n", Traj().Filename().full());
+    return 1;
+  }
+  // Coordinates must be present.
+  if (!trajio_->CoordInfo().HasCrd()) {
+    mprinterr("Error: No coordinates present in trajectory '%s'\n", Traj().Filename().full());
     return 1;
   }
   if (debug_ > 0) {


### PR DESCRIPTION
This PR gives users some more control over trajectory output via several new options. Several new options have been added to trajout:
```
[novelocity] [notemperature] [notime] [noforce] [noreplicadim]
```
All of these options function similarly to `nobox` in that they disable output of that type into the output trajectory.

In addition, several options have been added to NetCDF trajectory output:
```
mdvel   : Write only velocities to trajectory.
mdfrc   : Write only forces to trajectory.
mdcrd   : Write coordinates to trajectory (only required with mdvel/mdfrc).
```
This allows users to specify e.g. only forces be written, or forces and velocities, or coordinates and velocities, etc., to the NetCDF trajectory.

This also adds a check that throws a better error message when trying to read in a trajectory with no coordinates present (currently only relevant for NetCDF).