### PR TITLE
Do not automatically disable ARPACK when -macAccelerate specified

### DIFF
--- a/configure
+++ b/configure
@@ -672,7 +672,6 @@ while [[ ! -z $1 ]] ; do
       lgfortran=""
       BLAS="-framework Accelerate"
       LAPACK=""
-      ARPACK=""
       ;;
     "-nosanderlib"  ) USE_SANDERLIB=0 ;;
     "-nobzlib"      )


### PR DESCRIPTION
Can be disabled explicitly via `-noarpack` if desired.