### PR TITLE
Make sure when data sets are cleared they are also cleared from data files.

### DIFF
--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -319,6 +319,9 @@ int CpptrajState::ClearList( ArgList& argIn ) {
   }
   if ( enabled[L_DATASET]  ) {
     mprintf("\tClearing data sets.\n");
+    // Make sure sets are cleared from data files as well.
+    for (DataSetList::const_iterator ds = DSL_.begin(); ds != DSL_.end(); ++ds)
+      DFL_.RemoveDataSet( *ds );
     DSL_.Clear();
   }
   return 0;


### PR DESCRIPTION
Fixes potential segfault when listing DataFiles after a `clear datasets`.