### PR TITLE
Fix separate reference mask in 'drmsd' command

### DIFF
--- a/src/Action_DistRmsd.cpp
+++ b/src/Action_DistRmsd.cpp
@@ -24,7 +24,7 @@ Action::RetType Action_DistRmsd::Init(ArgList& actionArgs, ActionInit& init, int
   std::string rMaskExpr = actionArgs.GetMaskNext();
   if (rMaskExpr.empty())
     rMaskExpr = tMaskExpr;
-  REF_.SetRefMask( tMaskExpr );
+  REF_.SetRefMask( rMaskExpr );
  
   // Set up the RMSD data set
   drmsd_ = init.DSL().AddSet(DataSet::DOUBLE, actionArgs.GetStringNext(),"DRMSD");

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -1225,7 +1225,7 @@ int CpptrajState::RunNormal() {
     if (parmHasChanged) {
       // Set up actions for this parm
       if (actionList_.SetupActions( currentSetup, exitOnError_ )) {
-        mprintf("WARNING: Could not set up actions for %s: skipping.\n",
+        mprintf("Warning: Could not set up actions for %s: skipping.\n",
                 currentSetup.Top().c_str());
         continue;
       }


### PR DESCRIPTION
Bugfix: was always using target mask expression even if separate reference mask expression given.