### PR TITLE
Using configure for win build (appveyor) + update libcpptraj.dll.a

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
   - sh -lc "mkdir lib/"
   - sh -lc "echo \"CPPTRAJBIN=$(pwd)/bin\" > config.h"
   - sh -lc "echo \"CPPTRAJLIB=$(pwd)/lib\" >> config.h"
-  - echo SHARED_SUFFIX=.lib >> config.h
+  - echo SHARED_SUFFIX=.dll.a >> config.h
   - echo LIBCPPTRAJ_TARGET=$(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX) >> config.h
   - echo INSTALL_TARGETS= install_cpptraj install_ambpdb >> config.h
   - echo DBGFLAGS= >> config.h

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ environment:
   matrix:
   - PRINTF_EXPONENT_DIGITS: "2"
 
+cache:
+  - /usr/local/lib/libnetcdf.a
+  
 install:
   - set HOME=.
   - set MSYSTEM=MINGW64
@@ -20,6 +23,8 @@ install:
       mingw-w64-x86_64-readline
       diffutils
     \""
+  - ls C:/msys64/usr/lib/
+  - ls C:/msys64/mingw64/lib
   - "sh -lc \"
      if [ ! -f /usr/local/lib/libnetcdf.a ]; then
        curl -fsS -o netcdf-4.3.3.zip ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.zip &&
@@ -34,15 +39,18 @@ install:
   \""
 
 build_script:
-  - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ --with-bzlib=/mingw64/ --with-zlib=/mingw64 -shared -windows gnu
+  - echo "hello"
+  # - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ --with-bzlib=/mingw64/ --with-zlib=/mingw64 -shared -windows gnu
 
 after_build:
-  - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h
-  - find C:/msys64/usr/local
+  - echo "hello"
+  # - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h
+  # - find C:/msys64/usr/local
 
 test_script:
-  - set TEST_OS=windows
-  - sh -lc "cd test; make test.showerrors"
+  - echo "hello"
+  # - set TEST_OS=windows
+  # - sh -lc "cd test; make test.showerrors"
 
-artifacts:
-  - path: cpptraj-$(APPVEYOR_BUILD_ID).zip
+# artifacts:
+#   - path: cpptraj-$(APPVEYOR_BUILD_ID).zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
 
 cache:
   - /usr/local/lib/libnetcdf.a
+  - /usr/local/include/
   
 install:
   - set HOME=.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   \""
 
 build_script:
-  - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ --with-bzlib=/mingw64/ --with-zlib=/mingw64 -shared -windows gnu
+  - sh configure --with-netcdf=/usr/local/ --with-blas=/mingw64/ -openblas --with-bzlib=/mingw64/ --with-zlib=/mingw64 --with-arpack=/mingw64 -shared -windows gnu
 
 after_build:
   - echo "hello"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,7 @@ install:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - where g++
-  - where gcc
+  - set CXX=C:/msys64/mingw64/bin/g++.exe
   - where gfortran
   - "sh -lc \"pacman -S --noconfirm --needed
       mingw-w64-x86_64-openblas
@@ -27,8 +26,6 @@ install:
       mingw-w64-x86_64-readline
       diffutils
     \""
-  - ls C:/msys64/usr/lib/
-  - ls C:/msys64/mingw64/lib
   - "sh -lc \"
      if [ ! -f /usr/local/lib/libnetcdf.a ]; then
        curl -fsS -o netcdf-4.3.3.zip ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.zip &&
@@ -43,8 +40,7 @@ install:
   \""
 
 build_script:
-  - echo "hello"
-  # - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ --with-bzlib=/mingw64/ --with-zlib=/mingw64 -shared -windows gnu
+  - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ --with-bzlib=/mingw64/ --with-zlib=/mingw64 -shared -windows gnu
 
 after_build:
   - echo "hello"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,16 +38,17 @@ install:
 
 build_script:
   - sh configure --with-netcdf=/usr/local/ --with-blas=/mingw64/ -openblas --with-bzlib=/mingw64/ --with-zlib=/mingw64 --with-arpack=/mingw64 --with-readline=/mingw64/ -shared -windows gnu
+  - make libcpptraj -j2
+  - make install -j2
 
 after_build:
   - echo "hello"
-  # - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h
-  # - find C:/msys64/usr/local
+  - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h
+  - find C:/msys64/usr/local
 
 test_script:
-  - echo "hello"
-  # - set TEST_OS=windows
-  # - sh -lc "cd test; make test.showerrors"
+  - set TEST_OS=windows
+  - sh -lc "cd test; make test.showerrors"
 
-# artifacts:
-#   - path: cpptraj-$(APPVEYOR_BUILD_ID).zip
+artifacts:
+  - path: cpptraj-$(APPVEYOR_BUILD_ID).zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ install:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
+  - where g++
+  - where gcc
+  - where gfortran
   - "sh -lc \"pacman -S --noconfirm --needed
       mingw-w64-x86_64-openblas
       mingw-w64-x86_64-arpack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,10 @@ install:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - set CC=x86_64-w64-mingw32-gcc.exe
-  - set CXX=x86_64-w64-mingw32-g++.exe
-  - set FC=x86_64-w64-mingw32-gfortran.exe
+  - set MINGWPREFIX=x86_64-w64-mingw32
+  - set CC=%MINGWPREFIX%-gcc.exe
+  - set CXX=%MINGWPREFIX%-g++.exe
+  - set FC=%MINGWPREFIX%-gfortran.exe
   - "sh -lc \"pacman -S --noconfirm --needed
       mingw-w64-x86_64-openblas
       mingw-w64-x86_64-arpack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,34 +34,7 @@ install:
   \""
 
 build_script:
