### PR TITLE
Option for writing TER to PDB based on original TER info/chain ID

### DIFF
--- a/src/Residue.h
+++ b/src/Residue.h
@@ -5,21 +5,22 @@
 /// Hold information for a residue.
 class Residue {
   public:
-    Residue() : resname_(""), firstAtom_(0), lastAtom_(0), icode_(' '), chainID_(' ') {}
+    Residue() : resname_(""), firstAtom_(0), lastAtom_(0), icode_(' '), chainID_(' '), isTerminal_(false) {}
     /// CONSTRUCTOR - Copy given Residue, set first and last atom indices.
     Residue(Residue const& r, int first, int last) :
       resname_(r.resname_), firstAtom_(first), lastAtom_(last),
-      originalResNum_(r.originalResNum_), icode_(r.icode_), chainID_(r.chainID_)
+      originalResNum_(r.originalResNum_), icode_(r.icode_), chainID_(r.chainID_), isTerminal_(false)
     {}
     /// CONSTRUCTOR - Res name, original resnum, icode, chain ID
     Residue(NameType const& n, int r, char ic, char cid) :
-            resname_(n), originalResNum_(r), icode_(ic), chainID_(cid) {}
+            resname_(n), originalResNum_(r), icode_(ic), chainID_(cid), isTerminal_(false) {}
     inline void SetFirstAtom(int i)        { firstAtom_ = i;      }
     inline void SetLastAtom(int i)         { lastAtom_ = i;       }
     inline void SetOriginalNum(int i)      { originalResNum_ = i; }
     inline void SetIcode(char c)           { icode_ = c;          }
     inline void SetChainID(char c)         { chainID_ = c;        }
     inline void SetName(NameType const& n) { resname_ = n;        }
+    inline void SetTerminal(bool t)        { isTerminal_ = t;     }
     /// \return First atom in residue, indexing from 0
     inline int FirstAtom()        const { return firstAtom_;      }
     /// \return Atom _after_ the last in residue, indexing from 0
@@ -29,6 +30,7 @@ class Residue {
     inline char ChainID()         const { return chainID_;        }
     inline const char *c_str()    const { return *resname_;       }
     inline NameType const& Name() const { return resname_;        }
+    inline bool IsTerminal()      const { return isTerminal_;     }
     inline int NumAtoms()         const { return (lastAtom_ - firstAtom_); }
     inline bool NameIsSolvent()   const {
       return (resname_=="WAT " || resname_=="HOH " || resname_=="TIP3" ||
@@ -46,6 +48,7 @@ class Residue {
     int lastAtom_;       ///< Atom index after last atom in residue.
     int originalResNum_; ///< Original residue number.
     char icode_;         ///< Residue insertion code.
-    char chainID_;
+    char chainID_;       ///< Residue chain ID
+    bool isTerminal_;    ///< True if residue was originally a terminal residue
 };
 #endif

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -290,6 +290,7 @@ void Topology::StartNewMol() {
     //mprintf("DEBUG:\tMolecule %zu, atoms %i to %zu\n",
     //       molecules_.size(), lastAtom, atoms_.size());
   }
+  residues_.back().SetTerminal( true );
 }
 
 // Topology::CommonSetup()

--- a/src/Traj_PDBfile.h
+++ b/src/Traj_PDBfile.h
@@ -18,7 +18,7 @@ class Traj_PDBfile: public TrajectoryIO {
     static BaseIOtype* Alloc() { return (BaseIOtype*)new Traj_PDBfile(); }
     static void WriteHelp();
   private:
-    enum TER_Mode { BY_MOL = 0, BY_RES = 1, NO_TER = 2 };
+    enum TER_Mode { BY_MOL = 0, BY_RES, ORIGINAL_PDB, NO_TER };
     enum Radii_Mode { GB = 0, PARSE, VDW };
     Radii_Mode radiiMode_; ///< Radii to use if PQR.
     TER_Mode terMode_;     ///< TER card mode.


### PR DESCRIPTION
New option for PDB write: `pdbter`. This will write TER cards to output PDB based on placement of original TER cards or when chain ID changes. If no chain ID/TER info present, defaults back to `terbyres`.