### PR TITLE
Additional output options

### DIFF
--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -32,7 +32,7 @@ Cpptraj::~Cpptraj() { Command::Free(); }
 void Cpptraj::Usage() {
   mprinterr("\n"
             "Usage: cpptraj [-p <Top0>] [-i <Input0>] [-y <trajin>] [-x <trajout>]\n"
-            "               [-c <reference>] [-d <datain>] [-w <dataout>]\n"
+            "               [-c <reference>] [-d <datain>] [-w <dataout>] [-o <output>]\n"
             "               [-h | --help] [-V | --version] [--defines] [-debug <#>]\n"
             "               [--interactive] [--log <logfile>] [-tl]\n"
             "               [-ms <mask>] [-mr <mask>] [--mask <mask>] [--resmask <mask>]\n"
@@ -44,6 +44,7 @@ void Cpptraj::Usage() {
             "\t-c <reference>   : Read <reference> as reference coordinates; same as input 'reference <reference>'.\n"
             "\t-d <datain>      : Read data in from file <datain> ('readdata <datain>').\n"
             "\t-w <dataout>     : Write data from <datain> as file <dataout> ('writedata <dataout>).\n"
+            "\t-o <output>      : Write CPPTRAJ STDOUT output to file <output>.\n"
             "\t-h | --help      : Print command line help and exit.\n"
             "\t-V | --version   : Print version and exit.\n"
             "\t--defines        : Print compiler defines and exit.\n"
@@ -142,6 +143,7 @@ int Cpptraj::RunCpptraj(int argc, char** argv) {
   else
     mprinterr("Error: Error(s) occurred during execution.\n");
   mprintf("\n");
+  FinalizeIO();
   return err;
 }
 
@@ -331,6 +333,14 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
     } else if (arg == "-i" && i+1 != argc) {
       // -i: Input file(s)
       AddFiles( inputFiles, argc, argv, i );
+    } else if (arg == "-o" && i+1 != argc) {
+      // -o: Output file
+      FileName ofilename(argv[++i]);
+      if (ofilename.empty()) {
+        mprinterr("Error: Could not set up output file with name '%s'\n", ofilename.full());
+        return ERROR;
+      }
+      if (OutputToFile(ofilename.full())) return ERROR;
     } else if (arg == "-ms" && i+1 != argc) {
       // -ms: Parse mask string, print selected atom #s
       if (ProcessMask( topFiles, refFiles, std::string(argv[++i]), false, false )) return ERROR;

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -300,7 +300,10 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
     }
     if ( arg == "--interactive" )
       interactive = true;
-    else if ( arg == "-debug" && i+1 != argc) {
+    else if ( arg == "--suppress-all-output") {
+      mprintf("Info: All further output will be suppressed.\n");
+      SuppressAllOutput();
+    } else if ( arg == "-debug" && i+1 != argc) {
       // -debug: Set overall debug level
       ArgList dbgarg( argv[++i] );
       State_.SetListDebug( dbgarg );

--- a/src/CpptrajStdio.cpp
+++ b/src/CpptrajStdio.cpp
@@ -150,3 +150,24 @@ void SetWorldSilent(bool silentIn) {
 void SuppressAllOutput() { world_io_level_ = IO_STAY_SILENT; }
 
 void SuppressErrorMsg(bool suppressIn) { suppressErrorMsg_ = suppressIn; }
+
+void FinalizeIO() {
+  if (STDOUT_ != stdout) {
+    fclose(STDOUT_);
+    STDOUT_ = stdout;
+  }
+}
+
+/** Redirect output to file. If no name given assume STDOUT. */
+int OutputToFile(const char* fname) {
+  FinalizeIO();
+  if (fname != 0) {
+    mprintf("Info: Redirecting output to file '%s'\n", fname);
+    STDOUT_ = fopen(fname, "wb");
+    if (STDOUT_ == 0) {
+      loudPrinterr("Error: Could not open output file '%s'\n", fname);
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/src/CpptrajStdio.cpp
+++ b/src/CpptrajStdio.cpp
@@ -6,13 +6,13 @@
 
 enum IO_LEVEL_TYPE {
   IO_ALL = 0,    // Normal output
-  IO_SILENT,     // Supress STDOUT output
-  IO_STAY_SILENT // Supress All STDOUT output forever.
+  IO_SILENT,     // Suppress STDOUT output
+  IO_STAY_SILENT // Suppress All STDOUT output forever.
 };
 /// Controls mprintf/rprintf output.
 static IO_LEVEL_TYPE world_io_level = IO_ALL;
 /// Controls mprinterr/rprinterr output.
-static bool supressErrorMsg = false;
+static bool suppressErrorMsg = false;
 
 // mflush()
 /** Call flush on STDOUT only if this is the master thread */
@@ -34,7 +34,7 @@ void loudPrintf(const char* format, ...) {
   va_end(args);
 }
 
-/** Print message to STDERR even if supressErrorMsg */
+/** Print message to STDERR even if suppressErrorMsg */
 void loudPrinterr(const char *format, ...) {
 # ifdef MPI
   if (!Parallel::World().Master()) return;
@@ -86,7 +86,7 @@ void mprintf(const char *format, ...) {
 
 /** Print message to STDERR only if this is the master thread */
 void mprinterr(const char *format, ...) {
-  if (supressErrorMsg) return;
+  if (suppressErrorMsg) return;
 # ifdef MPI
   if (!Parallel::World().Master()) return;
 # endif
@@ -118,7 +118,7 @@ void rprintf(const char *format, ...) {
 /** Print message to STDERR for this worldrank */
 void rprinterr(const char *format, ...) {
   va_list args;
-  if (supressErrorMsg) return;
+  if (suppressErrorMsg) return;
   va_start(args,format);
 # ifdef MPI
   char buffer[1024];
@@ -131,7 +131,7 @@ void rprinterr(const char *format, ...) {
   va_end(args);
 }
 
-/** Change status of STDOUT output as long as SupressAllOutput has not
+/** Change status of STDOUT output as long as SuppressAllOutput has not
   * been called.
   * \param silentIn if true, silence STDOUT output, otherwise enable.
   */
@@ -144,7 +144,7 @@ void SetWorldSilent(bool silentIn) {
   }
 }
 
-/** Supress all STDOUT output for the entire run. */
-void SupressAllOutput() { world_io_level = IO_STAY_SILENT; }
+/** Suppress all STDOUT output for the entire run. */
+void SuppressAllOutput() { world_io_level = IO_STAY_SILENT; }
 
-void SupressErrorMsg(bool supressIn) { supressErrorMsg = supressIn; }
+void SuppressErrorMsg(bool suppressIn) { suppressErrorMsg = suppressIn; }

--- a/src/CpptrajStdio.h
+++ b/src/CpptrajStdio.h
@@ -17,7 +17,6 @@ void mprinterr(const char *, ...);
 void rprintf(const char *, ...);
 void rprinterr(const char *, ...);
 void SetWorldSilent(bool);
+void SupressAllOutput();
 void SupressErrorMsg(bool);
-//void printerr(const char *, const char *, ...);
-//void printwar(const char *, const char *, ...);
 #endif

--- a/src/CpptrajStdio.h
+++ b/src/CpptrajStdio.h
@@ -17,6 +17,6 @@ void mprinterr(const char *, ...);
 void rprintf(const char *, ...);
 void rprinterr(const char *, ...);
 void SetWorldSilent(bool);
-void SupressAllOutput();
-void SupressErrorMsg(bool);
+void SuppressAllOutput();
+void SuppressErrorMsg(bool);
 #endif

--- a/src/CpptrajStdio.h
+++ b/src/CpptrajStdio.h
@@ -19,4 +19,6 @@ void rprinterr(const char *, ...);
 void SetWorldSilent(bool);
 void SuppressAllOutput();
 void SuppressErrorMsg(bool);
+void FinalizeIO();
+int OutputToFile(const char*);
 #endif


### PR DESCRIPTION
This PR adds a new command line flag, `-o <output>`, for redirecting STDOUT output to a file. Also adds a hidden command line flag `--suppress-all-output` and internal function `SuppressAllOutput()` which can be used to suppress all STDOUT output, which should hopefully address #85.