### PR TITLE
Make GIST handle water models with extra points.

### DIFF
--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -363,6 +363,7 @@ Action::RetType Action_GIST::Setup(ActionSetup& setup) {
         for (unsigned int IDX = 0; IDX != nMolAtoms_; IDX++) {
           Q_.push_back( setup.Top()[o_idx+IDX].Charge() );
           q_sum += Q_.back();
+          //mprintf("DEBUG: Q= %20.10E  q_sum= %20.10E\n", setup.Top()[o_idx+IDX].Charge(), q_sum);
         }
         // Sanity checks. FIXME Assuming H1 and H2 are indices 1 and 2
         if (NotEqual(Q_[1], Q_[2]))

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -103,15 +103,14 @@ class Action_GIST : public Action {
     CpptrajFile* eijfile_;     ///< Eij matrix output
     CpptrajFile* infofile_;    ///< GIST info
     std::string prefix_;       ///< Output file name prefix
+    Darray Q_;                 ///< Solvent molecule charges (for dipole calc)
     double BULK_DENS_;         ///< Bulk water density
     double temperature_;       ///< Temperature
-    double q_O_;               ///< Charge on water oxygen
-    double q_H1_;              ///< Charge on water H1
-    double q_H2_;              ///< Charge on water H2 (sanity check)
     double NeighborCut2_;      ///< Cutoff for determining water neighbors (squared).
     unsigned int MAX_GRID_PT_; ///< Max number of grid points (voxels).
     unsigned int NSOLVENT_;    ///< Number of solvent molecules.
     unsigned int N_ON_GRID_;   ///< Number of water atoms on the grid.*
+    unsigned int nMolAtoms_;   ///< Number of atoms in a water molecule.+
     int NFRAME_;               ///< Total # frames analyzed
     int max_nwat_;             ///< Max number of waters in any voxel
     bool doOrder_;             ///< If true do the order calc

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -45,6 +45,14 @@ namespace Constants {
   /// Convert Joules to calories
   const double J_TO_CAL = 1.0 / CAL_TO_J;
   /// Convert electron charge to Amber units (w/ prefactor)
+  /** NOTE: This value is actually very low precision, but is used since this
+    *       is the value used by LEaP. The actual conversion of Coulomb's
+    *       constant for use with Amber units (i.e. e-, Ang, and kcal/mol)
+    *       is (with NA representing Avogadro's number):
+    *         (8.987552e9 N*m^2/C^2) * (1.602177e-19 C/e-)^2 * (10^10 Ang/m) *
+    *         (1/4184 kcal/J) * NA = 332.06279350
+    *       The square root of this value is 18.222590197
+    */
   const double ELECTOAMBER  = 18.2223;
   /// Convert Amber charge to electron charge
   const double AMBERTOELEC  = 1.0 / ELECTOAMBER;


### PR DESCRIPTION
Addresses #412, at least for water. Also fixes a minor memory issue in the nonbond energy calculation (should not affect results).

Minor note: This warning pops up for TIP4PEW:
```
Warning: Charges on water do not sum to 0 (1.09756e-09)
```
Issue here is that when LEaP converts from e- to Amber units in the topology, there is some precision loss, so that when converting back in cpptraj the charges are slightly off. May need to handle this at some point.