### PR TITLE
Small fixes for 'ti' analysis, more output formatting options

### DIFF
--- a/src/Analysis_TI.cpp
+++ b/src/Analysis_TI.cpp
@@ -119,6 +119,7 @@ Analysis::RetType Analysis_TI::Setup(ArgList& analyzeArgs, AnalysisSetup& setup,
     // Single curve
     curve_.push_back( setup.DSL().AddSet(DataSet::XYMESH, md) );
     if (curve_.back() == 0) return Analysis::ERR;
+    if (curveout_ != 0) curveout_->AddDataSet( curve_.back() );
     if (outfile != 0) outfile->ProcessArgs("noxcol");
   } else if (avgType_ == SKIP) {
     // As many curves as skip values

--- a/src/Analysis_TI.cpp
+++ b/src/Analysis_TI.cpp
@@ -119,6 +119,7 @@ Analysis::RetType Analysis_TI::Setup(ArgList& analyzeArgs, AnalysisSetup& setup,
     // Single curve
     curve_.push_back( setup.DSL().AddSet(DataSet::XYMESH, md) );
     if (curve_.back() == 0) return Analysis::ERR;
+    curve_.back()->ModifyDim(Dimension::X).SetLabel("Lambda");
     if (curveout_ != 0) curveout_->AddDataSet( curve_.back() );
     if (outfile != 0) outfile->ProcessArgs("noxcol");
   } else if (avgType_ == SKIP) {
@@ -127,6 +128,7 @@ Analysis::RetType Analysis_TI::Setup(ArgList& analyzeArgs, AnalysisSetup& setup,
       md.SetIdx( *it );
       DataSet* ds = setup.DSL().AddSet(DataSet::XYMESH, md);
       if (ds == 0) return Analysis::ERR;
+      ds->ModifyDim(Dimension::X).SetLabel("Lambda");
       ds->SetLegend( md.Name() + "_Skip" + integerToString(*it) );
       if (curveout_ != 0) curveout_->AddDataSet( ds );
       curve_.push_back( ds );
@@ -137,6 +139,7 @@ Analysis::RetType Analysis_TI::Setup(ArgList& analyzeArgs, AnalysisSetup& setup,
       md.SetIdx(nsample);
       DataSet* ds = setup.DSL().AddSet(DataSet::XYMESH, md);
       if (ds == 0) return Analysis::ERR;
+      ds->ModifyDim(Dimension::X).SetLabel("Lambda");
       ds->SetLegend( md.Name() + "_Sample" + integerToString(nsample) );
       if (curveout_ != 0) curveout_->AddDataSet( ds );
       curve_.push_back( ds );
@@ -484,6 +487,7 @@ int Analysis_TI::Calc_Increment() {
         md.SetIdx( increments[j] );
         DataSet* ds = masterDSL_->AddSet(DataSet::XYMESH, md);
         if (ds == 0) return Analysis::ERR;
+        ds->ModifyDim(Dimension::X).SetLabel("Lambda");
         ds->SetLegend( md.Name() + "_Skip" + integerToString(increments[j]) );
         if (curveout_ != 0) curveout_->AddDataSet( ds );
         curve_.push_back( ds );

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -348,7 +348,9 @@ int DataFile::ProcessArgs(ArgList &argIn) {
       return 1;
     }
     default_precision_ = prec_arg.getNextInteger(0);
-    setDataSetPrecision_ = true;
+    mprintf("\tSetting data file '%s' width.precision to %i.%i\n",
+            filename_.base(), default_width_, default_precision_);
+    SetDataFilePrecision(default_width_, default_precision_);
   } 
   if (dataio_->processWriteArgs(argIn)==1) return 1;
   //if (debug_ > 0) argIn.CheckForMoreArgs();

--- a/src/DataIO.cpp
+++ b/src/DataIO.cpp
@@ -8,7 +8,7 @@ DataIO::DataIO() :
   xcol_fmt_(TextFormat::DOUBLE), // default
   xcol_width_(8),                // default
   xcol_prec_(3),                 // default
-  x_format_set_(false),
+  x_prec_set_(false),
   valid1d_(false),
   valid2d_(false),
   valid3d_(false)
@@ -20,7 +20,7 @@ DataIO::DataIO(bool v1, bool v2, bool v3) :
   xcol_fmt_(TextFormat::DOUBLE), // default
   xcol_width_(8),                // default
   xcol_prec_(3),                 // default
-  x_format_set_(false),
+  x_prec_set_(false),
   valid1d_(v1),
   valid2d_(v2),
   valid3d_(v3)

--- a/src/DataIO.cpp
+++ b/src/DataIO.cpp
@@ -2,6 +2,30 @@
 #include "CpptrajStdio.h"
 #include "DataSet_MatrixDbl.h"
 
+// CONSTRUCTOR
+DataIO::DataIO() :
+  debug_(0),
+  xcol_fmt_(TextFormat::DOUBLE), // default
+  xcol_width_(8),                // default
+  xcol_prec_(3),                 // default
+  x_format_set_(false),
+  valid1d_(false),
+  valid2d_(false),
+  valid3d_(false)
+{}
+
+/** CONSTRUCTOR - Set valid for 1d, 2d, and/or 3d data sets */
+DataIO::DataIO(bool v1, bool v2, bool v3) :
+  debug_(0),
+  xcol_fmt_(TextFormat::DOUBLE), // default
+  xcol_width_(8),                // default
+  xcol_prec_(3),                 // default
+  x_format_set_(false),
+  valid1d_(v1),
+  valid2d_(v2),
+  valid3d_(v3)
+{}
+
 // DataIO::CheckValidFor()
 bool DataIO::CheckValidFor( DataSet const& dataIn ) const {
   if (valid1d_ && dataIn.Ndim() == 1) return true; 

--- a/src/DataIO.h
+++ b/src/DataIO.h
@@ -21,10 +21,10 @@ class DataIO : public BaseIOtype {
     bool CheckValidFor(DataSet const&) const;
     /// Set DataIO debug level.
     void SetDebug(int d) { debug_ = d; }
-    /// Set x column format, width, and precision.
-    void SetXcolFmt(TextFormat::FmtType t, int w, int p) {
-      xcol_fmt_ = t; xcol_width_ = w; xcol_prec_ = p; x_format_set_ = true;
-    }
+    /// Set x column format.
+    void SetXcolFmt(TextFormat::FmtType t) { xcol_fmt_ = t; }
+    /// Set x column width, and precision.
+    void SetXcolPrec(int w, int p) { xcol_width_ = w; xcol_prec_ = p; x_prec_set_ = true; }
     /// \return Current x column format
     TextFormat::FmtType XcolFmt() const { return xcol_fmt_; }
     /// \return Current x column width
@@ -44,14 +44,14 @@ class DataIO : public BaseIOtype {
     static DataSet* DetermineMatrixType(std::vector<double> const&, int, int,
                                         DataSetList&, std::string const&);
     /// \return true if x column format/width/precision previously set TODO always use these values?
-    bool XcolFmtSet()             const { return x_format_set_; }
+    bool XcolPrecSet()            const { return x_prec_set_; }
     int debug_;
   private:
     std::vector<DataSet::DataType> valid_; ///< Data sets for which DataIO is valid writer.
     TextFormat::FmtType xcol_fmt_; ///< X column format type
     int xcol_width_;               ///< X column width
     int xcol_prec_;                ///< X column precision
-    bool x_format_set_;            ///< True if X column format has been explicitly set.
+    bool x_prec_set_;              ///< True if X column width/precision have been explicitly set.
     bool valid1d_; ///< Valid for all 1D data sets. //TODO Remove
     bool valid2d_; ///< Valid for all 2D data sets.
     bool valid3d_; ///< Valid for all 3D data sets.

--- a/src/DataIO.h
+++ b/src/DataIO.h
@@ -7,9 +7,10 @@
 /// Base class that all DataIO objects inherit from.
 class DataIO : public BaseIOtype {
   public:
-    DataIO() : debug_(0), valid1d_(false), valid2d_(false), valid3d_(false) {}
+    DataIO() :
+      debug_(0), x_format_set_(false), valid1d_(false), valid2d_(false), valid3d_(false) {}
     DataIO(bool v1, bool v2, bool v3) :
-               valid1d_(v1), valid2d_(v2), valid3d_(v3) {}
+      debug_(0), x_format_set_(false), valid1d_(v1), valid2d_(v2), valid3d_(v3) {}
     virtual ~DataIO() {}
     // ----- Inherited Functions -----------------
     virtual int processReadArgs(ArgList&) = 0;
@@ -20,6 +21,10 @@ class DataIO : public BaseIOtype {
     /// \return True if this DataIO valid for given DataSet
     bool CheckValidFor(DataSet const&) const;
     void SetDebug(int d) { debug_ = d; }
+    /// Set x column format, width, and precision
+    void SetXcolFmt(TextFormat::FmtType t, int w, int p) {
+      xcol_fmt_ = t; xcol_width_ = w; xcol_prec_ = p; x_format_set_ = true;
+    }
   protected:
     /// Indicate this DataIO is valid for given DataSet type
     void SetValid(DataSet::DataType t) { valid_.push_back( t ); }
@@ -32,9 +37,17 @@ class DataIO : public BaseIOtype {
     /// Convert flattened matrix array to matrix in DataSetList.
     static DataSet* DetermineMatrixType(std::vector<double> const&, int, int,
                                         DataSetList&, std::string const&);
+    TextFormat::FmtType XcolFmt() const { return xcol_fmt_; }
+    int XcolWidth()               const { return xcol_width_; }
+    int XcolPrec()                const { return xcol_prec_;  }
+    bool XcolFmtSet()             const { return x_format_set_; }
     int debug_;
   private:
     std::vector<DataSet::DataType> valid_; ///< Data sets for which DataIO is valid writer.
+    TextFormat::FmtType xcol_fmt_; ///< X column format type
+    int xcol_width_;               ///< X column width
+    int xcol_prec_;                ///< X column precision
+    bool x_format_set_;            ///< True if X column format has been explicitly set.
     bool valid1d_; ///< Valid for all 1D data sets. //TODO Remove
     bool valid2d_; ///< Valid for all 2D data sets.
     bool valid3d_; ///< Valid for all 3D data sets.

--- a/src/DataIO.h
+++ b/src/DataIO.h
@@ -7,10 +7,9 @@
 /// Base class that all DataIO objects inherit from.
 class DataIO : public BaseIOtype {
   public:
-    DataIO() :
-      debug_(0), x_format_set_(false), valid1d_(false), valid2d_(false), valid3d_(false) {}
-    DataIO(bool v1, bool v2, bool v3) :
-      debug_(0), x_format_set_(false), valid1d_(v1), valid2d_(v2), valid3d_(v3) {}
+    DataIO();
+    /// Valid for 1d, 2d, and/or 3d data sets.
+    DataIO(bool, bool, bool);
     virtual ~DataIO() {}
     // ----- Inherited Functions -----------------
     virtual int processReadArgs(ArgList&) = 0;
@@ -20,11 +19,18 @@ class DataIO : public BaseIOtype {
     virtual bool ID_DataFormat(CpptrajFile&) = 0; // TODO: -> BaseIOtype?
     /// \return True if this DataIO valid for given DataSet
     bool CheckValidFor(DataSet const&) const;
+    /// Set DataIO debug level.
     void SetDebug(int d) { debug_ = d; }
-    /// Set x column format, width, and precision
+    /// Set x column format, width, and precision.
     void SetXcolFmt(TextFormat::FmtType t, int w, int p) {
       xcol_fmt_ = t; xcol_width_ = w; xcol_prec_ = p; x_format_set_ = true;
     }
+    /// \return Current x column format
+    TextFormat::FmtType XcolFmt() const { return xcol_fmt_; }
+    /// \return Current x column width
+    int XcolWidth()               const { return xcol_width_; }
+    /// \return Current x column precision
+    int XcolPrec()                const { return xcol_prec_;  }
   protected:
     /// Indicate this DataIO is valid for given DataSet type
     void SetValid(DataSet::DataType t) { valid_.push_back( t ); }
@@ -37,9 +43,7 @@ class DataIO : public BaseIOtype {
     /// Convert flattened matrix array to matrix in DataSetList.
     static DataSet* DetermineMatrixType(std::vector<double> const&, int, int,
                                         DataSetList&, std::string const&);
-    TextFormat::FmtType XcolFmt() const { return xcol_fmt_; }
-    int XcolWidth()               const { return xcol_width_; }
-    int XcolPrec()                const { return xcol_prec_;  }
+    /// \return true if x column format/width/precision previously set TODO always use these values?
     bool XcolFmtSet()             const { return x_format_set_; }
     int debug_;
   private:

--- a/src/DataIO_Gnuplot.cpp
+++ b/src/DataIO_Gnuplot.cpp
@@ -442,8 +442,13 @@ int DataIO_Gnuplot::WriteSets1D(DataSetList const& Sets)
   Dimension const& Xdim = static_cast<Dimension const&>( Xdata->Dim(0) ); 
   Dimension Ydim( 1.0, 1.0 );
   TextFormat x_format, y_format;
-  x_format.SetCoordFormat( maxFrames,   Xdim.Min(), Xdim.Step(), 8, 3 );
-  y_format.SetCoordFormat( Sets.size(), Ydim.Min(), Ydim.Step(), 8, 3 );
+  if (XcolFmtSet()) {
+    x_format = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
+    y_format = x_format;
+  } else {
+    x_format.SetCoordFormat( maxFrames,   Xdim.Min(), Xdim.Step(), 8, 3 );
+    y_format.SetCoordFormat( Sets.size(), Ydim.Min(), Ydim.Step(), 8, 3 );
+  }
   std::string xyfmt = x_format.Fmt() + " " + y_format.Fmt() + " ";
 
   // Turn off labels if number of sets is too large since they 
@@ -618,8 +623,13 @@ int DataIO_Gnuplot::WriteSet2D( DataSet const& setIn ) {
     // ----- ASCII FORMAT ------------------------
     // Setup XY coord format
     TextFormat x_fmt, y_fmt;
-    x_fmt.SetCoordFormat( set.Ncols(), Xdim.Min(), Xdim.Step(), 8, 3 );
-    y_fmt.SetCoordFormat( set.Nrows(), Ydim.Min(), Ydim.Step(), 8, 3 );
+    if (XcolFmtSet()) {
+      x_fmt = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
+      y_fmt = x_fmt;
+    } else {
+      x_fmt.SetCoordFormat( set.Ncols(), Xdim.Min(), Xdim.Step(), 8, 3 );
+      y_fmt.SetCoordFormat( set.Nrows(), Ydim.Min(), Ydim.Step(), 8, 3 );
+    }
     std::string xyfmt = x_fmt.Fmt() + " " + y_fmt.Fmt(); // FIXME No trailing space for bkwds compat
 
     DataSet::SizeArray positions(2, 0);

--- a/src/DataIO_Gnuplot.cpp
+++ b/src/DataIO_Gnuplot.cpp
@@ -441,8 +441,8 @@ int DataIO_Gnuplot::WriteSets1D(DataSetList const& Sets)
   DataSet* Xdata = Sets[0];
   Dimension const& Xdim = static_cast<Dimension const&>( Xdata->Dim(0) ); 
   Dimension Ydim( 1.0, 1.0 );
-  TextFormat x_format, y_format;
-  if (XcolFmtSet()) {
+  TextFormat x_format(XcolFmt()), y_format(XcolFmt());
+  if (XcolPrecSet()) {
     x_format = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
     y_format = x_format;
   } else {
@@ -622,8 +622,8 @@ int DataIO_Gnuplot::WriteSet2D( DataSet const& setIn ) {
   } else {
     // ----- ASCII FORMAT ------------------------
     // Setup XY coord format
-    TextFormat x_fmt, y_fmt;
-    if (XcolFmtSet()) {
+    TextFormat x_fmt(XcolFmt()), y_fmt(XcolFmt());
+    if (XcolPrecSet()) {
       x_fmt = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
       y_fmt = x_fmt;
     } else {

--- a/src/DataIO_Grace.cpp
+++ b/src/DataIO_Grace.cpp
@@ -130,8 +130,8 @@ int DataIO_Grace::WriteDataNormal(CpptrajFile& file, DataSetList const& Sets) {
     file.Printf("@  s%u legend \"%s\"\n@target G0.S%u\n@type xy\n",
                    setnum, (*set)->legend(), setnum );
     // Setup set X coord format.
-    TextFormat xfmt;
-    if (XcolFmtSet())
+    TextFormat xfmt(XcolFmt());
+    if (XcolPrecSet())
       xfmt = TextFormat( XcolFmt(), XcolWidth(), XcolPrec() );
     else
       xfmt.SetCoordFormat( maxFrames, (*set)->Dim(0).Min(), (*set)->Dim(0).Step(), 8, 3 );
@@ -163,8 +163,11 @@ int DataIO_Grace::WriteDataInverted(CpptrajFile& file, DataSetList const& Sets)
               "", Sets[0]->Dim(0).Label().c_str());
   // Setup set X coord format. 
   Dimension Xdim(0.0, 1.0);
-  TextFormat xfmt;
-  xfmt.SetCoordFormat( Sets.size(), Xdim.Min(), Xdim.Step(), 8, 3 );
+  TextFormat xfmt(XcolFmt());
+  if (XcolPrecSet())
+    xfmt = TextFormat( XcolFmt(), XcolWidth(), XcolPrec() );
+  else
+    xfmt.SetCoordFormat( Sets.size(), Xdim.Min(), Xdim.Step(), 8, 3 );
   // Loop over frames
   DataSet::SizeArray frame(1);
   for (frame[0] = 0; frame[0] < maxFrames; frame[0]++) {

--- a/src/DataIO_Grace.cpp
+++ b/src/DataIO_Grace.cpp
@@ -131,7 +131,10 @@ int DataIO_Grace::WriteDataNormal(CpptrajFile& file, DataSetList const& Sets) {
                    setnum, (*set)->legend(), setnum );
     // Setup set X coord format.
     TextFormat xfmt;
-    xfmt.SetCoordFormat( maxFrames, (*set)->Dim(0).Min(), (*set)->Dim(0).Step(), 8, 3 );
+    if (XcolFmtSet())
+      xfmt = TextFormat( XcolFmt(), XcolWidth(), XcolPrec() );
+    else
+      xfmt.SetCoordFormat( maxFrames, (*set)->Dim(0).Min(), (*set)->Dim(0).Step(), 8, 3 );
     // Write Data for set
     for (frame[0] = 0; frame[0] < maxFrames; frame[0]++) {
       file.Printf(xfmt.fmt(), (*set)->Coord(0, frame[0]));

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -664,8 +664,13 @@ int DataIO_Std::WriteSet2D( DataSet const& setIn, CpptrajFile& file ) {
     if (writeHeader_)
       file.Printf("#%s %s %s\n", Xdim.Label().c_str(), 
                   Ydim.Label().c_str(), set.legend());
-    xcoord_fmt.SetCoordFormat( set.Ncols(), Xdim.Min(), Xdim.Step(), 8, 3 );
-    ycoord_fmt.SetCoordFormat( set.Nrows(), Ydim.Min(), Ydim.Step(), 8, 3 );
+    if (XcolFmtSet()) {
+      xcoord_fmt = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
+      ycoord_fmt = xcoord_fmt;
+    } else {
+      xcoord_fmt.SetCoordFormat( set.Ncols(), Xdim.Min(), Xdim.Step(), 8, 3 );
+      ycoord_fmt.SetCoordFormat( set.Nrows(), Ydim.Min(), Ydim.Step(), 8, 3 );
+    }
     std::string xy_fmt = xcoord_fmt.Fmt() + " " + ycoord_fmt.Fmt() + " ";
     for (positions[1] = 0; positions[1] < set.Nrows(); ++positions[1]) {
       for (positions[0] = 0; positions[0] < set.Ncols(); ++positions[0]) {

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -507,22 +507,26 @@ int DataIO_Std::WriteDataNormal(CpptrajFile& file, DataSetList const& Sets) {
   // Set up X column.
   TextFormat x_col_format;
   if (hasXcolumn_) {
-    // Create format string for X column based on dimension in first data set.
-    // Adjust X col precision as follows: if the step is set and has a 
-    // fractional component set the X col width/precision to either the data
-    // width/precision or the current width/precision, whichever is larger. If
-    // the set is XYMESH but step has not been set (so we do not know spacing 
-    // between X values) use default precision. Otherwise the step has no
-    // fractional component so make the precision zero.
-    double step_i;
-    double step_f = modf( Xdim.Step(), &step_i );
-    double min_f  = modf( Xdim.Min(),  &step_i );
-    if (Xdim.Step() > 0.0 && (step_f > 0.0 || min_f > 0.0)) {
-      xcol_precision = std::max(xcol_precision, Xdata->Format().Precision());
-      xcol_width = std::max(xcol_width, Xdata->Format().Width());
-    } else if (Xdata->Type() != DataSet::XYMESH)
-      xcol_precision = 0;
-    x_col_format.SetCoordFormat( maxFrames, Xdim.Min(), Xdim.Step(), xcol_width, xcol_precision );
+    if (XcolFmtSet()) {
+      x_col_format = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
+    } else {
+      // Create format string for X column based on dimension in first data set.
+      // Adjust X col precision as follows: if the step is set and has a 
+      // fractional component set the X col width/precision to either the data
+      // width/precision or the current width/precision, whichever is larger. If
+      // the set is XYMESH but step has not been set (so we do not know spacing 
+      // between X values) use default precision. Otherwise the step has no
+      // fractional component so make the precision zero.
+      double step_i;
+      double step_f = modf( Xdim.Step(), &step_i );
+      double min_f  = modf( Xdim.Min(),  &step_i );
+      if (Xdim.Step() > 0.0 && (step_f > 0.0 || min_f > 0.0)) {
+        xcol_precision = std::max(xcol_precision, Xdata->Format().Precision());
+        xcol_width = std::max(xcol_width, Xdata->Format().Width());
+      } else if (Xdata->Type() != DataSet::XYMESH)
+        xcol_precision = 0;
+      x_col_format.SetCoordFormat( maxFrames, Xdim.Min(), Xdim.Step(), xcol_width, xcol_precision );
+    }
   } else {
     // If not writing an X-column, no leading space for the first dataset.
     Xdata->SetupFormat().SetFormatAlign( TextFormat::RIGHT );

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -724,13 +724,13 @@ int DataIO_Std::WriteSet3D( DataSet const& setIn, CpptrajFile& file ) {
                 Ydim.Label().c_str(), Zdim.Label().c_str(), set.legend());
   std::string xyz_fmt;
   if (XcolPrecSet()) {
+    TextFormat nfmt( XcolFmt(), XcolWidth(), XcolPrec() );
+    xyz_fmt = nfmt.Fmt() + " " + nfmt.Fmt() + " " + nfmt.Fmt() + " ";
+  } else {
     TextFormat xfmt( XcolFmt(), set.NX(), Xdim.Min(), Xdim.Step(), 8, 3 );
     TextFormat yfmt( XcolFmt(), set.NY(), Ydim.Min(), Ydim.Step(), 8, 3 );
     TextFormat zfmt( XcolFmt(), set.NZ(), Zdim.Min(), Zdim.Step(), 8, 3 );
     xyz_fmt = xfmt.Fmt() + " " + yfmt.Fmt() + " " + zfmt.Fmt() + " ";
-  } else {
-    TextFormat nfmt( XcolFmt(), XcolWidth(), XcolPrec() );
-    xyz_fmt = nfmt.Fmt() + " " + nfmt.Fmt() + " " + nfmt.Fmt() + " ";
   }
   for (pos[2] = 0; pos[2] < set.NZ(); ++pos[2]) {
     for (pos[1] = 0; pos[1] < set.NY(); ++pos[1]) {

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -383,11 +383,19 @@ void DataIO_Std::WriteHelp() {
 
 // DataIO_Std::processWriteArgs()
 int DataIO_Std::processWriteArgs(ArgList &argIn) {
-  isInverted_ = argIn.hasKey("invert");
-  hasXcolumn_ = !argIn.hasKey("noxcol");
-  writeHeader_ = !argIn.hasKey("noheader");
-  square2d_ = argIn.hasKey("square2d");
-  if (argIn.hasKey("nosquare2d")) square2d_ = false;
+  if (!isInverted_ && argIn.hasKey("invert"))
+    isInverted_ = true;
+  if (hasXcolumn_ && argIn.hasKey("noxcol"))
+    hasXcolumn_ = false;
+  if (writeHeader_ && argIn.hasKey("noheader"))
+    writeHeader_ = false;
+  bool original_square2d = square2d_;
+  if (argIn.hasKey("square2d"))
+    square2d_ = true;
+  else if (argIn.hasKey("nosquare2d"))
+    square2d_ = false;
+  else
+    square2d_ = original_square2d;
   return 0;
 }
 

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -513,9 +513,9 @@ int DataIO_Std::WriteDataNormal(CpptrajFile& file, DataSetList const& Sets) {
   size_t maxFrames = DetermineMax( Sets );
 
   // Set up X column.
-  TextFormat x_col_format;
+  TextFormat x_col_format(XcolFmt());
   if (hasXcolumn_) {
-    if (XcolFmtSet()) {
+    if (XcolPrecSet()) {
       x_col_format = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
     } else {
       // Create format string for X column based on dimension in first data set.
@@ -637,7 +637,7 @@ int DataIO_Std::WriteSet2D( DataSet const& setIn, CpptrajFile& file ) {
   if (Xdim.Step() == 1.0) xcol_precision = 0;
   
   DataSet::SizeArray positions(2);
-  TextFormat ycoord_fmt, xcoord_fmt;
+  TextFormat ycoord_fmt(XcolFmt()), xcoord_fmt(XcolFmt());
   if (square2d_) {
     // Print XY values in a grid:
     // x0y0 x1y0 x2y0
@@ -672,7 +672,7 @@ int DataIO_Std::WriteSet2D( DataSet const& setIn, CpptrajFile& file ) {
     if (writeHeader_)
       file.Printf("#%s %s %s\n", Xdim.Label().c_str(), 
                   Ydim.Label().c_str(), set.legend());
-    if (XcolFmtSet()) {
+    if (XcolPrecSet()) {
       xcoord_fmt = TextFormat(XcolFmt(), XcolWidth(), XcolPrec());
       ycoord_fmt = xcoord_fmt;
     } else {
@@ -722,10 +722,16 @@ int DataIO_Std::WriteSet3D( DataSet const& setIn, CpptrajFile& file ) {
   if (writeHeader_)
     file.Printf("#%s %s %s %s\n", Xdim.Label().c_str(), 
                 Ydim.Label().c_str(), Zdim.Label().c_str(), set.legend());
-  TextFormat xfmt( set.NX(), Xdim.Min(), Xdim.Step(), 8, 3 );
-  TextFormat yfmt( set.NY(), Ydim.Min(), Ydim.Step(), 8, 3 );
-  TextFormat zfmt( set.NZ(), Zdim.Min(), Zdim.Step(), 8, 3 );
-  std::string xyz_fmt = xfmt.Fmt() + " " + yfmt.Fmt() + " " + zfmt.Fmt() + " ";
+  std::string xyz_fmt;
+  if (XcolPrecSet()) {
+    TextFormat xfmt( XcolFmt(), set.NX(), Xdim.Min(), Xdim.Step(), 8, 3 );
+    TextFormat yfmt( XcolFmt(), set.NY(), Ydim.Min(), Ydim.Step(), 8, 3 );
+    TextFormat zfmt( XcolFmt(), set.NZ(), Zdim.Min(), Zdim.Step(), 8, 3 );
+    xyz_fmt = xfmt.Fmt() + " " + yfmt.Fmt() + " " + zfmt.Fmt() + " ";
+  } else {
+    TextFormat nfmt( XcolFmt(), XcolWidth(), XcolPrec() );
+    xyz_fmt = nfmt.Fmt() + " " + nfmt.Fmt() + " " + nfmt.Fmt() + " ";
+  }
   for (pos[2] = 0; pos[2] < set.NZ(); ++pos[2]) {
     for (pos[1] = 0; pos[1] < set.NY(); ++pos[1]) {
       for (pos[0] = 0; pos[0] < set.NX(); ++pos[0]) {

--- a/src/Exec_Commands.cpp
+++ b/src/Exec_Commands.cpp
@@ -78,7 +78,7 @@ void Exec_ListAll::Help() const {
 void Exec_SilenceActions::Help() const { mprintf("Silence Actions Init/Setup output.\n"); }
 // -----------------------------------------------------------------------------
 void Exec_DataFileCmd::Help() const {
-  mprintf("\t<data filename> <datafile cmd>\n"
+  mprintf("\t{<data filename> | *} <datafile cmd>\n"
           "  Pass <datafile cmd> to specified data file currently in data file list.\n");
   DataFile::WriteHelp();
   DataFile::WriteOptions();

--- a/src/Exec_DataSetCmd.h
+++ b/src/Exec_DataSetCmd.h
@@ -18,6 +18,7 @@ class Exec_DataSetCmd : public Exec {
     };
     static SelectPairType SelectKeys[];
 
+    RetType ChangeOutputFormat(CpptrajState&, ArgList&);
     RetType Remove(CpptrajState&, ArgList&);
     RetType MakeXY(CpptrajState&, ArgList&);
     RetType Make2D(CpptrajState&, ArgList&);

--- a/src/TextFormat.cpp
+++ b/src/TextFormat.cpp
@@ -73,7 +73,8 @@ void TextFormat::SetCoordFormat(size_t maxFrames, double min, double step,
   // Default width for column is at least default_width.
   if (col_width < default_width) col_width = default_width;
   // Set column data format string, left-aligned (no leading space).
-  type_ = DOUBLE;
+  if (type_ == INTEGER || type_ == STRING) // sanity check
+    type_ = DOUBLE;
   width_ = col_width;
   precision_ = col_precision;
   align_ = RIGHT;

--- a/src/TextFormat.cpp
+++ b/src/TextFormat.cpp
@@ -3,6 +3,10 @@
 
 char TextFormat::TypeChar_[] = { 'f', 'E', 'g', 'i', 's' };
 
+const char* TextFormat::TypeDesc_[] = {
+  "DOUBLE", "SCIENTIFIC", "GENERAL", "INTEGER", "STRING"
+};
+
 // TODO benchmark - will using a big buffer and C string routines be better?
 void TextFormat::SetFormatString() {
   std::string width_arg, prec_arg, left_arg, long_arg;
@@ -31,6 +35,18 @@ void TextFormat::SetFormatString() {
     fmt_.append( "%" + left_arg + long_arg + width_arg + prec_arg + TypeChar_[type_] );
     colwidth_ += width_;
   }
+}
+
+bool TextFormat::IsDoubleType(FmtType typeIn) {
+  return (typeIn == DOUBLE || typeIn == SCIENTIFIC || typeIn == GDOUBLE);
+}
+
+int TextFormat::SetFormatType(FmtType typeIn) {
+  if (IsDoubleType(typeIn) && IsDoubleType(type_)) {
+    type_ = typeIn;
+    return 1;
+  }
+  return 0;
 }
 
 void TextFormat::SetCoordFormat(size_t maxFrames, double min, double step,

--- a/src/TextFormat.h
+++ b/src/TextFormat.h
@@ -32,6 +32,10 @@ class TextFormat {
     TextFormat(size_t z, double m, double s, int w, int p) : type_(DOUBLE), width_(w),
                precision_(p), nelements_(1), colwidth_(0), align_(RIGHT), isLong_(false)
       { SetCoordFormat( z, m, s, w, p ); }
+    /// CONSTRUCTOR - For output coords, type, size, min, step, width, precision
+    TextFormat(FmtType t, size_t z, double m, double s, int w, int p) : type_(t), width_(w),
+               precision_(p), nelements_(1), colwidth_(0), align_(RIGHT), isLong_(false)
+      { SetCoordFormat( z, m, s, w, p ); }
     /// Set double format string for size, min, step, default width and precision 
     void SetCoordFormat(size_t, double, double, int, int);
     /// Set format type. Only works for double-precision formats.

--- a/src/TextFormat.h
+++ b/src/TextFormat.h
@@ -34,6 +34,8 @@ class TextFormat {
       { SetCoordFormat( z, m, s, w, p ); }
     /// Set double format string for size, min, step, default width and precision 
     void SetCoordFormat(size_t, double, double, int, int);
+    /// Set format type. Only works for double-precision formats.
+    int SetFormatType(FmtType);
     /// Set format string with new alignment.
     void SetFormatAlign(AlignType t) { align_ = t; SetFormatString(); }
     /// Set format string with new width
@@ -48,11 +50,14 @@ class TextFormat {
     int Width()              const { return width_;       }
     int Precision()          const { return precision_;   }
     int ColumnWidth()        const { return colwidth_;    }
+    static const char* typeDescription(FmtType f) { return TypeDesc_[f]; }
   private:
+    static inline bool IsDoubleType(FmtType);
     /// Set format string for current type, width, precision, etc 
     void SetFormatString();
 
     static char TypeChar_[]; ///< Hold printf format chars for each type.
+    static const char* TypeDesc_[]; ///< Hold text description of formats
 
     std::string fmt_;  ///< Hold format string.
     FmtType type_;     ///< Format type.

--- a/test/Test_TI/curve.agr.save
+++ b/test/Test_TI/curve.agr.save
@@ -1,5 +1,5 @@
 @with g0
-@  xaxis label "Frame"
+@  xaxis label "Lambda"
 @  yaxis label ""
 @  legend 0.2, 0.995
 @  legend char size 0.60

--- a/test/Test_TI/incr.crv.agr.save
+++ b/test/Test_TI/incr.crv.agr.save
@@ -1,5 +1,5 @@
 @with g0
-@  xaxis label "Frame"
+@  xaxis label "Lambda"
 @  yaxis label ""
 @  legend 0.2, 0.995
 @  legend char size 0.60


### PR DESCRIPTION
- For `ti`, ensure the curve data set is added to the curve output file when performing straight averaging of DV/DL.
- Change the `ti` curve X label to "Lambda".
- Make the `prec` argument affect sets already in the data file as well.
- Add `outformat` option to `dataset` command to allow double-precision sets to be written out in scientific or general (the shorter of floating point or scientific) notation.
- Add the `xfmt` and `xprec` arguments for data files to allow controlling format and width/precision of the X column.
- Allow `datafile` commands to be applied to all data files via `*` in lieu of file name.
- For standard output files ensure previously set options are not overwritten.