### PR TITLE
Fix error with PGI compilers

### DIFF
--- a/src/KDE.cpp
+++ b/src/KDE.cpp
@@ -50,7 +50,7 @@ int KDE::CalcKDE(DataSet_double& Out, DataSet_1D const& Pdata) const {
   M2 /= (N - 1.0);
   double stdev = sqrt(M2);
   double step = 0.0;
-  int bins = (int)sqrt(Pdata.Size());
+  int bins = (int)sqrt((double)Pdata.Size());
 /*
   std::sort(data.begin(), data.end());
   double min = data.front();


### PR DESCRIPTION
```
"KDE.cpp", line 53: error: more than one instance of overloaded function "sqrt"
          matches the argument list:
            function "sqrt(double)"
            function "std::sqrt(long double)"
            function "std::sqrt(float)"
            argument types are: (size_t)
    int bins = (int)sqrt(Pdata.Size());
```
Need to explicitly cast to double.