### PR TITLE
Minor fixes to tests/Makefiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,7 +96,12 @@ clean:
 	cd cuda_kernels && $(MAKE) clean
 
 uninstall:
-	/bin/rm -f $(CPPTRAJBIN)/cpptraj $(CPPTRAJBIN)/cpp_ambpdb readline/libreadline.a $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX) cuda_kernels/libcpptraj_cuda.a
+	/bin/rm -f $(CPPTRAJBIN)/cpptraj$(SFX)$(EXE)
+	/bin/rm -f $(CPPTRAJBIN)/ambpdb$(EXE)
+	/bin/rm -f $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX)
+	cd readline && make uninstall
+	cd xdrfile && make uninstall
+	cd cuda_kernels && make uninstall
 
 # Header dependencies
 include cpptrajdepend

--- a/src/Makefile_at
+++ b/src/Makefile_at
@@ -102,12 +102,14 @@ ReadLine.o: ReadLine.cpp
 clean:
 	/bin/rm -f $(OBJECTS) pub_fft.o cpptraj$(SFX) AmbPDB.o ambpdb$(SFX) *.LIBCPPTRAJ.o
 	cd readline && $(MAKE) -f Makefile_at clean
+	cd xdrfile && $(MAKE) -f Makefile_at clean
 
 uninstall:
 	/bin/rm -f $(BINDIR)/cpptraj$(SFX) $(BINDIR)/cpptraj.OMP$(SFX) $(BINDIR)/cpptraj.MPI$(SFX)
 	/bin/rm -f $(BINDIR)/ambpdb$(SFX)
 	/bin/rm -f $(LIBDIR)/libcpptraj.*
 	cd readline && $(MAKE) -f Makefile_at uninstall
+	cd xdrfile && $(MAKE) -f Makefile_at uninstall
 
 # Header dependencies
 include cpptrajdepend

--- a/src/cuda_kernels/Makefile
+++ b/src/cuda_kernels/Makefile
@@ -30,6 +30,8 @@ $(TARGET): $(OBJECTS)
 clean:
 	/bin/rm -f *.o $(TARGET)
 
+uninstall: clean
+
 # Dependencies
 core_kernels.o: core_kernels.cu
 

--- a/src/xdrfile/Makefile_main
+++ b/src/xdrfile/Makefile_main
@@ -29,6 +29,8 @@ test: $(TARGET) xdrfile_c_test.o
 clean:
 	/bin/rm -f *.o $(TARGET) a.out test.trr test.xtc test.xdr
 
+uninstall: clean
+
 # Dependencies
 xdrfile.o: xdrfile.c xdrfile.h
 

--- a/test/Test_Cluster_TrajWrites/RunTest.sh
+++ b/test/Test_Cluster_TrajWrites/RunTest.sh
@@ -23,13 +23,6 @@ runanalysis cluster crdset CRD1 C1 :2-10 clusters 3 epsilon 4.0 \
 write lifetime.dat C1[Lifetime]
 EOF
 RunCpptraj "Cluster command test, coordinate writes."
-DoTest clusterinfo.txt.save clusterinfo.txt
-DoTest cluster.c0.save cluster.c0
-DoTest rep.1.crd.save rep.c8.1.crd
-DoTest single.save single
-DoTest avg.summary.dat.save avg.summary.dat
-DoTest lifetime.dat.save lifetime.dat
-DoTest Avg.c0.rst7.save Avg.c0.rst7 
 
 cat > cluster.in <<EOF
 parm ../tz2.parm7
@@ -40,6 +33,13 @@ runanalysis cluster crdset CRD1 readinfo infofile clusterinfo.txt \
             clusterout fromInfo
 EOF
 RunCpptraj "Cluster command test, coordinate writes using info file."
+DoTest clusterinfo.txt.save clusterinfo.txt
+DoTest cluster.c0.save cluster.c0
+DoTest rep.1.crd.save rep.c8.1.crd
+DoTest single.save single
+DoTest avg.summary.dat.save avg.summary.dat
+DoTest lifetime.dat.save lifetime.dat
+DoTest Avg.c0.rst7.save Avg.c0.rst7
 DoTest cluster.c0.save fromInfo.c0
 
 EndTest

--- a/test/Test_RotateDihedral/RunTest.sh
+++ b/test/Test_RotateDihedral/RunTest.sh
@@ -24,7 +24,7 @@ rotatedihedral crdset TZ2 increment -19.3431 :8@N :8@CA :8@CB :8@CG
 crdout TZ2 tz2.rotate.2.mol2
 EOF
 RunCpptraj "Rotate dihedral by increment"
-DoTest tz2.rotate.1.mol2.save tz2.rotate.1.mol2
+DoTest tz2.rotate.1.mol2.save tz2.rotate.2.mol2
 
 # Rotate as a TRAJ data set
 cat > rotate.in <<EOF


### PR DESCRIPTION
Some tests had issues under AmberTools since intermediate files are deleted after they are checked by default.

Makefile rules needed some updating.