### PR TITLE
Improve 'pairwise' memory usage.

### DIFF
--- a/src/Action_Pairwise.h
+++ b/src/Action_Pairwise.h
@@ -26,6 +26,8 @@ class Action_Pairwise: public Action {
     typedef std::vector<double> Darray;
     enum EoutType {VDWOUT = 0, ELECOUT};
     enum PairCalcType { SET_REF, COMPARE_REF, NORMAL };
+    enum PrintModeType { ONLY_CUT = 0, OR_CUT, AND_CUT };
+    PrintModeType printMode_;  ///< Output print mode.
     PairCalcType nb_calcType_; ///< Type of nonbonded calc being performed
     AtomMask Mask0_;           ///< Calculate energy for atoms in mask
     AtomMask RefMask_;         ///< Reference mask
@@ -54,8 +56,6 @@ class Action_Pairwise: public Action {
     };
     /// Hold nonbond energy for each pair of atoms in reference
     std::vector<NonbondEnergyType> ref_nonbondEnergy_;
-    /// Hold cumulative LJ and elec energy for each atom
-    //std::vector<NonbondEnergyType> atom_nonbondEnergy;
 
     /// Count number of pairwise interactions that will actually be calcd.
     static int SetupNonbondParm(AtomMask const&, Topology const&);

--- a/src/Action_Pairwise.h
+++ b/src/Action_Pairwise.h
@@ -57,8 +57,8 @@ class Action_Pairwise: public Action {
     /// Hold cumulative LJ and elec energy for each atom
     //std::vector<NonbondEnergyType> atom_nonbondEnergy;
 
-    /// Set up nonbondParm for given Parm and atoms in mask
-    int SetupNonbondParm(AtomMask const&, Topology const&);
+    /// Count number of pairwise interactions that will actually be calcd.
+    static int SetupNonbondParm(AtomMask const&, Topology const&);
     /// Write energies to file
     inline void WriteEnergies(Topology const&, int, int, double, double, const char*);
     /// Calculate nonbond energy using nonbondParm for given frame


### PR DESCRIPTION
Improve `pairwise` memory usage by only storing atom pair energies that are calculated. Also fixes up determination of number of interactions that will be calculated.

Introduce 2 new options for printout (first is the original and remains default):
```
  printmode only : Only print energy cutoff is satisfied.
            or   : Print both energies if either cutoff is satisfied.
            and  : Print both energies if both cutoffs are satisfied.
```