### PR TITLE
Fix 'nastruct' when using a reference structure

### DIFF
--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1145,7 +1145,7 @@ Action::RetType Action_NAstruct::Setup(ActionSetup& setup) {
   unsigned int idx = 0;
   // Set up NA_base for each selected NA residue 
   for (Range::const_iterator resnum = actualRange.begin();
-                             resnum != actualRange.end(); ++resnum, ++idx)
+                             resnum != actualRange.end(); ++resnum)
   {
 #   ifdef NASTRUCTDEBUG
     mprintf(" ----- Setting up %i:%s -----\n", *resnum+1, setup.Top().Res(*resnum).c_str());
@@ -1179,11 +1179,13 @@ Action::RetType Action_NAstruct::Setup(ActionSetup& setup) {
     } else {
       // Ensure base type has not changed. //TODO: Re-set up reference? Check # atoms etc?
       if (currentBase.Type() != Bases_[idx].Type()) {
-        mprinterr("Error: Residue %s base type has changed from %s\n",
-                  setup.Top().TruncResNameNum(*resnum).c_str(), Bases_[idx].BaseName().c_str());
+        mprinterr("Error: Residue %s base has changed from %s to %s\n",
+                  setup.Top().TruncResNameNum(*resnum).c_str(), Bases_[idx].BaseName().c_str(),
+                  currentBase.BaseName().c_str());
         return Action::ERR;
       }
     }
+    idx++;
   } // End Loop over NA residues
   mprintf("\tSet up %zu bases.\n", Bases_.size());
   if (Bases_.empty()) {

--- a/src/AtomMask.cpp
+++ b/src/AtomMask.cpp
@@ -155,6 +155,7 @@ void AtomMask::PrintMaskAtoms(const char *header) const {
       mprintf(" %i",*atom + 1);
   } else 
     mprintf("No atoms selected.");
+  mprintf("\n");
 }
 
 /** Set up an atom mask containing selected atom numbers given a char

--- a/src/AxisType.cpp
+++ b/src/AxisType.cpp
@@ -534,8 +534,19 @@ int NA_Base::Setup_Base(RefBase const& REF, Residue const& RES, int resnum,
     md.SetLegend( basename_ );
     md.SetScalarType( MetaData::PUCKER );
     md.SetScalarMode( MetaData::M_PUCKER );
-    pucker_ = (DataSet_1D*)masterDSL.AddSet(DataSet::FLOAT, md);
-    if (pucker_ == 0) return 1;
+    // Check if pucker data set is already present
+    DataSet* ds = masterDSL.CheckForSet( md );
+    if (ds == 0) {
+      pucker_ = (DataSet_1D*)masterDSL.AddSet(DataSet::FLOAT, md);
+      if (pucker_ == 0) return 1;
+    } else {
+      // Check that it is the correct type.
+      if (ds->Type() != DataSet::FLOAT) {
+        mprinterr("Error: Set '%s' already present but is not FLOAT.\n", ds->legend());
+        return 1;
+      }
+      pucker_ = (DataSet_1D*)ds;
+    }
   } else
     pucker_ = 0;
   return 0;


### PR DESCRIPTION
There were two issues that are now fixed:

1. Cpptraj would always try to set up a new pucker data set; however if Setup() had been previously called, a pucker data set would already exist resulting in an error. Now fixed.
2. When checking if an existing base type matched current the index was being incremented for all residues, not just nucleic acid, which could cause a segmentation fault when the N.A. residues were not the first residues in the system.