### PR TITLE
Fix the 'surf' command for systems where solute is not at beginning of molecule.

### DIFF
--- a/src/Action_Surf.cpp
+++ b/src/Action_Surf.cpp
@@ -140,7 +140,7 @@ Action::RetType Action_Surf::Setup(ActionSetup& setup) {
       // Atom has no neighbors
       if ( cmask1.AtomInCharMask( atom ) ) {
         // Calculate surface area of atom i
-        double vdwi2 = VDW_.back() * VDW_.back();
+        double vdwi2 = SI.vdwradii * SI.vdwradii;
         double Si = vdwi2 * Constants::FOURPI; 
         mprintf("DBG: AtomNoNbr %i P1 %g Si %g\n", atom, SI.P1, Si);
         noNeighborTerm_ += (SI.P1 * Si);

--- a/src/Action_Surf.cpp
+++ b/src/Action_Surf.cpp
@@ -10,9 +10,11 @@
 // CONSTRUCTOR
 Action_Surf::Action_Surf() : surf_(0) {} 
 
+// Action_Surf::Help()
 void Action_Surf::Help() const {
-  mprintf("\t<name> <mask1> [out filename]\n"
-          "  Calculate LCPO surface area of atoms in <mask1>\n");
+  mprintf("\t<name> [<mask1>] [out <filename>]\n"
+          "  Calculate LCPO surface area of atoms in <mask1>, or all solute\n"
+          "  atoms if no mask specified.\n");
 }
 
 // Action_Surf::Init()
@@ -22,15 +24,21 @@ Action::RetType Action_Surf::Init(ArgList& actionArgs, ActionInit& init, int deb
   DataFile* outfile = init.DFL().AddDataFile( actionArgs.GetStringKey("out"), actionArgs);
 
   // Get Masks
-  Mask1_.SetMaskString( actionArgs.GetMaskNext() );
+  std::string maskexp = actionArgs.GetMaskNext();
+  if (!maskexp.empty()) Mask1_.SetMaskString( maskexp );
 
   // Dataset to store surface area 
   surf_ = init.DSL().AddSet(DataSet::DOUBLE, actionArgs.GetStringNext(), "SA");
   if (surf_==0) return Action::ERR;
-  // Add dataset to data file list
+  // Add DataSet to DataFileList
   if (outfile != 0) outfile->AddDataSet( surf_ );
 
-  mprintf("    SURF: Calculating surface area for atoms in mask [%s]\n",Mask1_.MaskString());
+  mprintf("    SURF: ");
+  if (!Mask1_.MaskStringSet())
+    mprintf("Calculating LCPO surface area for all solute atoms.\n");
+  else
+    mprintf("Calculating LCPO surface area for atoms in mask '%s'\n", Mask1_.MaskString());
+  if (outfile != 0) mprintf("\tOutput to '%s'\n", outfile->DataFilename().full());
   mprintf("#Citation: Weiser, J.; Shenkin, P. S.; Still, W. C.; \"Approximate atomic\n"
           "#          surfaces from linear combinations of pairwise overlaps (LCPO).\"\n"
           "#          J. Comp. Chem. (1999), V.20, pp.217-230.\n");
@@ -39,209 +47,54 @@ Action::RetType Action_Surf::Init(ArgList& actionArgs, ActionInit& init, int deb
 }
 
 // Action_Surf::Setup()
-/** Set LCPO surface area calc parameters for this parmtop if not already set. 
-  * Get the mask, and check that the atoms in mask belong to solute. 
+/** There are two modes. If a mask has been specified, want surface area of
+  * only atoms in mask. Otherwise want surface area of all solute atoms. In
+  * either case attempt to identify solute atoms (i.e. exclude solvent/ions).
   */
 Action::RetType Action_Surf::Setup(ActionSetup& setup) {
-  SurfInfo SI;
+  if (Mask1_.MaskStringSet()) {
+    if (setup.Top().SetupIntegerMask( Mask1_ )) return Action::ERR;
+    if (Mask1_.None()) {
+      mprintf("Warning: Mask '%s' corresponds to 0 atoms.\n", Mask1_.MaskString());
+      return Action::SKIP;
+    }
+    Mask1_.MaskInfo();
+  }
+ 
+  // Determine solute atoms.
+  SoluteAtoms_.ResetMask();
+  SoluteAtoms_.SetNatoms( setup.Top().Natom() );
+  if ( setup.Top().Nmol() > 0) {
+    for (int at = 0; at != setup.Top().Natom(); at++)
+    {
+      Molecule const& mol = setup.Top().Mol( setup.Top()[at].MolNum() );
+      if (!mol.IsSolvent() && mol.NumAtoms() > 1)
+        SoluteAtoms_.AddSelectedAtom( at );
+    }
+  } else {
+    mprintf("Warning: No molecule info in '%s'. Adding all atoms.\n");
+    for (int at = 0; at != setup.Top().Natom(); at++)
+      SoluteAtoms_.AddSelectedAtom( at );
+  }
+  if (!Mask1_.MaskStringSet())
+    Mask1_ = SoluteAtoms_;
+  mprintf("\t%i solute atoms. Calculating LCPO surface area for %i atoms.\n",
+          SoluteAtoms_.Nselected(), Mask1_.Nselected());
 
-  if (setup.Top().SetupIntegerMask( Mask1_ )) return Action::ERR;
-  if (Mask1_.None()) {
-    mprintf("Warning: Mask '%s' corresponds to 0 atoms.\n", Mask1_.MaskString());
-    return Action::SKIP;
-  }
-  mprintf("\tLCPO surface area will be calculated for %i atoms.\n",Mask1_.Nselected());
-
-  // Setup surface area calc for this parm.
-  // Check that each atom in Mask1 is part of solute
-  // Create a separate mask for building the atom neighbor list that only
-  // includes atoms with vdw radius > 2.5. Consider all atoms for icosa, only
-  // non-H's for LCPO
-  atomi_neighborMask_.ResetMask();
-  atomi_noNeighborMask_.ResetMask();
-  atomj_neighborMask_.ResetMask();
-  SurfaceInfo_neighbor_.clear();
-  SurfaceInfo_noNeighbor_.clear();
-  int soluteAtoms = 0;
-  for (AtomMask::const_iterator atomi = Mask1_.begin(); atomi!=Mask1_.end(); atomi++) {
-    int molNum = setup.Top()[ *atomi ].MolNum();
-    if (setup.Top().Mol( molNum ).IsSolvent()) {
-      mprinterr("Error: Atom %i in mask %s does not belong to solute.\n",
-                *atomi+1, Mask1_.MaskString());
-      return Action::ERR;
-    }
-    ++soluteAtoms;
-    SetAtomLCPO( setup.Top(), *atomi, &SI ); 
-    if (SI.vdwradii > 2.5) {
-      atomi_neighborMask_.AddAtom(*atomi);
-      SurfaceInfo_neighbor_.push_back( SI );
-    } else {
-      atomi_noNeighborMask_.AddAtom(*atomi);
-      SurfaceInfo_noNeighbor_.push_back( SI );
-    }
-  }
-  mprintf("\t%i solute atoms.\n",soluteAtoms);
-  if (soluteAtoms <= 0) {
-    mprinterr("Error: No solute atoms in %s.\n",setup.Top().c_str());
-    return Action::ERR;
-  }
-  // From all solute atoms, create a second mask for building atom 
-  // neighbor list that only includes atoms with vdw radius > 2.5.
-  VDW_.clear();
-  VDW_.reserve( soluteAtoms );
-  if (setup.Top().Nmol() < 1) {
-    mprinterr("Error: Topology %s has no molecule information, LCPO surface area\n"
-              "Error:   cannot be calculated. Try using 'fixatomorder' prior to 'surf' command.\n",
-              setup.Top().c_str());
-    return Action::ERR;
-  }
-  for (Topology::mol_iterator mol = setup.Top().MolStart(); 
-                              mol != setup.Top().MolEnd(); ++mol)
-  {
-    if (!mol->IsSolvent()) {
-      for (int atomj=mol->BeginAtom(); atomj != mol->EndAtom(); atomj++) {
-        SetAtomLCPO( setup.Top(), atomj, &SI );
-        VDW_.push_back( SI.vdwradii );
-        if (SI.vdwradii > 2.5)
-          atomj_neighborMask_.AddAtom(atomj);
-      }
-    }
-  }
   return Action::OK;  
 }
 
 // Action_Surf::DoAction()
 /** Calculate surface area. */
 Action::RetType Action_Surf::DoAction(int frameNum, ActionFrame& frm) {
-  double SA;
-  int atomi, idx;
-  AtomMask::const_iterator atomj; 
-  std::vector<int> ineighbor; // TODO: Class var
-  std::vector<double> Distances_i_j; // TODO: Class var
-  int max_atomi_neighbormask = atomi_neighborMask_.Nselected();
 
-  // Set up neighbor list for each atom in mask and calc its surface 
-  // area contribution. Sum these up to get the total surface area.
-  SA = 0.0;
-#ifdef _OPENMP
-#pragma omp parallel private(atomi,idx,atomj,ineighbor,Distances_i_j) reduction(+: SA)
-{
-#pragma omp for 
-#endif
-  for (idx = 0; idx < max_atomi_neighbormask; idx++) {
-    atomi = atomi_neighborMask_[idx];
-    // Vdw of atom i
-    double vdwi = VDW_[atomi];
-    // Set up neighbor list for atom i
-    ineighbor.clear();
-    Distances_i_j.clear();
-    for (atomj = atomj_neighborMask_.begin(); atomj != atomj_neighborMask_.end(); atomj++)
-    {
-      if (atomi != *atomj) {
-        double dij = sqrt( DIST2_NoImage(frm.Frm().XYZ(atomi), frm.Frm().XYZ(*atomj)) );
-        // Count atoms as neighbors if their VDW radii touch
-        if ( (vdwi + VDW_[*atomj]) > dij ) {
-          ineighbor.push_back(*atomj);
-          Distances_i_j.push_back(dij);
-        }
-        //mprintf("SURF_NEIG:  %i %i %lf\n",atomi,*atomj,dij);
-      }
-    }
-    // Calculate surface area
-    // -------------------------------------------------------------------------
-    // Calculate LCPO surface area Ai for atomi:
-    // Ai = P1*S1 + P2*Sum(Aij) + P3*Sum(Ajk) + P4*Sum(Aij * Sum(Ajk))
-    double sumaij = 0.0;
-    double sumajk = 0.0;
-    double sumaijajk = 0.0;
-
-    // DEBUG - print neighbor list
-    //mprintf("SURF: Neighbors for atom %i:",atomi);
-    //for (std::vector<int>::iterator jt = ineighbor.begin(); jt != ineighbor.end(); jt++) {
-    //  mprintf(" %i",*jt);
-    //}
-    //mprintf("\n");
-
-    // Calculate surface area of atom i
-    double vdwi2 = vdwi * vdwi;
-    double Si = vdwi2 * Constants::FOURPI;
-
-    // Loop over all neighbors of atomi (j)
-    // NOTE: Factor through the 2 in aij and ajk?
-    std::vector<double>::const_iterator Dij = Distances_i_j.begin();
-    for (std::vector<int>::const_iterator jt = ineighbor.begin(); 
-                                          jt != ineighbor.end(); 
-                                          ++jt, ++Dij) 
-    {
-      //printf("i,j %i %i\n",atomi + 1,(*jt)+1);
-      double vdwj = VDW_[*jt];
-      double vdwj2 = vdwj * vdwj;
-      double dij = *Dij;
-      double tmpaij = vdwi - (dij * 0.5) - ( (vdwi2 - vdwj2)/(2.0 * dij) );
-      double aij = Constants::TWOPI * vdwi * tmpaij;
-      sumaij += aij;
-
-      // Find which neighbors of atom i (j and k) are themselves neighbors
-      double sumajk_2 = 0.0;
-      for (std::vector<int>::const_iterator kt = ineighbor.begin(); 
-                                            kt != ineighbor.end(); 
-                                            kt++) 
-      {
-        if ( (*kt) == (*jt) ) continue;
-        //printf("i,j,k %i %i %i\n",atomi + 1,(*jt)+1,(*kt)+1);
-        double vdwk = VDW_[*kt];
-        double djk = sqrt(DIST2_NoImage(frm.Frm().XYZ(*jt), frm.Frm().XYZ(*kt)));
-        //printf("%4s%6i%6i%12.8lf\n","DJK ",(*jt)+1,(*kt)+1,djk);
-        //printf("%6s%6.2lf%6.2lf\n","AVD ",vdwj,vdwk);
-        if ( (vdwj + vdwk) > djk ) {
-          double vdw2dif = vdwj2 - (vdwk * vdwk);
-          double tmpajk = (2.0*vdwj) - djk - (vdw2dif / djk);
-          double ajk = Constants::PI*vdwj*tmpajk;
-          //tmpajk = vdwj - (djk *0.5) - ( (vdwj2 - (vdwk * vdwk))/(2.0 * djk) );
-          //ajk = 2.0 * PI * vdwi * tmpajk;
-          //printf("%4s%6i%6i%12.8lf%12.8lf%12.8lf\n","AJK ",(*jt)+1,(*kt)+1,ajk,vdw2dif,tmpajk);
-          sumajk += ajk;
-          sumajk_2 += ajk;
-        }
-      } // END loop over neighbor-neighbor pairs of atom i (kt)
-
-      sumaijajk += (aij * sumajk_2);
-
-      // DEBUG
-      //printf("%4s%20.8lf %20.8lf %20.8lf\n","AJK ",aij,sumajk,sumaijajk);
-
-    } // END Loop over neighbors of atom i (jt)
-    SA += ( (SurfaceInfo_neighbor_[idx].P1 * Si       ) +
-            (SurfaceInfo_neighbor_[idx].P2 * sumaij   ) +
-            (SurfaceInfo_neighbor_[idx].P3 * sumajk   ) +
-            (SurfaceInfo_neighbor_[idx].P4 * sumaijajk) 
-          );
-    // -------------------------------------------------------------------------
-  } // END Loop over atoms in mask (atomi) 
-#ifdef _OPENMP
-} // END pragma omp parallel
-#endif
-  // Second loop over atoms with no neighbors (vdw <= 2.5)
-  int idxj=0;
-  for (atomj = atomi_noNeighborMask_.begin(); atomj != atomi_noNeighborMask_.end(); atomj++)
-  {
-    // Vdw of atom i
-    double vdwi = VDW_[*atomj];
-    // Calculate surface area of atom i
-    double vdwi2 = vdwi * vdwi;
-    double Si = vdwi2 * Constants::FOURPI; 
-    SA += (SurfaceInfo_noNeighbor_[idxj++].P1 * Si);
-  }
-
-  surf_->Add(frameNum, &SA);
-
-  return Action::OK;
+  return Action::ERR;
 } 
-
+/*
 // -----------------------------------------------------------------------------
 // Action_Surf::AssignLCPO()
-/** Assign parameters for LCPO method. All radii are incremented by 1.4 Ang.
-  */
+* Assign parameters for LCPO method. All radii are incremented by 1.4 Ang.
+
 void Action_Surf::AssignLCPO(SurfInfo *S, double vdwradii, double P1, double P2,
                       double P3, double P4) 
 {
@@ -261,12 +114,12 @@ static void WarnLCPO(NameType const& atype, int atom, int numBonds) {
 }
 
 // Action_Surf::SetAtomLCPO()
-/** Set up parameters only used in surface area calcs.
+* Set up parameters only used in surface area calcs.
   * Adapted from gbsa=1 method in SANDER, mdread.F90
   * \param currentParm The Topology containing atom information. 
   * \param atidx The atom number to set up parameters for.
   * \param SIptr Address to store the SI parameters.
-  */
+
 void Action_Surf::SetAtomLCPO(Topology const& currentParm, int atidx, SurfInfo* SIptr) 
 {
   const Atom& atom = currentParm[atidx];
@@ -369,3 +222,4 @@ void Action_Surf::SetAtomLCPO(Topology const& currentParm, int atidx, SurfInfo* 
       }
   } // END switch atom.Element() 
 }
+*/

--- a/src/Action_Surf.cpp
+++ b/src/Action_Surf.cpp
@@ -317,10 +317,10 @@ void Action_Surf::SetAtomLCPO(Topology const& currentParm, int atidx, SurfInfo* 
     case Atom::CARBON:
       if (atom.Nbonds() == 4) {
         switch ( numBonds ) {
-          case 1: AssignLCPO(SIptr, 1.70, 0.77887, -0.28063, -0.0012968, 0.00039328); break;
-          case 2: AssignLCPO(SIptr, 1.70, 0.56482, -0.19608, -0.0010219, 0.0002658);  break;
+          case 1: AssignLCPO(SIptr, 1.70, 0.77887, -0.28063,  -0.0012968,  0.00039328); break;
+          case 2: AssignLCPO(SIptr, 1.70, 0.56482, -0.19608,  -0.0010219,  0.0002658);  break;
           case 3: AssignLCPO(SIptr, 1.70, 0.23348, -0.072627, -0.00020079, 0.00007967); break;
-          case 4: AssignLCPO(SIptr, 1.70, 0.00000, 0.00000, 0.00000, 0.00000); break;
+          case 4: AssignLCPO(SIptr, 1.70, 0.00000,  0.00000,   0.00000,    0.00000); break;
           default: WarnLCPO(atom.Type(),atidx + 1,numBonds);
                    AssignLCPO(SIptr, 1.70, 0.77887, -0.28063, -0.0012968, 0.00039328);
         }
@@ -335,12 +335,12 @@ void Action_Surf::SetAtomLCPO(Topology const& currentParm, int atidx, SurfInfo* 
       break;
     case Atom::OXYGEN:
       if (atype0=='O' && atype1==' ') 
-        AssignLCPO(SIptr, 1.60, 0.68563, -0.1868, -0.00135573, 0.00023743);
+        AssignLCPO(SIptr, 1.60, 0.68563, -0.1868,  -0.00135573, 0.00023743);
       else if (atype0=='O' && atype1=='2')
-        AssignLCPO(SIptr, 1.60, 0.88857, -0.33421, -0.0018683, 0.00049372);
+        AssignLCPO(SIptr, 1.60, 0.88857, -0.33421, -0.0018683,  0.00049372);
       else {
         switch ( numBonds ) {
-          case 1: AssignLCPO(SIptr, 1.60, 0.77914, -0.25262, -0.0016056, 0.00035071); break;
+          case 1: AssignLCPO(SIptr, 1.60, 0.77914, -0.25262, -0.0016056,  0.00035071); break;
           case 2: AssignLCPO(SIptr, 1.60, 0.49392, -0.16038, -0.00015512, 0.00016453); break;
           default: WarnLCPO(atom.Type(),atidx + 1,numBonds);
                    AssignLCPO(SIptr, 1.60, 0.77914, -0.25262, -0.0016056, 0.00035071);
@@ -350,17 +350,17 @@ void Action_Surf::SetAtomLCPO(Topology const& currentParm, int atidx, SurfInfo* 
     case Atom::NITROGEN:
       if (atype0=='N' && atype1=='3') {
         switch ( numBonds ) {
-          case 1: AssignLCPO(SIptr, 1.65, 0.078602, -0.29198, -0.0006537, 0.00036247); break;
-          case 2: AssignLCPO(SIptr, 1.65, 0.22599, -0.036648, -0.0012297, 0.000080038); break;
+          case 1: AssignLCPO(SIptr, 1.65, 0.078602, -0.29198,  -0.0006537,  0.00036247); break;
+          case 2: AssignLCPO(SIptr, 1.65, 0.22599,  -0.036648, -0.0012297,  0.000080038); break;
           case 3: AssignLCPO(SIptr, 1.65, 0.051481, -0.012603, -0.00032006, 0.000024774); break;
           default: WarnLCPO(atom.Type(),atidx + 1,numBonds);
                    AssignLCPO(SIptr, 1.65, 0.078602, -0.29198, -0.0006537, 0.00036247);
         }
       } else {
         switch ( numBonds ) {
-          case 1: AssignLCPO(SIptr, 1.65, 0.73511, -0.22116, -0.00089148, 0.0002523); break;
-          case 2: AssignLCPO(SIptr, 1.65, 0.41102, -0.12254, -0.000075448, 0.00011804); break;
-          case 3: AssignLCPO(SIptr, 1.65, 0.062577, -0.017874, -0.00008312, 0.000019849); break;
+          case 1: AssignLCPO(SIptr, 1.65, 0.73511,  -0.22116,  -0.00089148,  0.0002523); break;
+          case 2: AssignLCPO(SIptr, 1.65, 0.41102,  -0.12254,  -0.000075448, 0.00011804); break;
+          case 3: AssignLCPO(SIptr, 1.65, 0.062577, -0.017874, -0.00008312,  0.000019849); break;
           default: WarnLCPO(atom.Type(),atidx + 1,numBonds);
                    AssignLCPO(SIptr, 1.65, 0.078602, -0.29198, -0.0006537, 0.00036247);
         }
@@ -368,13 +368,13 @@ void Action_Surf::SetAtomLCPO(Topology const& currentParm, int atidx, SurfInfo* 
       break;
     case Atom::SULFUR:
       if (atype0=='S' && atype1=='H') 
-        AssignLCPO(SIptr, 1.90, 0.7722, -0.26393, 0.0010629, 0.0002179);
+        AssignLCPO(SIptr, 1.90, 0.7722,  -0.26393,  0.0010629, 0.0002179);
       else 
         AssignLCPO(SIptr, 1.90, 0.54581, -0.19477, -0.0012873, 0.00029247);
       break;
     case Atom::PHOSPHORUS:
       switch ( numBonds ) {
-        case 3: AssignLCPO(SIptr, 1.90, 0.3865, -0.18249, -0.0036598, 0.0004264); break;
+        case 3: AssignLCPO(SIptr, 1.90, 0.3865,  -0.18249,  -0.0036598,    0.0004264); break;
         case 4: AssignLCPO(SIptr, 1.90, 0.03873, -0.0089339, 0.0000083582, 0.0000030381); break;
         default: WarnLCPO(atom.Type(),atidx + 1,numBonds);
                  AssignLCPO(SIptr, 1.90, 0.3865, -0.18249, -0.0036598, 0.0004264);

--- a/src/Action_Surf.cpp
+++ b/src/Action_Surf.cpp
@@ -126,7 +126,7 @@ Action::RetType Action_Surf::Setup(ActionSetup& setup) {
     int atom = SoluteMask_[idx];
     // TODO streamline SurfInfo
     SetAtomLCPO( setup.Top(), atom, &SI );
-    mprintf("Atom %i vdw %f\n", atom, SI.vdwradii);
+//    mprintf("Atom %i vdw %f\n", atom, SI.vdwradii);
     if (SI.vdwradii > neighborCut_) {
       // Atom has neighbors.
       HeavyAtoms_.push_back( atom );
@@ -142,7 +142,7 @@ Action::RetType Action_Surf::Setup(ActionSetup& setup) {
         // Calculate surface area of atom i
         double vdwi2 = SI.vdwradii * SI.vdwradii;
         double Si = vdwi2 * Constants::FOURPI; 
-        mprintf("DBG: AtomNoNbr %i P1 %g Si %g\n", atom, SI.P1, Si);
+//        mprintf("DBG: AtomNoNbr %i P1 %g Si %g\n", atom, SI.P1, Si);
         noNeighborTerm_ += (SI.P1 * Si);
       }
     }
@@ -157,8 +157,10 @@ Action::RetType Action_Surf::Setup(ActionSetup& setup) {
   {
 # pragma omp master
   {
-  Ineighbor_.resize( omp_get_num_threads() );
-  DIJ_.resize( omp_get_num_threads() );
+  int nthreads = omp_get_num_threads();
+  Ineighbor_.resize( nthreads );
+  DIJ_.resize( nthreads );
+  mprintf("\tParallelizing calculation with %i threads.\n", nthreads);
   }
   }
 # endif

--- a/src/Action_Surf.cpp
+++ b/src/Action_Surf.cpp
@@ -16,9 +16,11 @@ Action_Surf::Action_Surf() :
 
 // Action_Surf::Help()
 void Action_Surf::Help() const {
-  mprintf("\t<name> [<mask1>] [out <filename>]\n"
-          "  Calculate LCPO surface area of atoms in <mask1>, or all solute\n"
-          "  atoms if no mask specified.\n");
+  mprintf("\t<name> [<mask1>] [out <filename>] [solutemask <mask>]\n"
+          "  Calculate LCPO surface area of atoms in <mask1>. If 'solutemask'\n"
+          "  is specified, calculate the contribution of <mask1> to selected\n"
+          "  solute atoms. If solute is not specified, it is considered to be\n"
+          "  any molecule not marked as solvent > 1 atom in size.\n");
 }
 
 // Action_Surf::Init()
@@ -30,6 +32,8 @@ Action::RetType Action_Surf::Init(ArgList& actionArgs, ActionInit& init, int deb
   // Get Masks
   std::string maskexp = actionArgs.GetMaskNext();
   if (!maskexp.empty()) Mask1_.SetMaskString( maskexp );
+  maskexp = actionArgs.GetStringKey("solutemask");
+  if (!maskexp.empty()) SoluteMask_.SetMaskString( maskexp );
 
   // Dataset to store surface area 
   surf_ = init.DSL().AddSet(DataSet::DOUBLE, actionArgs.GetStringNext(), "SA");
@@ -42,6 +46,10 @@ Action::RetType Action_Surf::Init(ArgList& actionArgs, ActionInit& init, int deb
     mprintf("Calculating LCPO surface area for all solute atoms.\n");
   else
     mprintf("Calculating LCPO surface area for atoms in mask '%s'\n", Mask1_.MaskString());
+  if (!SoluteMask_.MaskStringSet())
+    mprintf("\tSolute will be all molecules not marked as solvent with size > 1 atom.\n");
+  else
+    mprintf("\tSolute will be atoms selected by mask '%s'\n", SoluteMask_.MaskString());
   if (outfile != 0) mprintf("\tOutput to '%s'\n", outfile->DataFilename().full());
   mprintf("#Citation: Weiser, J.; Shenkin, P. S.; Still, W. C.; \"Approximate atomic\n"
           "#          surfaces from linear combinations of pairwise overlaps (LCPO).\"\n"

--- a/src/Action_Surf.h
+++ b/src/Action_Surf.h
@@ -45,6 +45,7 @@ class Action_Surf: public Action {
     Parray Params_;       ///< Hold vdW + SA params for atoms in SA_Atoms_ 
     double neighborCut_;    ///< Atoms with vdW > this have neighbors.
     double noNeighborTerm_; ///< SA contribution from atoms with no neighbors.
+    double offset_;         ///< vdW offset; Amber default is 1.4 Ang.
     /// Hold indices of atoms that are neighbors to the current atom.
 #   ifdef _OPENMP
     std::vector<Iarray> Ineighbor_;

--- a/src/Action_Surf.h
+++ b/src/Action_Surf.h
@@ -18,36 +18,44 @@ class Action_Surf: public Action {
     Action::RetType Setup(ActionSetup&);
     Action::RetType DoAction(int, ActionFrame&);
     void Print() {}
-    /// Assign LCPO vdW radius and parameters 1-4.
-//    void AssignLCPO(SurfInfo*, double, double, double, double, double);
-//    void SetAtomLCPO(Topology const&,int, SurfInfo*);
 
-    /// Contain LCPO parameters
-    class SurfInfo;
+    /// Struct for storing vdW and LCPO SA params for an atom
+    struct SurfInfo {
+      double vdwradii;
+      double P1;
+      double P2;
+      double P3;
+      double P4;
+    };
+    /// Assign LCPO vdW radius and parameters 1-4 to given SurfInfo.
+    void AssignLCPO(SurfInfo*, double, double, double, double, double);
+    /// Assign LCPO vdw and parameters to SurfInfo for specified atom.
+    void SetAtomLCPO(Topology const&,int, SurfInfo*);
 
-    DataSet* surf_;        ///< Hold LCPO surface area data
-    AtomMask Mask1_;       ///< Atoms to calculate SA for
-    AtomMask SoluteAtoms_; ///< All solute atoms
+    typedef std::vector<double> Darray;
+    typedef std::vector<int> Iarray;
+    typedef std::vector<SurfInfo> Parray;
 
-};
-/// Hold LCPO parameters
-class Action_Surf::SurfInfo {
-  public:
-    SurfInfo() : vdw_(0.0), P1_(0.0), P2_(0.0), P3_(0.0), P4_(0.0) {}
-//    SurfInfo(double v, double p1, double p2, double p3, double p4) :
-//      vdw_(v), P1_(p1), P2_(p2), P3_(p3), P4_(p4) {}
-    /// CONSTRUCTOR - Set LCPO parameters from atom element/type/#bonds
-    SurfInfo(Atom const&);
-    double VDW() const { return vdw_; }
-    double P1()  const { return P1_; }
-    double P2()  const { return P2_; }
-    double P3()  const { return P3_; }
-    double P4()  const { return P4_; }
-  private:
-    double vdw_;
-    double P1_;
-    double P2_;
-    double P3_;
-    double P4_;
+    DataSet* surf_;       ///< Hold LCPO surface area data
+    AtomMask Mask1_;      ///< Atoms to calculate SA for.
+    AtomMask SoluteMask_; ///< Used to select solute atoms.
+    Iarray HeavyAtoms_;   ///< Solute atoms with vdW > neighborCut (need vdW radii only)
+    Darray VDW_;          ///< Hold vdW radii for HeavyAtoms_
+    Iarray SA_Atoms_;     ///< Selected solute atoms with vdW > neighborCut (need vdW + SA params)
+    Parray Params_;       ///< Hold vdW + SA params for atoms in SA_Atoms_ 
+    double neighborCut_;    ///< Atoms with vdW > this have neighbors.
+    double noNeighborTerm_; ///< SA contribution from atoms with no neighbors.
+    /// Hold indices of atoms that are neighbors to the current atom.
+#   ifdef _OPENMP
+    std::vector<Iarray> Ineighbor_;
+#   else
+    Iarray Ineighbor_;
+#   endif
+    /// Hold distances from current atom to neighbors.
+#   ifdef _OPENMP
+    std::vector<Darray> DIJ_;
+#   else
+    Darray DIJ_;
+#   endif
 };
 #endif

--- a/src/Action_Surf.h
+++ b/src/Action_Surf.h
@@ -18,29 +18,36 @@ class Action_Surf: public Action {
     Action::RetType Setup(ActionSetup&);
     Action::RetType DoAction(int, ActionFrame&);
     void Print() {}
+    /// Assign LCPO vdW radius and parameters 1-4.
+//    void AssignLCPO(SurfInfo*, double, double, double, double, double);
+//    void SetAtomLCPO(Topology const&,int, SurfInfo*);
 
-    DataSet* surf_;
-    AtomMask Mask1_;
-    AtomMask atomi_neighborMask_;
-    AtomMask atomi_noNeighborMask_;
-    AtomMask atomj_neighborMask_;
-    /// Contain data for an atoms LCPO SA calc
-    // TODO: Rework VDW storage
-    struct SurfInfo {
-      double vdwradii;
-      double P1;
-      double P2;
-      double P3;
-      double P4;
-    };
-    /// Contain LCPO data for all atoms in atomi_neighborMask
-    std::vector<SurfInfo> SurfaceInfo_neighbor_;
-    /// Contain LCPO data for all atoms in atomi_noNeighborMask
-    std::vector<SurfInfo> SurfaceInfo_noNeighbor_;
-    /// Contain vdw radii for all atoms
-    std::vector<double> VDW_;
+    /// Contain LCPO parameters
+    class SurfInfo;
 
-    void AssignLCPO(SurfInfo *, double, double, double, double , double );
-    void SetAtomLCPO(Topology const&,int, SurfInfo*);
+    DataSet* surf_;        ///< Hold LCPO surface area data
+    AtomMask Mask1_;       ///< Atoms to calculate SA for
+    AtomMask SoluteAtoms_; ///< All solute atoms
+
+};
+/// Hold LCPO parameters
+class Action_Surf::SurfInfo {
+  public:
+    SurfInfo() : vdw_(0.0), P1_(0.0), P2_(0.0), P3_(0.0), P4_(0.0) {}
+//    SurfInfo(double v, double p1, double p2, double p3, double p4) :
+//      vdw_(v), P1_(p1), P2_(p2), P3_(p3), P4_(p4) {}
+    /// CONSTRUCTOR - Set LCPO parameters from atom element/type/#bonds
+    SurfInfo(Atom const&);
+    double VDW() const { return vdw_; }
+    double P1()  const { return P1_; }
+    double P2()  const { return P2_; }
+    double P3()  const { return P3_; }
+    double P4()  const { return P4_; }
+  private:
+    double vdw_;
+    double P1_;
+    double P2_;
+    double P3_;
+    double P4_;
 };
 #endif


### PR DESCRIPTION
Intended to address #493.

This improves the bookkeeping in the `surf` command so that systems where solute does not begin from the first atom are properly handled. Also introduce some new keywords:

- **[solutemask <mask>]** Allows solute atoms to be specified instead of searched for.
- **[offset <offset>]** (Advanced use only) change the vdW offset (default 1.4 Ang).
- **[nbrcut <cut>]** (Advanced use only) change the neighbor cutoff (default 2.5 Ang.).
