### PR TITLE
Add 'guessbp' option to 'nastruct' to determine base pairing based on strand layout

### DIFF
--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -555,7 +555,7 @@ int Action_NAstruct::DetermineBasePairing() {
               mprintf(", %i hbonds.\n", NHB);
 #             endif
               entry->second.nhb_ = NHB;
-              entry->second.n_wc_hb_ = 2;
+              entry->second.n_wc_hb_ = n_wc_hb;
               entry->second.isAnti_ = AntiParallel;
             } // END if # hydrogen bonds > 0
           } // END if Z angle < cut
@@ -586,11 +586,13 @@ int Action_NAstruct::GuessBasePairing() {
     int s0end = Strands_[sidx0].second;
     int s1beg = Strands_[sidx1].first;
     int s1end = Strands_[sidx1].second;
+#   ifdef NASTRUCTDEBUG
     mprintf("\tStrand %u: %i:%s to %i:%s\n", sidx0,
             Bases_[s0beg].ResNum()+1, Bases_[s0beg].ResName(),
             Bases_[s0end].ResNum()+1, Bases_[s0end].ResName(),
             Bases_[s1beg].ResNum()+1, Bases_[s1beg].ResName(),
             Bases_[s1end].ResNum()+1, Bases_[s1end].ResName());
+#   endif
     int nstrand0 = s0end - s0beg;
     int nstrand1 = s1end - s1beg;
     if (nstrand0 != nstrand1) {

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -525,8 +525,8 @@ int Action_NAstruct::DetermineBasePairing() {
   return 0;
 }
 
-/** Try to guess base pairing based on molecule layout. Assume NA molecules
-  * are laid out 5' to 3', and that consecutive molecules are supposed to
+/** Try to guess base pairing based on strand layout. Assume NA strands
+  * are laid out 5' to 3', and that consecutive strands are supposed to
   * base pair.
   */
 int Action_NAstruct::GuessBasePairing() {
@@ -563,14 +563,14 @@ int Action_NAstruct::GuessBasePairing() {
     int idx1 = s1end;
     for (int idx0 = s0beg; idx0 < s0end + 1; idx0++, idx1--)
     {
-        BPmap::iterator entry =AddBasePair(idx0, Bases_[idx0], idx1, Bases_[idx1]);
-#       ifdef NASTRUCTDEBUG
-        mprintf("\n");
-#       endif
-        // Assume WC and anti-parallel for now
-        entry->second.nhb_ = 0;
-        entry->second.n_wc_hb_ = 0;
-        entry->second.isAnti_ = true;
+      BPmap::iterator entry = AddBasePair(idx0, Bases_[idx0], idx1, Bases_[idx1]);
+#     ifdef NASTRUCTDEBUG
+      mprintf("\n");
+#     endif
+      // Assume WC and anti-parallel for now
+      entry->second.nhb_ = 0;
+      entry->second.n_wc_hb_ = 0;
+      entry->second.isAnti_ = true;
     }
   }
 

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -508,50 +508,9 @@ int Action_NAstruct::DetermineBasePairing() {
           if (t_delta < z_angle_cut_) {
             int NHB = CalcNumHB(*base1, *base2, n_wc_hb);
             if (NHB > 0) {
-              Rpair respair(base1->ResNum(), base2->ResNum());
-              // Bases are paired. Try to find existing base pair.
-              BPmap::iterator entry = BasePairs_.find( respair );
-              if (entry == BasePairs_.end()) {
-                // New base pair
-#               ifdef NASTRUCTDEBUG
-                mprintf("      New base pair: %i to %i", base1->ResNum()+1, base2->ResNum()+1);
-#               endif
-                MetaData md(dataname_, BasePairs_.size() + 1); // Name, index
-                md.SetLegend( base1->BaseName() + base2->BaseName() );
-                BPtype BP;
-                md.SetAspect("shear");
-                BP.shear_   = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                md.SetAspect("stretch");
-                BP.stretch_ = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                md.SetAspect("stagger");
-                BP.stagger_ = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                md.SetAspect("buckle");
-                BP.buckle_  = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                md.SetAspect("prop");
-                BP.prop_    = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                md.SetAspect("open");
-                BP.opening_ = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                md.SetAspect("hb");
-                BP.hbonds_  = (DataSet_1D*)masterDSL_->AddSet(DataSet::INTEGER, md);
-                md.SetAspect("bp");
-                BP.isBP_ = (DataSet_1D*)masterDSL_->AddSet(DataSet::INTEGER, md);
-                if (grooveCalcType_ == PP_OO) {
-                  md.SetAspect("major");
-                  BP.major_   = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                  md.SetAspect("minor");
-                  BP.minor_   = (DataSet_1D*)masterDSL_->AddSet(DataSet::FLOAT, md);
-                } else {
-                  BP.major_ = 0;
-                  BP.minor_ = 0;
-                }
-                BP.bpidx_ = BasePairs_.size();
-                BP.base1idx_ = base1 - Bases_.begin();
-                BP.base2idx_ = base2 - Bases_.begin();
-                entry = BasePairs_.insert( entry, std::pair<Rpair, BPtype>(respair, BP) ); // FIXME does entry make more efficient?
-              }
+              BPmap::iterator entry = AddBasePair(base1-Bases_.begin(), *base1,
+                                                  base2-Bases_.begin(), *base2);
 #             ifdef NASTRUCTDEBUG
-              else
-                mprintf("      Existing base pair: %i to %i", base1->ResNum()+1, base2->ResNum()+1);
               mprintf(", %i hbonds.\n", NHB);
 #             endif
               entry->second.nhb_ = NHB;

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -508,6 +508,12 @@ int Action_NAstruct::DetermineBasePairing() {
   return 0;
 }
 
+/** Try to guess base pairing based on molecule layout. Assume NA molecules
+  * are laid out 5' to 3', and that consecutive molecules are supposed to
+  * base pair.
+  */
+//int Action_NAstruct::GuessBasePairing()
+
 // -----------------------------------------------------------------------------
 // AverageMatrices()
 static Matrix_3x3 AverageMatrices(Matrix_3x3 const& RotatedR1, Matrix_3x3 const& RotatedR2) {
@@ -1193,6 +1199,7 @@ Action::RetType Action_NAstruct::Setup(ActionSetup& setup) {
     return Action::SKIP;
   }
   // Determine base connectivity.
+  int strandNum = 0;
   std::vector<int> Visited( setup.Top().Res(Bases_.back().ResNum()).LastAtom(), 0 );
   for (Barray::iterator base = Bases_.begin(); base != Bases_.end(); ++base) {
     Residue const& res = setup.Top().Res( base->ResNum() );
@@ -1215,6 +1222,9 @@ Action::RetType Action_NAstruct::Setup(ActionSetup& setup) {
       if (c5neighbor == Bases_[idx].ResNum()) base->SetC5Idx( idx );
       if (c3neighbor == Bases_[idx].ResNum()) base->SetC3Idx( idx );
     }
+    // Set NA strand number. If no 3' neighbor increment the strand number.
+    base->SetStrandNum( strandNum );
+    if (c3neighbor == -1) strandNum++;
   }
   // DEBUG - Print base connectivity.
   if (debug_ > 0) {
@@ -1225,7 +1235,7 @@ Action::RetType Action_NAstruct::Setup(ActionSetup& setup) {
         mprintf(" (5'= %s)", setup.Top().TruncResNameNum( Bases_[base->C5resIdx()].ResNum() ).c_str());
       if (base->C3resIdx() != -1)
         mprintf(" (3'= %s)", setup.Top().TruncResNameNum( Bases_[base->C3resIdx()].ResNum() ).c_str());
-      mprintf("\n");
+      mprintf(" %i\n", base->StrandNum());
     }
   }
   return Action::OK;  

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -40,8 +40,8 @@ class Action_NAstruct: public Action {
     // ----- Enumerations ------------------------
     enum HbondType { WC = 0, HOOG, OTHER };
     enum GrooveType { PP_OO = 0, HASSAN_CALLADINE };
-    /// How to find base pairs: first frame, reference structure, all frames.
-    enum FindType { FIRST = 0, REFERENCE, ALL };
+    /// How to find base pairs: first frame, reference structure, all frames, guess.
+    enum FindType { FIRST = 0, REFERENCE, ALL, GUESS };
     // ----- Data Structures ---------------------
     /// Hold a base pair.
     struct BPtype {
@@ -97,6 +97,7 @@ class Action_NAstruct: public Action {
     typedef std::pair<int,int> Rpair;         ///< Pair of residue numbers / BP indices
     typedef std::map<Rpair,BPtype> BPmap;     ///< Map of residue numbers to BP
     typedef std::map<Rpair,StepType> StepMap; ///< Map of BP indices to Steps
+    typedef std::vector<Rpair> StrandArray;   ///< Hold indices into Bases_ for strand beg/end
     // ----- Functions ---------------------------
     /// Recursively travel sugar-phosphate backbone to find the next residue in a strand.
     static int TravelBackbone(Topology const&, int, std::vector<int>&);
@@ -110,8 +111,12 @@ class Action_NAstruct: public Action {
     static HbondType ID_HBtype(NA_Base const&, int, NA_Base const&, int);
     /// Calculate the total number of hydrogen bonds and WC hbonds between two bases.
     int CalcNumHB(NA_Base const&, NA_Base const&, int&);
-    /// Determine which bases are paired, set base pair data .
+    /// \return New/existing base pair corresponding to given bases.
+    BPmap::iterator AddBasePair(int, NA_Base const&, int, NA_Base const&);
+    /// Determine which bases are paired geometrically, set base pair data.
     int DetermineBasePairing();
+    /// Guess which bases are paired based on strand layout.
+    int GuessBasePairing();
     /// Calculate translational/rotational parameters between two axes.
     int calculateParameters(NA_Axis const&, NA_Axis const&, NA_Axis*, double*);
     /// Calculate helical parameters between two axes.
@@ -133,6 +138,7 @@ class Action_NAstruct: public Action {
     Barray Bases_;                      ///< Hold nucleobases
     BPmap BasePairs_;                   ///< Hold base pairs
     StepMap Steps_;                     ///< Hold base pair steps.
+    StrandArray Strands_;               ///< Hold strand info
     NA_Base::PmethodType puckerMethod_; ///< Pucker calculation method.
     double HBdistCut2_;                 ///< distance Cutoff^2 for determining hydrogen bonds
     double originCut2_;                 ///< Cutoff^2 for determining base-pairing vi origins

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -116,7 +116,7 @@ class Action_NAstruct: public Action {
     /// Determine which bases are paired geometrically, set base pair data.
     int DetermineBasePairing();
     /// Guess which bases are paired based on strand layout.
-    int GuessBasePairing();
+    int GuessBasePairing(Topology const&);
     /// Calculate translational/rotational parameters between two axes.
     int calculateParameters(NA_Axis const&, NA_Axis const&, NA_Axis*, double*);
     /// Calculate helical parameters between two axes.
@@ -157,6 +157,7 @@ class Action_NAstruct: public Action {
     CpptrajFile* stepout_;              ///< Base pair step out (BPstep.<suffix>).
     CpptrajFile* helixout_;             ///< Helical parameters out (Helix.<suffix>).
     std::string dataname_;              ///< NA DataSet name (default NA).
+    std::vector<bool> BpTypes_;         ///< Hold specified base pairing types for strands
     // TODO: Replace these with new DataSet type
     DataSetList* masterDSL_;
 #   ifdef NASTRUCTDEBUG

--- a/src/AxisType.cpp
+++ b/src/AxisType.cpp
@@ -334,6 +334,7 @@ NA_Base::NA_Base() :
   rnum_(0),
   c3idx_(-1),
   c5idx_(-1),
+  strandNum_(-1),
   bchar_('?'),
   type_(UNKNOWN_BASE)
 {
@@ -346,6 +347,7 @@ NA_Base::NA_Base(const NA_Base& rhs) :
   rnum_(rhs.rnum_),
   c3idx_(rhs.c3idx_),
   c5idx_(rhs.c5idx_),
+  strandNum_(rhs.strandNum_),
   bchar_(rhs.bchar_),
   type_(rhs.type_),
   Ref_(rhs.Ref_),
@@ -371,6 +373,7 @@ NA_Base& NA_Base::operator=(const NA_Base& rhs) {
     rnum_ = rhs.rnum_;
     c3idx_ = rhs.c3idx_;
     c5idx_ = rhs.c5idx_;
+    strandNum_ = rhs.strandNum_;
     bchar_ = rhs.bchar_;
     type_ = rhs.type_;
     Ref_ = rhs.Ref_;
@@ -505,6 +508,7 @@ int NA_Base::Setup_Base(RefBase const& REF, Residue const& RES, int resnum,
       rnum_ = resnum;
       c3idx_ = -1;
       c5idx_ = -1;
+      strandNum_ = -1;
       bchar_ = REF.BaseChar();
 #     ifdef NASTRUCTDEBUG
       rname_ = RES.Name();

--- a/src/AxisType.h
+++ b/src/AxisType.h
@@ -50,6 +50,7 @@ class NA_Base {
     void SetInputFrame(Frame const&);
     void SetC3Idx(int i)                 { c3idx_ = i;             }
     void SetC5Idx(int i)                 { c5idx_ = i;             }
+    void SetStrandNum(int i)             { strandNum_ = i;         }
     void PrintAtomNames() const;
     NA_Axis&       Axis()                { return axis_;           } //TODO: Remove?
     NA_Axis const& Axis()          const { return axis_;           }
@@ -57,6 +58,7 @@ class NA_Base {
     int ResNum()                   const { return rnum_;           }
     int C3resIdx()                 const { return c3idx_;          }
     int C5resIdx()                 const { return c5idx_;          }
+    int StrandNum()                const { return strandNum_;      }
     char BaseChar()                const { return bchar_;          }
     Frame const& Ref()             const { return Ref_;            }
     Frame const& Input()           const { return Inp_;            }
@@ -90,6 +92,7 @@ class NA_Base {
     int rnum_;                      ///< Original residue number
     int c3idx_;                     ///< Index of c3' neighbor res.
     int c5idx_;                     ///< Index of c5' neighbor res.
+    int strandNum_;                 ///< Internal NA strand number.
     char bchar_;                    ///< 1 char base name.
     NAType type_;                   ///< Base type.
     Frame Ref_;                     ///< Reference coords.


### PR DESCRIPTION
Adds the `guessbp` option to cpptraj `nastruct` which tries to guess base pairing in a very naive way based on how NA strands are laid out. It assumes that consecutive pairs of strands should base pair (i.e. strand 0 to strand 1, strand 2 to strand 3, etc) and that strands are laid out 5' to 3'. The `bptype` argument can be used one or more types to specify the pairing type between strands: `anti` or `para` (parallel). Can be useful for cases where it can be challenging to obtain base pairing via geometric criteria. 