### PR TITLE
Add 'ucell' and 'shape' options to CHARMM Trajectory Read

### DIFF
--- a/src/Traj_CharmmDcd.h
+++ b/src/Traj_CharmmDcd.h
@@ -8,6 +8,7 @@ class Traj_CharmmDcd : public TrajectoryIO {
     Traj_CharmmDcd();
     static BaseIOtype* Alloc() { return (BaseIOtype*)new Traj_CharmmDcd(); }
     static void WriteHelp();
+    static void ReadHelp();
     ~Traj_CharmmDcd();
   private:
     int dcdatom_;            ///< Number of atoms in DCD file.
@@ -50,11 +51,11 @@ class Traj_CharmmDcd : public TrajectoryIO {
     int readFrame(int,Frame&);
     int writeFrame(int,Frame const&);
     void Info();
+    int processReadArgs(ArgList&);
     int processWriteArgs(ArgList&);
 
     int readVelocity(int, Frame&) { return 1; }
     int readForce(int, Frame&)    { return 1; }
-    int processReadArgs(ArgList&) { return 0; }
 #   ifdef MPI
     // Parallel functions
     int parallelOpenTrajin(Parallel::Comm const&);

--- a/src/TrajectoryFile.cpp
+++ b/src/TrajectoryFile.cpp
@@ -40,7 +40,7 @@ const FileTypes::AllocToken TrajectoryFile::TF_AllocArray[] = {
   { "PDB",                0, Traj_PDBfile::WriteHelp, Traj_PDBfile::Alloc        },
   { "Mol2",               0, Traj_Mol2File::WriteHelp, Traj_Mol2File::Alloc       },
   { "CIF",                0, 0, Traj_CIF::Alloc            },
-  { "Charmm DCD",         0, Traj_CharmmDcd::WriteHelp, Traj_CharmmDcd::Alloc      },
+  { "Charmm DCD",         Traj_CharmmDcd::ReadHelp, Traj_CharmmDcd::WriteHelp, Traj_CharmmDcd::Alloc      },
   { "Gromacs TRX",        0, Traj_GmxTrX::WriteHelp, Traj_GmxTrX::Alloc         },
 # ifdef NO_XDRFILE
   { "Gromacs XTC", 0, 0, 0                  },


### PR DESCRIPTION
Add `ucell` and `shape` options to CHARMM DCD `trajin` to force reading of box info as unit cell parameters or shape matrix respectively.