### PR TITLE
Improvements to Travis to help prevent possible false positives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,14 @@ matrix:
     - { os: linux, env: COMPILER=gnu BUILD_FLAGS="-openmp -shared" OPT=openmp OMP_NUM_THREADS=1 BUILD_TYPE=libcpptraj TEST_TYPE=test.libcpptraj }
 
 before_install:
+  - set -e
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew tap homebrew/science;
       brew update;
       brew install netcdf fftw;
       curl -L https://anaconda.org/AmberMD/pysander/16.0/download/osx-64/pysander-16.0-py27_1.tar.bz2 > $HOME/osx_libsander.tar.bz2;
       tar jxf $HOME/osx_libsander.tar.bz2 lib/libsander.dylib include/sander.h;
+      shell_session_update() { echo "Overriding shell_session_update"; };
     else
       wget https://anaconda.org/AmberMD/pysander/16.0/download/linux-64/pysander-16.0-py27_1.tar.bz2;
       tar jxf pysander-16.0-py27_1.tar.bz2 lib/libsander.so include/sander.h;


### PR DESCRIPTION
Be more conservative about when to return an error (set -e means if any command results in a non-zero exit status, it kills the shell and returns non-zero).

Also work around this stupid thing on Mac Travis builds:

```
Done. Your build exited with 0.
/Users/travis/build.sh: line 148: shell_session_update: command not found
```