### PR TITLE
Properly allocate reference trajectory frame for '2drms'

### DIFF
--- a/src/Analysis_Rms2d.cpp
+++ b/src/Analysis_Rms2d.cpp
@@ -197,8 +197,8 @@ Analysis::RetType Analysis_Rms2d::Analyze() {
   */
 int Analysis_Rms2d::CalcRmsToTraj() {
   float R = 0.0;
+  Frame RefFrame = RefTraj_->AllocateFrame();
   // Setup reference frame for selected reference atoms
-  Frame RefFrame( RefParm_->Atoms() );
   Frame SelectedRef( RefFrame, RefMask_ );
   size_t totalref = RefTraj_->Size();
   // Setup target from from Coords


### PR DESCRIPTION
Prevents segfaults with certain trajectories.