### PR TITLE
add test pytraj build from master branch 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   override:
-    - bash utils/test_pytraj_build.sh
+    - bash util/test_pytraj_build.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker pull hainm/pytraj-manylinux-build-box
+
+test:
+  override:
+    - bash utils/test_pytraj_build.sh

--- a/util/test_pytraj_build.sh
+++ b/util/test_pytraj_build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/../"; pwd;)
+DOCKER_IMAGE=hainm/pytraj-manylinux-build-box
+
+docker info
+cat << EOF | docker run -i \
+                        -v ${FEEDSTOCK_ROOT}:/cpptraj \
+                        -a stdin -a stdout -a stderr \
+                        ${DOCKER_IMAGE}\
+                        bash || exit $?
+
+set -x
+cd /cpptraj/
+
+bash configure -shared -openmp gnu
+make libcpptraj -j4
+export CPPTRAJHOME=`pwd`
+
+git clone https://github.com/amber-md/pytraj
+cd pytraj
+python setup.py install
+# make sure we can run very simple test
+python run_tests.py -s
+EOF

--- a/util/test_pytraj_build.sh
+++ b/util/test_pytraj_build.sh
@@ -15,11 +15,11 @@ cd /cpptraj/
 
 bash configure -shared -openmp gnu
 make libcpptraj -j4
-export CPPTRAJHOME=`pwd`
+export CPPTRAJHOME=/cpptraj
 
 git clone https://github.com/amber-md/pytraj
 cd pytraj
-python setup.py install
+/opt/conda/bin/python setup.py install
 # make sure we can run very simple test
 python run_tests.py -s
 EOF

--- a/util/test_pytraj_build.sh
+++ b/util/test_pytraj_build.sh
@@ -19,7 +19,7 @@ export CPPTRAJHOME=/cpptraj
 
 git clone https://github.com/amber-md/pytraj
 cd pytraj
-/opt/conda/bin/python setup.py install
+/opt/python/cp35-cp35m/bin/python setup.py install
 # make sure we can run very simple test
-python run_tests.py -s
+/opt/python/cp35-cp35m/bin/python run_tests.py -s
 EOF


### PR DESCRIPTION
related to #442 

Since I won't have much time to keep track of cpptraj change closely, it's great if you can add pytraj build
with cpptraj. We should always make the amber-md/{cpptraj, pytraj} master branch stable and keep them sync.

I add circleci integration to avoid slowing down travis. You need to activate `cpptraj` by yourself (which is similar to travis): https://circleci.com/gh/hainm/cpptraj/202

This PR should be merged (if you're ok) after you have a look at #442 (again, if you're ok).