### PR TITLE
Add 'include <cstdio>' to address OpenMPI problem.

### DIFF
--- a/src/FileIO_Mpi.cpp
+++ b/src/FileIO_Mpi.cpp
@@ -1,9 +1,7 @@
 #include "FileIO_Mpi.h"
 #ifdef MPI
-#ifdef MPICH_IGNORE_CXX_SEEK
-// Needed on some old Intel MPI platforms
+// Needed for some older Intel MPI and newer OpenMPI versions
 # include <cstdio>
-#endif
 // FileIO_Mpi::Open()
 int FileIO_Mpi::Open(const char *filename, const char *mode) {
   if (comm_.IsNull()) return 1;


### PR DESCRIPTION
Seems some new versions of OpenMPI need the `#include <cstdio>` directive as well as older versions of intel MPI. Just including cstdio does not seem to negatively affect other MPI distributions so always include it. I wish they would keep their interfaces consistent...

Addresses #402 