### PR TITLE
Minor improvements to FFT memory handling and 'corr'

### DIFF
--- a/src/Action_VelocityAutoCorr.cpp
+++ b/src/Action_VelocityAutoCorr.cpp
@@ -199,7 +199,8 @@ void Action_VelocityAutoCorr::Print() {
     // transformed array after FFT, every 3rd value will be the correlation
     // via dot products that we want (once it is normalized).
     unsigned int total_length = Vel_[0].Size() * 3;
-    CorrF_FFT pubfft( total_length );
+    CorrF_FFT pubfft;
+    pubfft.CorrSetup( total_length );
     ComplexArray data1 = pubfft.Array();
     //mprintf("Complex Array Size is %i (%i actual)\n", data1.size(), data1.size()*2);
     ProgressBar progress( Vel_.size() );

--- a/src/Analysis_Corr.cpp
+++ b/src/Analysis_Corr.cpp
@@ -64,12 +64,14 @@ Analysis::RetType Analysis_Corr::Setup(ArgList& analyzeArgs, AnalysisSetup& setu
   }
 
   // Setup output dataset
-  std::string corrname = "C(" + D1_->Meta().Legend();
-  if (D2_ != D1_) corrname += ("-" + D2_->Meta().Legend());
-  corrname += ")";
   Ct_ = setup.DSL().AddSet( DataSet::DOUBLE, dataset_name, "Corr" );
   if (Ct_ == 0) return Analysis::ERR;
-  Ct_->SetLegend( corrname );
+  if (dataset_name.empty()) {
+    std::string corrname = "C(" + D1_->Meta().Legend();
+    if (D2_ != D1_) corrname += ("-" + D2_->Meta().Legend());
+    corrname += ")";
+    Ct_->SetLegend( corrname );
+  }
   outfile->AddDataSet( Ct_ );
 
   if (calc_covar_)
@@ -115,7 +117,7 @@ Analysis::RetType Analysis_Corr::Analyze() {
     DataSet_1D const& set1 = static_cast<DataSet_1D const&>( *D1_ );
     DataSet_1D const& set2 = static_cast<DataSet_1D const&>( *D2_ );
     set1.CrossCorr( set2, *((DataSet_1D*)Ct_), lagmax_, calc_covar_, usefft_ );
-    mprintf("    CORRELATION COEFFICIENT %6s to %6s IS %10.4f\n",
+    mprintf("    CORRELATION COEFFICIENT %s to %s IS %.4f\n",
             D1_->legend(), D2_->legend(), set1.CorrCoeff( set2 ) );
   }
 

--- a/src/Analysis_Corr.cpp
+++ b/src/Analysis_Corr.cpp
@@ -120,6 +120,7 @@ Analysis::RetType Analysis_Corr::Analyze() {
 
   mprintf("    CORR: %u elements, max lag %i\n",Nelements,lagmax_);
 
+  Analysis::RetType err = Analysis::OK;
   if (D1_->Type() == DataSet::VECTOR) {
     DataSet_Vector const& set1 = static_cast<DataSet_Vector const&>( *D1_ );
     DataSet_Vector const& set2 = static_cast<DataSet_Vector const&>( *D2_ );
@@ -127,12 +128,13 @@ Analysis::RetType Analysis_Corr::Analyze() {
   } else {
     DataSet_1D const& set1 = static_cast<DataSet_1D const&>( *D1_ );
     DataSet_1D const& set2 = static_cast<DataSet_1D const&>( *D2_ );
-    set1.CrossCorr( set2, *((DataSet_1D*)Ct_), lagmax_, calc_covar_, usefft_ );
+    if (set1.CrossCorr( set2, *((DataSet_1D*)Ct_), lagmax_, calc_covar_, usefft_ ))
+      err = Analysis::ERR;
     double coeff = set1.CorrCoeff( set2 );
     mprintf("    CORRELATION COEFFICIENT %s to %s IS %.4f\n",
             D1_->legend(), D2_->legend(), coeff );
     Coeff_->Add(0, &coeff);
   }
 
-  return Analysis::OK;
+  return err;
 }

--- a/src/Analysis_Corr.h
+++ b/src/Analysis_Corr.h
@@ -15,8 +15,9 @@ class Analysis_Corr : public Analysis {
   private:
     DataSet *D1_;
     DataSet *D2_;
-    int lagmax_;
     DataSet* Ct_;
+    DataSet* Coeff_;
+    int lagmax_;
     bool usefft_;
     bool calc_covar_;
 };

--- a/src/Analysis_IRED.cpp
+++ b/src/Analysis_IRED.cpp
@@ -269,10 +269,10 @@ Analysis::RetType Analysis_IRED::Analyze() {
   ComplexArray data1_;
   if (drct_) {
     data1_.Allocate( Nframes );
-    corfdir_.Allocate( nsteps );
+    corfdir_.CorrSetup( nsteps );
   } else {
     // Initialize FFT
-    pubfft_.Allocate( Nframes );
+    pubfft_.CorrSetup( Nframes );
     data1_ = pubfft_.Array();
   }
   // ----- Cm(t) CALCULATION ---------------------

--- a/src/Analysis_Rotdif.cpp
+++ b/src/Analysis_Rotdif.cpp
@@ -1000,7 +1000,8 @@ int Analysis_Rotdif::fft_compute_corr(DataSet_Vector const& rotated_vectors, int
   pY.assign(nsteps, 0.0);
 
   // Calculate correlation fn
-  CorrF_FFT pubfft( n_of_vecs );
+  CorrF_FFT pubfft;
+  pubfft.CorrSetup( n_of_vecs );
   ComplexArray data1 = pubfft.Array();
   // Loop over m = -olegendre, ..., +olegendre
   for (int midx = -olegendre_; midx <= olegendre_; ++midx) { 

--- a/src/Analysis_Timecorr.cpp
+++ b/src/Analysis_Timecorr.cpp
@@ -231,10 +231,10 @@ Analysis::RetType Analysis_Timecorr::Analyze() {
     data1_.Allocate( frame );
     if (mode_ == CROSSCORR)
       data2_.Allocate( frame ); 
-    corfdir_.Allocate( nsteps ); 
+    corfdir_.CorrSetup( nsteps ); 
   } else {
     // Initialize FFT
-    pubfft_.Allocate( frame );
+    pubfft_.CorrSetup( frame );
     data1_ = pubfft_.Array();
     if (mode_ == CROSSCORR)
       data2_ = data1_;

--- a/src/Corr.cpp
+++ b/src/Corr.cpp
@@ -1,8 +1,11 @@
 #include "Corr.h"
-// CorrF_Direct::Allocate()
-void CorrF_Direct::Allocate(int stepsIn) {
+// CorrF_Direct::CorrSetup()
+int CorrF_Direct::CorrSetup(int stepsIn) {
   nsteps_ = stepsIn;
-  table_.resize(2*nsteps_, 0.0);
+  int memsize = 2 * nsteps_;
+  if (memsize < 0) return 1;
+  table_.resize(memsize, 0.0);
+  return 0;
 }
 
 // CorrF_Direct::AutoCorr()
@@ -49,9 +52,9 @@ void CorrF_Direct::CrossCorr(ComplexArray& data1, ComplexArray const& data2) {
 }
 
 // -----------------------------------------------------------------------------
-// CorrF_FFT::Allocate()
-void CorrF_FFT::Allocate(int stepsIn) {
-  pubfft_.SetupFFT_NextPowerOf2( stepsIn );
+// CorrF_FFT::CorrSetup()
+int CorrF_FFT::CorrSetup(int stepsIn) {
+  return pubfft_.SetupFFT_NextPowerOf2( stepsIn );
 }
 
 // CorrF_FFT::AutoCorr()

--- a/src/Corr.h
+++ b/src/Corr.h
@@ -13,8 +13,7 @@
 class CorrF_Direct {
   public:
     CorrF_Direct() : nsteps_(0) {}
-    CorrF_Direct(int stepsIn) : nsteps_(stepsIn), table_(2*nsteps_, 0.0) {}
-    void Allocate(int);
+    int CorrSetup(int);
     void AutoCorr(ComplexArray&);
     void CrossCorr(ComplexArray&, ComplexArray const&);
   private:
@@ -26,8 +25,7 @@ class CorrF_Direct {
 class CorrF_FFT {
   public:
     CorrF_FFT() {}
-    CorrF_FFT(int stepsIn) : pubfft_( stepsIn ) {}
-    void Allocate(int);
+    int CorrSetup(int);
     void AutoCorr(ComplexArray&);
     void CrossCorr(ComplexArray&, ComplexArray&);
     ComplexArray Array() { return ComplexArray( pubfft_.size() ); }

--- a/src/DataSet_1D.cpp
+++ b/src/DataSet_1D.cpp
@@ -145,7 +145,8 @@ int DataSet_1D::CrossCorr( DataSet_1D const& D2, DataSet_1D& Ct,
   double norm = 1.0;
   if ( usefft ) {
     // Calc using FFT
-    CorrF_FFT pubfft1(Nelements);
+    CorrF_FFT pubfft1;
+    if (pubfft1.CorrSetup(Nelements)) return 1;
     ComplexArray data1 = pubfft1.Array();
     data1.PadWithZero(Nelements);
     if (Meta().IsTorsionArray()) {

--- a/src/DataSet_Vector.cpp
+++ b/src/DataSet_Vector.cpp
@@ -80,7 +80,8 @@ int DataSet_Vector::CalcVectorCorr(DataSet_Vector const& V2, DataSet_1D& Ct,
   bool crosscorr = (&V2 != this);
   
   unsigned int arraySize = Nvecs * 3; // XYZ
-  CorrF_FFT pubfft( arraySize );
+  CorrF_FFT pubfft;
+  pubfft.CorrSetup( arraySize );
   ComplexArray data1 = pubfft.Array();
   data1.PadWithZero( arraySize );
   ComplexArray data2;

--- a/src/PubFFT.cpp
+++ b/src/PubFFT.cpp
@@ -11,8 +11,13 @@ extern "C" {
 }
 #endif
 
+/** \return Next power of 2 >= sizeIn.
++  * NOTE: This function is used when correlation is being calculated with
++  *       FFT. As such the value is multiplied by 2.0 (via the final '+ 1'
++  *       to provide enough space for zero padding to avoid end effects.
++  */
 inline static int NextPowOf2(int sizeIn) {
-  return (ldexp( 1.0, (int)(log((double)(4 * sizeIn - 1)) / log(2.0)) + 1));
+  return (ldexp( 1.0, (int)((log((double)sizeIn-1) / log(2.0)) + 1.0) + 1 ));
 }
 
 // CONSTRUCTOR
@@ -41,7 +46,7 @@ PubFFT::~PubFFT() {
 
 // CONSTRUCTOR
 PubFFT::PubFFT(int fft_sizeIn) {
-  fft_size_ = NextPowOf2( fft_sizeIn ) / 2;
+  fft_size_ = NextPowOf2( fft_sizeIn );
 # ifdef FFTW_FFT
   in_  = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * fft_size_);
   forwards_plan_  = fftw_plan_dft_1d(fft_size_, in_, in_, FFTW_FORWARD,  FFTW_ESTIMATE);
@@ -172,7 +177,7 @@ int PubFFT::Allocate(int sizeIn) {
 }
 
 // PubFFT::SetupFFT_NextPowerOf2()
-int PubFFT::SetupFFT_NextPowerOf2(int sizeIn) { return Allocate( NextPowOf2( sizeIn ) / 2 ); }
+int PubFFT::SetupFFT_NextPowerOf2(int sizeIn) { return Allocate( NextPowOf2( sizeIn ) ); }
 
 // PubFFT::SetupFFTforN()
 int PubFFT::SetupFFTforN(int sizeIn) { return Allocate( sizeIn ); }

--- a/src/PubFFT.cpp
+++ b/src/PubFFT.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath> // log, ldexp
 #include "PubFFT.h"
+#include "CpptrajStdio.h"
 
 #ifndef FFTW_FFT
 extern "C" {
@@ -10,15 +11,6 @@ extern "C" {
   void pubfft_back_(int&, double*, double*, int*); // Backward FFT
 }
 #endif
-
-/** \return Next power of 2 >= sizeIn.
-+  * NOTE: This function is used when correlation is being calculated with
-+  *       FFT. As such the value is multiplied by 2.0 (via the final '+ 1'
-+  *       to provide enough space for zero padding to avoid end effects.
-+  */
-inline static int NextPowOf2(int sizeIn) {
-  return (ldexp( 1.0, (int)((log((double)sizeIn-1) / log(2.0)) + 1.0) + 1 ));
-}
 
 // CONSTRUCTOR
 PubFFT::PubFFT() :
@@ -41,22 +33,6 @@ PubFFT::~PubFFT() {
   }
 # else
   if (saved_work_ != 0) delete[] saved_work_;
-# endif
-}
-
-// CONSTRUCTOR
-PubFFT::PubFFT(int fft_sizeIn) {
-  fft_size_ = NextPowOf2( fft_sizeIn );
-# ifdef FFTW_FFT
-  in_  = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * fft_size_);
-  forwards_plan_  = fftw_plan_dft_1d(fft_size_, in_, in_, FFTW_FORWARD,  FFTW_ESTIMATE);
-  backwards_plan_ = fftw_plan_dft_1d(fft_size_, in_, in_, FFTW_BACKWARD, FFTW_ESTIMATE);
-# else
-  saved_work_size_ = 4 * fft_size_;
-  std::fill(saved_factors_, saved_factors_+saved_factors_size_, 0);
-  saved_work_ = new double[ saved_work_size_ ];
-  std::fill(saved_work_, saved_work_+saved_work_size_, 0.0);
-  pubfft_init_( fft_size_, saved_work_, saved_factors_ );
 # endif
 }
 
@@ -147,7 +123,10 @@ void PubFFT::Back(ComplexArray& fft_array) {
 
 // PubFFT::Allocate()
 int PubFFT::Allocate(int sizeIn) {
-  if (sizeIn < 0) return 1;
+  if (sizeIn < 0) {
+    mprinterr("Error: Invalid memory size given for FFT (%i)\n", sizeIn);
+    return 1;
+  }
   fft_size_ = sizeIn;
 # ifdef FFTW_FFT
   // Destroy any existing plans/storage space, allocate new space.
@@ -168,12 +147,24 @@ int PubFFT::Allocate(int sizeIn) {
   if (saved_work_size_ > 0) {
     saved_work_ = new double[ saved_work_size_ ];
     std::fill(saved_work_, saved_work_+saved_work_size_, 0.0);
+  } else if (saved_work_size_ < 0) {
+    mprinterr("Error: Could not allocate memory for FFT; invalid size (%i)\n", saved_work_size_);
+    return 1;
   } else
     saved_work_ = 0;
   // NOTE: Should this be called if fft_size is 0?
   pubfft_init_( fft_size_, saved_work_, saved_factors_ );
 # endif
   return 0;
+}
+
+/** \return Next power of 2 >= sizeIn.
+  * NOTE: This function is used when correlation is being calculated with
+  *       FFT. As such the value is multiplied by 2.0 (via the final '+ 1'
+  *       to provide enough space for zero padding to avoid end effects.
+  */
+inline static int NextPowOf2(int sizeIn) {
+  return (ldexp( 1.0, (int)((log((double)sizeIn-1) / log(2.0)) + 1.0) + 1 ));
 }
 
 // PubFFT::SetupFFT_NextPowerOf2()

--- a/src/PubFFT.h
+++ b/src/PubFFT.h
@@ -17,6 +17,7 @@ class PubFFT {
     int size() const { return fft_size_; }
     void Forward(ComplexArray&);
     void Back(ComplexArray&);
+    /// Set up FFT with size == to next power of 2, times 2 for zero padding
     int SetupFFT_NextPowerOf2(int);
     int SetupFFTforN(int);
   private:

--- a/src/PubFFT.h
+++ b/src/PubFFT.h
@@ -9,8 +9,6 @@ class PubFFT {
   public:
     PubFFT();
     ~PubFFT();
-    /// Takes FFT size as input; ensures size is power of 2
-    PubFFT(int);
     PubFFT(const PubFFT&);
     PubFFT& operator=(const PubFFT&);
     /// \return FFT size in terms of number of complex numbers.


### PR DESCRIPTION
This PR cleans up code related to allocating memory for FFT calcs when pubfft is being used, and improves the code documentation. It also prints a more helpful error message when there are memory issues.

In addition, the `corr` analysis command now saves correlation coefficient as a 1 value data set with aspect `[coeff]`.