### PR TITLE
Various improvements to PDB writing

### DIFF
--- a/src/CIFfile.cpp
+++ b/src/CIFfile.cpp
@@ -74,6 +74,8 @@ int CIFfile::DataBlock::GetColumnData(int NexpectedCols, BufferedLine& infile, b
       idx = 0;
     }
     const char *tkn = infile.NextToken();
+    // Skip blanks
+    if (tkn == 0) continue;
     idx++;
     //mprintf("DEBUG: Token %i '%s'\n", idx, tkn);
     if (isSerial && nReadCols == 0) {

--- a/src/PDBfile.cpp
+++ b/src/PDBfile.cpp
@@ -244,9 +244,9 @@ void PDBfile::WriteRecordHeader(PDB_RECTYPE Record, int anum, NameType const& na
   resName[4]='\0';
   atomName[4]='\0';
   // Residue number in PDB format can only be 4 digits wide
-  while (resnum>9999) resnum-=9999;
+  if (resnum > 9999) resnum = resnum % 9999;
   // Atom number in PDB format can only be 5 digits wide
-  while (anum>99999) anum-=99999;
+  if (anum > 99999) anum = anum % 99999;
   // Residue names in PDB format are 3 chars long, right-justified, starting
   // at column 18, while the alternate location indicator is column 17. 
   // However in Amber residues can be 4 characters long; in this case overwrite

--- a/src/PDBfile.cpp
+++ b/src/PDBfile.cpp
@@ -237,7 +237,7 @@ int PDBfile::pdb_Bonds(int* bnd) {
 // PDBfile::WriteRecordHeader()
 void PDBfile::WriteRecordHeader(PDB_RECTYPE Record, int anum, NameType const& name,
                                 char altLoc, NameType const& resnameIn, char chain, 
-                                int resnum, char icode)
+                                int resnum, char icode, const char* Elt)
 {
   char resName[5], atomName[5];
 
@@ -262,13 +262,18 @@ void PDBfile::WriteRecordHeader(PDB_RECTYPE Record, int anum, NameType const& na
   int rn_idx = 3;
   for (int i = rn_size - 1; i > -1; i--, rn_idx--)
     resName[rn_idx] = resnameIn[i];
-  // Atom names in PDB format start from col 14 when <= 3 chars, 13 when 4 chars.
-  if (name[3]!=' ') { // 4 chars
+  // Determine size in characters of element name if given.
+  int eNameChars = 0;
+  if (Elt != 0) eNameChars = strlen( Elt );
+  // For atoms with element names of 1 character, names in PDB format start
+  // from col 14 when <= 3 chars, 13 when 4 chars. Atoms with element names of
+  // 2 characters start from col 13.
+  if (eNameChars == 2 || name[3] != ' ') { // 4 chars or 2 char elt name
     atomName[0] = name[0];
     atomName[1] = name[1];
     atomName[2] = name[2];
     atomName[3] = name[3];
-  } else {            // <= 3 chars
+  } else {            // <= 3 chars or 1 char elt name
     atomName[0] = ' ';
     atomName[1] = name[0];
     atomName[2] = name[1];
@@ -328,7 +333,7 @@ void PDBfile::WriteCoord(PDB_RECTYPE Record, int anum, NameType const& name,
                          double X, double Y, double Z, float Occ, float B, 
                          const char* Elt, int charge, bool highPrecision) 
 {
-  WriteRecordHeader(Record, anum, name, altLoc, resnameIn,  chain, resnum, icode);
+  WriteRecordHeader(Record, anum, name, altLoc, resnameIn,  chain, resnum, icode, Elt);
   if (highPrecision)
     Printf("   %8.3f%8.3f%8.3f%8.4f%8.4f      %2s%2s\n", X, Y, Z, Occ, B, Elt, "");
   else
@@ -340,8 +345,8 @@ void PDBfile::WriteANISOU(int anum, NameType const& name,
                           NameType const& resnameIn, char chain, int resnum,
                           int u11, int u22, int u33, int u12, int u13, int u23,
                           const char* Elt, int charge)
-{
-  WriteRecordHeader(ANISOU, anum, name, ' ', resnameIn, chain, resnum, ' '); // TODO icode, altLoc
+{ // TODO icode, altLoc
+  WriteRecordHeader(ANISOU, anum, name, ' ', resnameIn, chain, resnum, ' ', Elt);
   Printf(" %7i%7i%7i%7i%7i%7i      %2s%2i\n", u11, u22, u33, 
          u12, u13, u23, Elt, charge);
 }

--- a/src/PDBfile.h
+++ b/src/PDBfile.h
@@ -35,7 +35,7 @@ class PDBfile : public CpptrajFile {
     // -------------------------------------------
     /// Write PDB record header.
     void WriteRecordHeader(PDB_RECTYPE, int, NameType const&, char,
-                           NameType const&, char, int, char);
+                           NameType const&, char, int, char, const char*);
     /// Write HETATM record using internal atom numbering
     void WriteHET(int, double, double, double);
     /// Write no-name ATOM record using internal atom numbering

--- a/src/Traj_PDBfile.cpp
+++ b/src/Traj_PDBfile.cpp
@@ -249,11 +249,15 @@ int Traj_PDBfile::setupTrajout(FileName const& fname, Topology* trajParm,
   resNames_.reserve( trajParm->Nres() );
   if (pdbres_) {
     for (Topology::res_iterator res = trajParm->ResStart();
-                                res != trajParm->ResEnd(); ++res) {
+                                res != trajParm->ResEnd(); ++res)
+    {
       NameType rname = res->Name();
+      // First check if this is water.
+      if ( res->NameIsSolvent() )
+        rname = "HOH ";
       // convert protein residue names back to more like PDBV3 format:
-      if (rname == "HID " || rname == "HIE " ||
-          rname == "HIP " || rname == "HIC "   )
+      else if (rname == "HID " || rname == "HIE " ||
+               rname == "HIP " || rname == "HIC "   )
         rname = "HIS ";
       else if (rname == "CYX " || rname == "CYM ")
         rname = "CYS ";
@@ -264,22 +268,26 @@ int Traj_PDBfile::setupTrajout(FileName const& fname, Topology* trajParm,
       else if (rname == "GLH ")
         rname = "GLU ";
       // also for nucleic acid names:
-      else if ( rname[2] == ' ' && rname[3] == ' ' ) {
-        // RNA names
-        if      ( rname[0] == 'G' ) rname="  G ";
-        else if ( rname[0] == 'C' ) rname="  C ";
-        else if ( rname[0] == 'A' ) rname="  A ";
-        else if ( rname[0] == 'U' ) rname="  U ";
-      } else if ( rname[0] == 'D' ) {
-        // DNA names
-        if      ( rname[1] == 'G' ) rname=" DG ";
-        else if ( rname[1] == 'C' ) rname=" DC ";
-        else if ( rname[1] == 'A' ) rname=" DA ";
-        else if ( rname[1] == 'T' ) rname=" DT ";
-      } else if ( rname == "URA" || rname == "URI" )
-        rname="  U ";
-      else if ( rname == "THY" )
-        rname=" DT ";
+      else if ( rname == "C3  " )  rname = "  C ";
+      else if ( rname == "U3  " )  rname = "  U ";
+      else if ( rname == "G3  " )  rname = "  G ";
+      else if ( rname == "A3  " )  rname = "  A ";
+      else if ( rname == "C5  " )  rname = "  C ";
+      else if ( rname == "U5  " )  rname = "  U ";
+      else if ( rname == "G5  " )  rname = "  G ";
+      else if ( rname == "A5  " )  rname = "  A ";
+      else if ( rname == "DC3 " )  rname = " DC ";
+      else if ( rname == "DT3 " )  rname = " DT ";
+      else if ( rname == "DG3 " )  rname = " DG ";
+      else if ( rname == "DA3 " )  rname = " DA ";
+      else if ( rname == "DC5 " )  rname = " DC ";
+      else if ( rname == "DT5 " )  rname = " DT ";
+      else if ( rname == "DG5 " )  rname = " DG ";
+      else if ( rname == "DA5 " )  rname = " DA ";
+      else if ( rname == "URA " || rname == "URI" )
+        rname = "  U ";
+      else if ( rname == "THY " )
+        rname = " DT ";
       else if ( rname == "GUA" || rname == "ADE" || rname == "CYT" ) {
         // Determine if RNA or DNA via existence of O2'
         bool isRNA = false;

--- a/src/Traj_PDBfile.cpp
+++ b/src/Traj_PDBfile.cpp
@@ -465,7 +465,7 @@ int Traj_PDBfile::writeFrame(int set, Frame const& frameOut) {
       // FIXME: Should anum not be incremented until after? 
       file_.WriteRecordHeader(PDBfile::TER, anum, "", ' ', resNames_[res],
                               chainID_[res], pdbTop_->Res(res).OriginalResNum(),
-                              pdbTop_->Res(res).Icode());
+                              pdbTop_->Res(res).Icode(), atom.ElementName());
       anum += ter_num_;
       ++terIdx;
     }

--- a/src/Traj_PDBfile.cpp
+++ b/src/Traj_PDBfile.cpp
@@ -318,6 +318,7 @@ int Traj_PDBfile::setupTrajout(FileName const& fname, Topology* trajParm,
   // Set up TER cards.
   TER_idxs_.clear();
   if (terMode_ == BY_RES) {
+    bool lastResWasSolvent = false;
     // Write a TER card every time residue of atom N+1 is not bonded to any
     // atom of residue of atom N. Do not do this for solvent.
     for (Topology::res_iterator res = trajParm->ResStart();
@@ -328,6 +329,8 @@ int Traj_PDBfile::setupTrajout(FileName const& fname, Topology* trajParm,
         // FIXME build this into the loop.
         if ( res+1 == trajParm->ResEnd() )
           TER_idxs_.push_back( res->LastAtom() - 1 );
+        else if ( lastResWasSolvent )
+          TER_idxs_.push_back( (res-1)->LastAtom() - 1 );
         else {
           int r2_first = (res+1)->FirstAtom();
           int r2_last  = (res+1)->LastAtom();
@@ -347,7 +350,9 @@ int Traj_PDBfile::setupTrajout(FileName const& fname, Topology* trajParm,
           if (!residues_are_bonded)
             TER_idxs_.push_back( res->LastAtom() - 1 );
         }
-      }
+        lastResWasSolvent = false;
+      } else
+        lastResWasSolvent = true;
     }
   } else if (terMode_ == BY_MOL) {
     // Write a TER card at the end of every molecule


### PR DESCRIPTION
- Atom names with 2 character element names are now correctly aligned on column 13 instead of 14.
- Fix conversion of nucleic acid residue names for `pdbres`.
- Water residue name now changed to `HOH` for `pdbres` to be consistent with PDB V3 standard.
- Residue numbers > 9999 and atom numbers > 99999 now wrap to 0 instead of 1 to make atom/residue counting easier.
- Fix potential segfault when reading CIF files.
- Make sure when `terbyres` is specified that `TER` cards are printed when going from solvent to solute as well as vice versa.

Should address #375