-  - sh -lc "mkdir bin/"
-  - sh -lc "mkdir lib/"
-  - sh -lc "echo \"CPPTRAJBIN=$(pwd)/bin\" > config.h"
-  - sh -lc "echo \"CPPTRAJLIB=$(pwd)/lib\" >> config.h"
-  - echo SHARED_SUFFIX=.dll.a >> config.h
-  - echo LIBCPPTRAJ_TARGET=$(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX) >> config.h
-  - echo INSTALL_TARGETS= install_cpptraj install_ambpdb >> config.h
-  - echo DBGFLAGS= >> config.h
-  - echo CC=gcc >> config.h
-  - echo CXX=g++ >> config.h
-  - echo FC=gfortran >> config.h
-  - echo CFLAGS=   -O3 -Wall -DHASBZ2 -DHASGZ -DBINTRAJ -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/local/include -I/mingw64/include -Ixdrfile $(DBGFLAGS) >> config.h
-  - echo CXXFLAGS= -O3 -Wall -DHASBZ2 -DHASGZ -DBINTRAJ -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/local/include -I/mingw64/include -Ixdrfile $(DBGFLAGS) >> config.h
-  - echo FFLAGS=   -O3       -DHASBZ2 -DHASGZ -DBINTRAJ -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/local/include -I/mingw64/include -Ixdrfile -ffree-form $(DBGFLAGS) >> config.h
-  - echo READLINE_TARGET=/mingw64/lib/libreadline.a >> config.h
-  - echo READLINE_HOME=/mingw64/include/readline/ >> config.h
-  - echo XDRFILE=xdrfile/libxdrfile.a >> config.h
-  - echo XDRFILE_HOME=xdrfile >> config.h
-  - echo XDRFILE_TARGET=xdrfile/libxdrfile.a >> config.h
-  - echo FFT_DEPEND=pub_fft.o >> config.h
-  - echo FFT_LIB=pub_fft.o >> config.h
-  - echo LDFLAGS=-lreadline -ltermcap -larpack -L/usr/local/lib -lnetcdf -lopenblas -lbz2 -lz xdrfile/libxdrfile.a -lgfortran -lquadmath -w  -static >> config.h
-  - echo SFX= >> config.h
-  - echo EXE=.exe >> config.h
-  - sh -lc "cat config.h"
-  - sh -lc "make -j2 libcpptraj"
-  - sh -lc "make -j2 install"
-
+  - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ -shared -windows gnu
 
 after_build:
   - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   \""
 
 build_script:
-  - sh configure --with-netcdf=/usr/local/ --with-blas=/mingw64/ -openblas --with-bzlib=/mingw64/ --with-zlib=/mingw64 --with-arpack=/mingw64 -shared -windows gnu
+  - sh configure --with-netcdf=/usr/local/ --with-blas=/mingw64/ -openblas --with-bzlib=/mingw64/ --with-zlib=/mingw64 --with-arpack=/mingw64 --with-readline=/mingw64/ -shared -windows gnu
 
 after_build:
   - echo "hello"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ install:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - set CXX=C:/msys64/mingw64/bin/g++.exe
-  - ls C:/msys64/mingw64/bin/
-  - where gfortran
+  - set CC=x86_64-w64-mingw32-gcc.exe
+  - set CXX=x86_64-w64-mingw32-g++.exe
+  - set FC=x86_64-w64-mingw32-gfortran.exe
   - "sh -lc \"pacman -S --noconfirm --needed
       mingw-w64-x86_64-openblas
       mingw-w64-x86_64-arpack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
 
 after_build:
   - echo "hello"
-  - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h
+  - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.dll.a src/*.h
   - find C:/msys64/usr/local
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   \""
 
 build_script:
-  - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ -shared -windows gnu
+  - sh configure --with-netcdf=/usr/local/ --with-lapack=/mingw64/ --with-blas=/mingw64/ --with-arpack=/mingw64/ --with-bzlib=/mingw64/ --with-zlib=/mingw64 -shared -windows gnu
 
 after_build:
   - 7z a cpptraj-%APPVEYOR_BUILD_ID%.zip bin/ambpdb.exe bin/cpptraj.exe lib/libcpptraj.lib src/*.h

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,15 +7,12 @@ environment:
   matrix:
   - PRINTF_EXPONENT_DIGITS: "2"
 
-cache:
-  - /usr/local/lib/libnetcdf.a
-  - /usr/local/include/
-  
 install:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
   - set CXX=C:/msys64/mingw64/bin/g++.exe
+  - ls C:/msys64/mingw64/bin/
   - where gfortran
   - "sh -lc \"pacman -S --noconfirm --needed
       mingw-w64-x86_64-openblas

--- a/configure
+++ b/configure
@@ -687,7 +687,7 @@ while [[ ! -z $1 ]] ; do
       ;;
     "-windows")
       printf "WINDOWS support requested. Implies -static."
-      READLINE_TARGET="noreadline"
+      # READLINE_TARGET="noreadline"
       STATIC=1
       WINDOWS="yes"
       uname | grep -i linux > /dev/null 2>&1
@@ -699,6 +699,7 @@ while [[ ! -z $1 ]] ; do
         quadmath="-lquadmath"
       fi
       EXE=".exe"
+      SHARED_SUFFIX='.dll.a'
       ;;
     "-openblas")
       echo "Using OpenBLAS"


### PR DESCRIPTION
Why `libcpptraj.dll.a`?
- to be consistent with recent change in AMBER
- help pytraj (`libcpptraj.lib` is not recognized)

Also using `configure ...` script rather the hard-coded `config.h`.