### PR TITLE
Add check to configure to see if flag needed for older MPI versions

### DIFF
--- a/configure
+++ b/configure
@@ -1251,6 +1251,26 @@ if [[ $USEMPI -ne 0 ]] ; then
     CXX=mpiicpc
     FC=mpiifort
   fi
+  # Older Intel compilers have a problem with the order of stdio vs mpi
+  cat > testp.cpp <<EOF
+#include <cstdio>
+#include <mpi.h>
+int main() { printf("Testing a C++ MPI program.\n"); return 0; }
+EOF
+  $CXX -o testp testp.cpp > /dev/null 2> compile.err 
+  if [ "$?" -ne 0 ] ; then
+    # Try to fix with -DMPICH_IGNORE_CXX_SEEK
+    $CXX -o testp -DMPICH_IGNORE_CXX_SEEK testp.cpp > /dev/null 2> compile.err
+    if [ "$?" -eq 0 ] ; then
+      # That worked. Add to CXXFLAGS
+      CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"
+    else
+      echo "Error: Could not compile an MPI program with $CXX." > /dev/stderr
+      cat compile.err
+      exit 1
+    fi
+  fi
+  rm -f testp.cpp testp compile.err
 fi
 
 # Set up compiler flags if not already set


### PR DESCRIPTION
Specifically in this case Intel MPI before version 5, but check for all just in case.

Related to http://bugzilla.ambermd.org/show_bug.cgi?id=342

Some pertinent details from the bug report follow:
```
This problem is specific to older versions of Intel MPI - other MPI
libraries should work fine. This happens because both stdio.h and the MPI C++
interface use SEEK_SET, SEEK_CUR, and SEEK_END. Although Intel claims (and is
correct) that this is a bug in the MPI version 2 standard, it's something that
only older versions of Intel MPI have a problem with. The issue is resolved in
newer versions.
```