### PR TITLE
Fix handling of unit cell information in CHARMM trajectories

### DIFF
--- a/src/Box.cpp
+++ b/src/Box.cpp
@@ -165,6 +165,10 @@ bool Box::BadTruncOctAngle(double angle) {
   return (fabs( TRUNCOCTBETA_ - angle ) > TruncOctEps_);
 }
 
+bool Box::IsAngle(double angle, double tgt) {
+  return (fabs(tgt - angle) < Constants::SMALL);
+}
+
 // Box::SetBoxType()
 /** Determine box type (none/ortho/nonortho) based on box angles. */
 void Box::SetBoxType() {
@@ -188,6 +192,9 @@ void Box::SetBoxType() {
   else if ( IsTruncOct( box_[3] ) && IsTruncOct( box_[4] ) && IsTruncOct( box_[5] ) )
     // All 109.47, truncated octahedron
     btype_ = TRUNCOCT;
+  else if ( IsAngle(box_[3],60.0) && IsAngle(box_[4],90.0) && IsAngle(box_[5],60.0) )
+    // 60/90/60, rhombic dodecahedron
+    btype_ = RHOMBIC;
   else if (box_[3] == 0 && box_[4] != 0 && box_[5] == 0) {
     // Only beta angle is set (e.g. from Amber topology).
     if (box_[4] == 90.0) {
@@ -213,8 +220,8 @@ void Box::SetBoxType() {
     }
   }
   //if (debug_>0) mprintf("\tBox type is %s (beta=%lf)\n",TypeName(), box_[4]);
-  // Check for low-precision truncated octahedron angles.
   if (btype_ == TRUNCOCT) {
+    // Check for low-precision truncated octahedron angles.
     if ( BadTruncOctAngle(box_[3]) || BadTruncOctAngle(box_[4]) || BadTruncOctAngle(box_[5]) )
       mprintf("Warning: Low precision truncated octahedron angles detected (%g vs %g).\n"
               "Warning:   If desired, the 'box' command can be used during processing\n"

--- a/src/Box.h
+++ b/src/Box.h
@@ -62,6 +62,7 @@ class Box {
   private:
     static inline bool IsTruncOct(double);
     static inline bool BadTruncOctAngle(double);
+    static inline bool IsAngle(double,double);
     void SetBoxType();
 
     static const double TRUNCOCTBETA_;

--- a/src/Traj_CharmmDcd.h
+++ b/src/Traj_CharmmDcd.h
@@ -14,6 +14,7 @@ class Traj_CharmmDcd : public TrajectoryIO {
     int dcdframes_;          ///< Number of frames in DCD file.
     bool isBigEndian_;       ///< True if file is Big endian
     bool is64bit_;           ///< True if file is 64 bit
+    bool hasShapeMatrix_;    ///< Unit cell info is stored as shape matrix.
     unsigned int blockSize_; ///< Size of block bytes: 32 bit = 4, 64 bit = 8
     size_t dcd_dim_;         ///< Number of dimensions in DCD file.
     size_t boxBytes_;        ///< Number of bytes used by box coords if present.

--- a/src/Traj_CharmmDcd.h
+++ b/src/Traj_CharmmDcd.h
@@ -14,7 +14,6 @@ class Traj_CharmmDcd : public TrajectoryIO {
     int dcdframes_;          ///< Number of frames in DCD file.
     bool isBigEndian_;       ///< True if file is Big endian
     bool is64bit_;           ///< True if file is 64 bit
-    bool hasShapeMatrix_;    ///< Unit cell info is stored as shape matrix.
     unsigned int blockSize_; ///< Size of block bytes: 32 bit = 4, 64 bit = 8
     size_t dcd_dim_;         ///< Number of dimensions in DCD file.
     size_t boxBytes_;        ///< Number of bytes used by box coords if present.
@@ -24,6 +23,8 @@ class Traj_CharmmDcd : public TrajectoryIO {
     size_t coordinate_size_; ///< Size of X|Y|Z coord frame in bytes.
     int nfixedat_;           ///< Number of fixed atoms
     int nfreeat_;            ///< Number of free atoms
+    enum CType { UNKNOWN = 0, SHAPE, UCELL };
+    CType charmmCellType_;   ///< If SHAPE (default), unit cell info is stored as shape matrix.
     int* freeat_;            ///< Free atom indices
     float* xcoord_;          ///< Master coord array, start of X coords
     float* ycoord_;          ///< Pointer to start of Y coords in master coord array


### PR DESCRIPTION
CHARMM versions 22 and up store elements of the symmetric shape matrix, not unit cell parameters. This PR fixes cpptraj so it takes this into account during reads and writes. Also adds an option to write older CHARMM trajectories (`ucell`) with unit cell parameters instead. Also fixes detection of rhombic dodecahedron boxes.