### PR TITLE
Add 'moveanchor' option to 'autoimage'

### DIFF
--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -221,15 +221,36 @@ Action::RetType Action_AutoImage::Setup(ActionSetup& setup) {
   return Action::OK;
 }
 
+/// Round floating point to nearest whole number.
+static inline int ANINT(double xIn) {
+  double fpart, ipart;
+  fpart = modf(xIn, &ipart);
+  if (fpart < 0.0) fpart = -fpart;
+  if (fpart < 0.5)
+    return ipart;
+  if (xIn > 0.0)
+    return ipart + 1.0;
+  else
+    return ipart - 1.0;
+}
+
 static inline int Round(double d, int& dir) {
-  if (d < 0.0) {
+  dir = ANINT(d);
+  if (dir == 0) {
+    dir = 1;
+    return 1;
+  } else
+    return dir + dir;
+/*  if (d < 0.0) {
     dir = -1;
     return floor(d) - 1;
   } else {
     dir = 1;
     return ceil(d) + 1;
   }
+*/
 }
+
 
 // Action_AutoImage::DoAction()
 Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {

--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -290,7 +290,7 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
       double framedist2 = DIST2_NoImage( anchorcenter, framecenter );
       double imageddist2 = DIST2_NoImage( anchorcenter, imagedcenter );
 //      mprintf("DBG: [%5i] Fixed @%i-%i frame dist2=%12.4f, imaged dist2=%12.4f\n",
-//              frameNum, firstAtom+1, lastAtom+1, framedist2, imageddist2);
+//              frameNum, firstAtom+1, lastAtom, framedist2, imageddist2);
       if (imageddist2 < framedist2) {
         // Imaging these atoms moved them closer to anchor. Update coords in currentFrame.
         frm.ModifyFrm().Translate(Trans, firstAtom, lastAtom);

--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -289,8 +289,8 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
       imagedcenter = framecenter + Trans;
       double framedist2 = DIST2_NoImage( anchorcenter, framecenter );
       double imageddist2 = DIST2_NoImage( anchorcenter, imagedcenter );
-      mprintf("DBG: [%5i] Fixed @%i-%i frame dist2=%12.4f, imaged dist2=%12.4f\n",
-              frameNum, firstAtom+1, lastAtom+1, framedist2, imageddist2);
+//      mprintf("DBG: [%5i] Fixed @%i-%i frame dist2=%12.4f, imaged dist2=%12.4f\n",
+//              frameNum, firstAtom+1, lastAtom+1, framedist2, imageddist2);
       if (imageddist2 < framedist2) {
         // Imaging these atoms moved them closer to anchor. Update coords in currentFrame.
         frm.ModifyFrm().Translate(Trans, firstAtom, lastAtom);

--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -2,6 +2,7 @@
 #include "CpptrajStdio.h"
 #include "DistRoutines.h"
 #include "ImageRoutines.h"
+//#incl ude <cmath> // DEBUG
 
 // CONSTRUCTOR
 Action_AutoImage::Action_AutoImage() :
@@ -289,8 +290,9 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
       imagedcenter = framecenter + Trans;
       double framedist2 = DIST2_NoImage( anchorcenter, framecenter );
       double imageddist2 = DIST2_NoImage( anchorcenter, imagedcenter );
-//      mprintf("DBG: [%5i] Fixed @%i-%i frame dist2=%12.4f, imaged dist2=%12.4f\n",
-//              frameNum, firstAtom+1, lastAtom, framedist2, imageddist2);
+//      mprintf("DBG: %5i %3u %6i %6i {%8.2f %8.2f %8.2f} frame dist2=%6.2f, imaged dist2=%6.2f\n",
+//              frameNum, (atom1-fixedList_.begin())/2, firstAtom+1, lastAtom,
+//              Trans[0], Trans[1], Trans[2], sqrt(framedist2), sqrt(imageddist2));
       if (imageddist2 < framedist2) {
         // Imaging these atoms moved them closer to anchor. Update coords in currentFrame.
         frm.ModifyFrm().Translate(Trans, firstAtom, lastAtom);

--- a/src/Action_AutoImage.h
+++ b/src/Action_AutoImage.h
@@ -26,6 +26,7 @@ class Action_AutoImage : public Action {
     bool usecom_;         ///< If true imaging of mobile region uses molecule center.
     bool truncoct_;       ///< If true image into truncated octahedron shape.
     bool useMass_;        ///< If true use center of mass
+    bool movingAnchor_;   ///< If true anchor position set to previous fixed molecule
     enum TriclinicArg {OFF, FORCE, FAMILIAR};
     TriclinicArg triclinic_; ///< Determine whether triclinic code should be used.
 

--- a/src/Action_AutoImage.h
+++ b/src/Action_AutoImage.h
@@ -12,24 +12,24 @@ class Action_AutoImage : public Action {
     Action::RetType DoAction(int, ActionFrame&);
     void Print() {}
 
+    typedef std::vector<int> pairList;
+
+    static pairList SetupAtomRanges(Topology const&, std::string const&);
+
     AtomMask anchorMask_; ///< Used to center anchor region.
     std::string anchor_;  ///< Mask expression for anchor region.
     std::string fixed_;   ///< Mask expression for fixed region.
     std::string mobile_;  ///< Mask expression for mobile region.
+    int debug_;
     bool origin_;         ///< If true imaging occurs w.r.t. coordinate origin.
     bool ortho_;          ///< If true imaging is orthogonal.
     bool usecom_;         ///< If true imaging of mobile region uses molecule center.
-    bool truncoct_;
-    bool useMass_;
+    bool truncoct_;       ///< If true image into truncated octahedron shape.
+    bool useMass_;        ///< If true use center of mass
     enum TriclinicArg {OFF, FORCE, FAMILIAR};
     TriclinicArg triclinic_; ///< Determine whether triclinic code should be used.
 
-    typedef std::vector<int> pairList;
-    pairList anchorList_;
-    pairList fixedList_;
-    pairList mobileList_;
-
-    static pairList SetupAtomRanges(Topology const&, std::string const&, bool);
-    static pairList SetupAtomRanges(Topology const&, std::string const&);
+    pairList fixedList_;  ///< Contain first and last atom indices for fixed elements
+    pairList mobileList_; ///< Contain first and last atom indices for mobile elements.
 };
 #endif


### PR DESCRIPTION
This PR was inspired by a recent post to the [Amber mailing list](http://archive.ambermd.org/201707/0192.html) which involved a hexamer that `autoimage` could not properly image since no molecule or even region of a molecule could be considered to be the "center" of the system.

This PR adds the `moveanchor` option to `autoimage`; instead of a single anchor point, each fixed molecule uses the position of the previous fixed molecule as an anchor (the first fixed molecule still uses the anchor point). This relies on molecules that are close in sequence also being close in space, so it works for this system but may not work in general.

Note: the imaged translation vector calculation that `moveanchor` uses is different than the default (it is a direct calculation instead of a search), although the results so far seem to be the same. I think the new way is a little more efficient but I'd like it to be used for a while before I consider making it the default. Also, since this only pertains to "fixed" molecules, the performance difference will be negligible in most cases. This PR includes some general cleanup of the autoimage code as well.

@hainm There is a test case but since the test files are a bit large I'm keeping them in a separate repository.