### PR TITLE
Add 'pdbres' keyword to atomicfluct byres output to use original PDB numbering.

### DIFF
--- a/src/Action_AtomicFluct.h
+++ b/src/Action_AtomicFluct.h
@@ -26,6 +26,7 @@ class Action_AtomicFluct : public Action, ActionFrameCounter {
     int sets_;
     bool bfactor_;
     bool calc_adp_;
+    bool usePdbRes_;
     CpptrajFile* adpoutfile_;
     std::string outfilename_;
     Topology *fluctParm_;


### PR DESCRIPTION
(If pdb numbering available). Also add/cleanup some informational output. Partially address #459.