### PR TITLE
Fixes for COR format and 'rotdif'

### DIFF
--- a/src/Analysis_Rotdif.cpp
+++ b/src/Analysis_Rotdif.cpp
@@ -1398,13 +1398,16 @@ int Analysis_Rotdif::DetermineDeffsAlt() {
       namebuffer = corrOut_;
     else
       namebuffer = "CtFit.dat";
-    outfile.OpenWrite(namebuffer);
-    outfile.Printf("%-12s %20s %20s %20s\n", "#Time", "<Ct>", "SingleExp", "MultiExp");
-    CurveFit::Darray const& Ct_multi = fit.FinalY();
-    for (int n = 0; n != ctMax; n++)
-      outfile.Printf("%12.6g %20.8e %20.8e %20.8e\n",
-                     Xvals[n], CtTotal[n], Ct_single[n], Ct_multi[n]);
-    outfile.CloseFile();
+    if (outfile.OpenWrite(namebuffer))
+      mprinterr("Error: Could not write Ct and fit curves.\n");
+    else {
+      outfile.Printf("%-12s %20s %20s %20s\n", "#Time", "<Ct>", "SingleExp", "MultiExp");
+      CurveFit::Darray const& Ct_multi = fit.FinalY();
+      for (int n = 0; n != ctMax; n++)
+        outfile.Printf("%12.6g %20.8e %20.8e %20.8e\n",
+                       Xvals[n], CtTotal[n], Ct_single[n], Ct_multi[n]);
+      outfile.CloseFile();
+    }
   }
 
   return 0;
@@ -1599,11 +1602,14 @@ int Analysis_Rotdif::DetermineDeffs() {
         namebuffer = AppendNumber( corrOut_, nvec );
       else
         namebuffer = AppendNumber( "p1p2.dat", nvec );
-      outfile.OpenWrite(namebuffer);
-      for (int i = 0; i < maxdat; i++) 
-        //outfile.Printf("%lf %lf %lf\n",pX[i], p2[i], p1[i]);
-        outfile.Printf("%12.6g %20.8e\n",pX[i], pY[i]);
-      outfile.CloseFile();
+      if (outfile.OpenWrite(namebuffer))
+        mprinterr("Error: Could not write PX to file.\n");
+      else {
+        for (int i = 0; i < maxdat; i++) 
+          //outfile.Printf("%lf %lf %lf\n",pX[i], p2[i], p1[i]);
+          outfile.Printf("%12.6g %20.8e\n",pX[i], pY[i]);
+        outfile.CloseFile();
+      }
       //    Write Mesh
       if (debug_>3) {
         namebuffer = AppendNumber( "mesh.dat", nvec );

--- a/src/Traj_CharmmCor.cpp
+++ b/src/Traj_CharmmCor.cpp
@@ -53,6 +53,8 @@ int Traj_CharmmCor::setupTrajin(FileName const& fname, Topology* trajParm)
               corAtom_, trajParm->c_str(), trajParm->Natom());
     return TRAJIN_ERR;
   }
+  if (extendedFmt_)
+    mprintf("\tCOR file: extended format.\n");
   file_.CloseFile();
   // Just 1 frame.
   return 1;
@@ -85,9 +87,9 @@ int Traj_CharmmCor::readFrame(int set, Frame& frameIn) {
     }
     int ncrd;
     if (extendedFmt_)
-      ncrd = sscanf(buffer, "%*5i%*5i%*5s%*5s%10lf%10lf%10lf\n", xptr, xptr+1, xptr+2);
+      ncrd = sscanf(buffer, "%*10i%*10i%*10s%*10s%20lf%20lf%20lf", xptr, xptr+1, xptr+2);
     else
-      ncrd = sscanf(buffer, "%*10i%*10i%*10s%*10s%20lf%20lf%20lf\n", xptr, xptr+1, xptr+2);
+      ncrd = sscanf(buffer, "%*5i%*5i%*5s%*5s%10lf%10lf%10lf", xptr, xptr+1, xptr+2);
     if (ncrd != 3) {
       mprinterr("Error: Reading coordinates for COR atom %i (got %i)\n", at+1, ncrd);
       return 1;


### PR DESCRIPTION
- Fix reading extended format for CHARMM COR files.
- Fix potential segfault in `rotdif` command when `corrout` file can not be opened.
