### PR TITLE
CHARMM replica log/trajectory processing fixes etc

### DIFF
--- a/src/DataIO_CharmmRepLog.cpp
+++ b/src/DataIO_CharmmRepLog.cpp
@@ -44,11 +44,7 @@ int DataIO_CharmmRepLog::processReadArgs(ArgList& argIn) {
 int DataIO_CharmmRepLog::ReadData(FileName const& fnameIn, 
                             DataSetList& datasetlist, std::string const& dsname)
 {
-  int err = 0;
-  if (nrep_ > 0)
-    err = ReadReplogArray(fnameIn, datasetlist, dsname);
- 
-  return err;
+  return ReadReplogArray(fnameIn, datasetlist, dsname);
 }
 
 int DataIO_CharmmRepLog::ReadReplogArray(FileName const& fnameIn,
@@ -61,13 +57,23 @@ int DataIO_CharmmRepLog::ReadReplogArray(FileName const& fnameIn,
   // Search for replica logs from 0 to nrep-1
   typedef std::vector<FileName> Narray;
   Narray Fnames;
-  for (int i = 0; i != nrep_; i++) {
-    FileName fname( fnameIn.DirPrefix() + prefix + integerToString(i) );
-    if (!File::Exists(fname)) {
-      mprinterr("Error: File '%s' not found.\n", fname.full());
-      return 1;
+  if (nrep_ == 0) {
+    mprintf("\tSearching for replica logs with prefix '%s'\n", prefix.c_str());
+    FileName fname( fnameIn.DirPrefix() + prefix + integerToString(0) );
+    while (File::Exists(fname)) {
+      nrep_++;
+      Fnames.push_back( fname );
+      fname = FileName( fnameIn.DirPrefix() + prefix + integerToString(nrep_) );
     }
-    Fnames.push_back( fname );
+  } else {
+    for (int i = 0; i != nrep_; i++) {
+      FileName fname( fnameIn.DirPrefix() + prefix + integerToString(i) );
+      if (!File::Exists(fname)) {
+        mprinterr("Error: File '%s' not found.\n", fname.full());
+        return 1;
+      }
+      Fnames.push_back( fname );
+    }
   }
   mprintf("\t%zu replica logs.\n", Fnames.size());
   std::vector<int> CoordinateIndices( nrep_ );

--- a/src/DataIO_CharmmRepLog.cpp
+++ b/src/DataIO_CharmmRepLog.cpp
@@ -193,9 +193,12 @@ int DataIO_CharmmRepLog::ReadReplogArray(FileName const& fnameIn,
           mprintf("Info: Hamiltonian (THAM) info detected in log.\n");
         isHREMD = true;
       }
-      // Now actually at the coordinate index
+      // Now actually at the coordinate index (tag)
       int crdidx;
-      sscanf(ptr, "%*31c%5i", &crdidx);
+      // NOTE: We want the tag BEFORE exchange since this is what corresponds
+      //       to any trajectory frames written.
+      //sscanf(ptr, "%*31c%5i", &crdidx);
+      sscanf(ptr, "%*16c%5i", &crdidx);
       // Next line has result
       ptr = infile.Line();
       bool result = (ptr[67]=='T');

--- a/src/DataIO_CharmmRepLog.h
+++ b/src/DataIO_CharmmRepLog.h
@@ -15,6 +15,7 @@ class DataIO_CharmmRepLog : public DataIO {
   private:
     int ReadReplogArray(FileName const&, DataSetList&, std::string const&);
 
-    int nrep_; ///< Number of replicas.
+    std::string crdidx_; ///< Hold user-specified starting coord indices arg
+    int nrep_;           ///< Number of replicas.
 };
 #endif

--- a/src/DataIO_RemLog.cpp
+++ b/src/DataIO_RemLog.cpp
@@ -146,7 +146,7 @@ int DataIO_RemLog::ReadRemdDimFile(FileName const& rd_name,
             return 0;
           }
           //mprintf("\t\tGroup %i\n", group_num);
-          std::vector<int> indices;
+          IdxArray indices;
           int group_index = rd_arg.getNextInteger(-1);
           while (group_index != -1) {
             indices.push_back( group_index );
@@ -206,7 +206,7 @@ int DataIO_RemLog::ReadRemdDimFile(FileName const& rd_name,
 /** buffer should be positioned at the first exchange. */
 DataIO_RemLog::TmapType 
   DataIO_RemLog::SetupTemperatureMap(BufferedLine& buffer,
-                                     std::vector<int>& CrdIdxs) const
+                                     IdxArray& CrdIdxs) const
 {
   TmapType TemperatureMap;
   std::vector<TlogType> tList; // Hold temps and associated coord idxs
@@ -250,7 +250,7 @@ DataIO_RemLog::TmapType
 // DataIO_RemLog::Setup_pH_Map()
 /** buffer should be positioned at the first exchange. */
 DataIO_RemLog::TmapType 
-  DataIO_RemLog::Setup_pH_Map(BufferedLine& buffer, std::vector<int>& CrdIdxs) const
+  DataIO_RemLog::Setup_pH_Map(BufferedLine& buffer, IdxArray& CrdIdxs) const
 {
   TmapType pH_Map;
   std::vector<TlogType> pList; // Hold temps and associated coord idxs
@@ -427,7 +427,7 @@ int DataIO_RemLog::ReadData(FileName const& fnameIn,
   // Temperature map for dimensions (if needed) 
   std::vector<TmapType> TemperatureMap;
   // Coordinate indices for temperature dimensions (if needed)
-  std::vector< std::vector<int> > TempCrdIdxs;
+  std::vector< IdxArray > TempCrdIdxs;
   // Log files for each dimension
   std::vector<BufferedLine> buffer( GroupDims.size() );
   // logFileGroups will be used to hold all dimension replica logs for all runs.
@@ -593,7 +593,8 @@ int DataIO_RemLog::ReadData(FileName const& fnameIn,
   }
 
   // Coordinate indices for each replica. Start crdidx = repidx (from 1) for now.
-  std::vector<int> CoordinateIndices( n_mremd_replicas );
+  typedef DataSet_RemLog::IdxArray IdxArray;
+  IdxArray CoordinateIndices( n_mremd_replicas );
   // Split up crdidx arg
   ArgList idxArgs( crdidx_, "," );
   for (int repidx = 0; repidx < n_mremd_replicas; repidx++) {
@@ -632,13 +633,12 @@ int DataIO_RemLog::ReadData(FileName const& fnameIn,
       return 1;
     }
     mprintf("\tReading final coordinate indices from last frame of existing set.\n");
-    for (int repidx = 0; repidx < n_mremd_replicas; repidx++)
-      CoordinateIndices[repidx] = ((DataSet_RemLog*)ds)->LastRepFrame(repidx).CoordsIdx();
+    CoordinateIndices = ((DataSet_RemLog*)ds)->RestartCrdIndices();
   }
 //  if (!idxArgs.empty()) {
     mprintf("\tInitial coordinate indices:");
-    for (std::vector<int>::const_iterator c = CoordinateIndices.begin();
-                                          c != CoordinateIndices.end(); ++c)
+    for (IdxArray::const_iterator c = CoordinateIndices.begin();
+                                  c != CoordinateIndices.end(); ++c)
       mprintf(" %i", *c);
     mprintf("\n");
 //  }

--- a/src/DataIO_RemLog.cpp
+++ b/src/DataIO_RemLog.cpp
@@ -599,8 +599,8 @@ int DataIO_RemLog::ReadData(FileName const& fnameIn,
   for (int repidx = 0; repidx < n_mremd_replicas; repidx++) {
     if (!idxArgs.empty()) {
       // User-specified starting coord indices
-      CoordinateIndices[repidx] = idxArgs.getNextInteger(0);
-      if (CoordinateIndices[repidx] < 0 || CoordinateIndices[repidx] > n_mremd_replicas )
+      CoordinateIndices[repidx] = idxArgs.getNextInteger(-1);
+      if (CoordinateIndices[repidx] < 1 || CoordinateIndices[repidx] > n_mremd_replicas )
       {
         mprinterr("Error: Given coordinate index out of range or not enough indices given.\n");
         return 1;

--- a/src/DataIO_RemLog.cpp
+++ b/src/DataIO_RemLog.cpp
@@ -417,8 +417,6 @@ int DataIO_RemLog::ReadData(FileName const& fnameIn,
     }
     mprintf("\tExpecting %zu replica dimensions.\n", GroupDims.size());
   }
-  // Split up crdidx arg
-  ArgList idxArgs( crdidx_, "," );
   mprintf("\tReading from log files:");
   for (Sarray::const_iterator it = logFilenames_.begin(); it != logFilenames_.end(); ++it)
     mprintf(" %s", it->c_str());
@@ -596,6 +594,8 @@ int DataIO_RemLog::ReadData(FileName const& fnameIn,
 
   // Coordinate indices for each replica. Start crdidx = repidx (from 1) for now.
   std::vector<int> CoordinateIndices( n_mremd_replicas );
+  // Split up crdidx arg
+  ArgList idxArgs( crdidx_, "," );
   for (int repidx = 0; repidx < n_mremd_replicas; repidx++) {
     if (!idxArgs.empty()) {
       // User-specified starting coord indices

--- a/src/DataIO_RemLog.h
+++ b/src/DataIO_RemLog.h
@@ -21,6 +21,7 @@ class DataIO_RemLog : public DataIO {
     static const char* LogDescription[];
     typedef std::vector<std::string> Sarray; // TODO FileName array?
     typedef std::map<double,int> TmapType; // FIXME: Use ReplicaMap
+    typedef DataSet_RemLog::IdxArray IdxArray;
 
     /// Read remlog header
     int ReadRemlogHeader(BufferedLine&, LogType&, unsigned int) const;
@@ -28,9 +29,9 @@ class DataIO_RemLog : public DataIO {
     int ReadRemdDimFile(FileName const&, DataSet_RemLog::GdimArray&, ReplicaDimArray&);
 
     /// Set up replica temperature map
-    TmapType SetupTemperatureMap(BufferedLine&,std::vector<int>&) const;
+    TmapType SetupTemperatureMap(BufferedLine&, IdxArray&) const;
     /// Set up replica pH map
-    TmapType Setup_pH_Map(BufferedLine&, std::vector<int>&) const;
+    TmapType Setup_pH_Map(BufferedLine&, IdxArray&) const;
     /// Count number of Hamiltonian replicas
     int CountHamiltonianReps(BufferedLine&) const;
 

--- a/src/DataIO_RemLog.h
+++ b/src/DataIO_RemLog.h
@@ -4,7 +4,7 @@
 #include "DataIO.h"
 #include "BufferedLine.h"
 #include "DataSet_RemLog.h"
-/// Read replica exchange log data.
+/// Read Amber replica exchange log data.
 class DataIO_RemLog : public DataIO {
   public:
     DataIO_RemLog();

--- a/src/DataSet_RemLog.h
+++ b/src/DataSet_RemLog.h
@@ -90,6 +90,7 @@ class DataSet_RemLog : public DataSet {
     bool wrap_;                ///< If true highest rep can exchange with lowest
 };
 // ----- Public Class Definitions ----------------------------------------------
+/** Hold information for one exchange of a single replica. */
 class DataSet_RemLog::ReplicaFrame {
   public:
     ReplicaFrame() :

--- a/src/DataSet_RemLog.h
+++ b/src/DataSet_RemLog.h
@@ -57,7 +57,7 @@ class DataSet_RemLog : public DataSet {
     int SetRestartCrdIndices(IdxArray const&);
     /// \return Final coordinate indices. Clear any restart coordinate indices.
     IdxArray RestartCrdIndices();
-     /// \return Final coordinate indices. Clear any restart coordinate indices.
+     /// \return Final coordinate indices. Do not clear restart coordinate indices.
     IdxArray CrdIndicesArg() const;
    
     // ----- DataSet routines --------------------

--- a/src/DataSet_RemLog.h
+++ b/src/DataSet_RemLog.h
@@ -12,6 +12,7 @@ class DataSet_RemLog : public DataSet {
     static DataSet* Alloc() { return (DataSet*)new DataSet_RemLog();}
     /// Replica location in dimension
     enum LocationType { BOTTOM = 0, MIDDLE, TOP };
+    typedef std::vector<int> IdxArray;
     // -------------------------------------------
     /// Used to hold replica partner information. TODO may be redundant/only necessary for Amber remlog
     class GroupReplica;
@@ -52,7 +53,13 @@ class DataSet_RemLog : public DataSet {
     void PrintReplicaStats() const;
     /// \return replica index offset
     int Offset() const { return offset_; }
-    
+    /// Set final coordinate indices if exchanged before final restart written.
+    int SetRestartCrdIndices(IdxArray const&);
+    /// \return Final coordinate indices. Clear any restart coordinate indices.
+    IdxArray RestartCrdIndices();
+     /// \return Final coordinate indices. Clear any restart coordinate indices.
+    IdxArray CrdIndicesArg() const;
+   
     // ----- DataSet routines --------------------
     size_t Size()                       const { return ensemble_.size(); }
 #   ifdef MPI
@@ -74,10 +81,11 @@ class DataSet_RemLog : public DataSet {
     /// Setup a single 1D group.
     void SetupDim1Group(int);
 
-    ReplicaEnsemble ensemble_; // [replica][exchange]
-    GdimArray groupDims_;      // [dim][group][idx]
-    RepInfoArray repInfo_;     // [replica][dim]
-    ReplicaDimArray repDims_;  // [dim]
+    IdxArray finalCrdIdx_;
+    ReplicaEnsemble ensemble_; ///< [replica][exchange]
+    GdimArray groupDims_;      ///< [dim][group][idx]
+    RepInfoArray repInfo_;     ///< [replica][dim]
+    ReplicaDimArray repDims_;  ///< [dim]
     int offset_;               ///< Replica number offset
     bool wrap_;                ///< If true highest rep can exchange with lowest
 };

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -220,7 +220,7 @@ int EnsembleIn_Multi::ReadEnsemble(int currentFrame, FrameArray& f_ensemble,
     else if (targetType_ == ReplicaInfo::CRDIDX) {
       int currentRemExchange = (int)((double)currentFrame * remdFrameFactor_) + remdFrameOffset_;
       //mprintf("DEBUG:\tTrajFrame#=%i  RemdExch#=%i\n", currentFrame+1, currentRemExchange+1);
-      fidx = remlogData_.RepFrame( currentRemExchange, repIdx++ ).CoordsIdx() - 1;
+      fidx = remlogData_.RepFrame(currentRemExchange, repIdx++).CoordsIdx() - remlogData_.Offset();
       //mprintf("DEBUG:\tFrame %i\tPosition %u is assigned index %i\n", currentFrame, member, fidx);
     }
 #   ifndef MPI

--- a/src/EnsembleIn_Multi.cpp
+++ b/src/EnsembleIn_Multi.cpp
@@ -342,10 +342,10 @@ void EnsembleIn_Multi::EnsembleInfo(int showExtended) const {
 std::string EnsembleIn_Multi::FinalCrdIndices() const {
   if (remlogData_.Empty()) return std::string();
   std::string arg("crdidx ");
-  int finalExchg = remlogData_.NumExchange() - 1;
+  DataSet_RemLog::IdxArray rst = remlogData_.CrdIndicesArg();
   for (unsigned int rep = 0; rep < remlogData_.Size(); rep++) {
     if (rep > 0) arg += ",";
-    arg += ( integerToString( remlogData_.RepFrame(finalExchg, rep).CoordsIdx() ) );
+    arg += integerToString( rst[rep] );
   }
   return arg;
 }

--- a/src/Exec_Traj.cpp
+++ b/src/Exec_Traj.cpp
@@ -8,7 +8,9 @@ void Exec_Trajin::Help() const {
           "\t           [ <Format Options> ]\n"
           "\t           [ remdtraj [remdtrajtemp <T> | remdtrajidx <#>]\n"
           "\t             [trajnames <rep1>,<rep2>,...,<repN> ] ]\n"
-          "  Load trajectory specified by <filename> to the input trajectory list.\n");
+          "  Load trajectory specified by <filename> to the input trajectory list.\n"
+          "  If desired, additional velocity or force information can be read from\n"
+          "  files specified by 'mdvel' and/or 'mdfrc'.\n");
   TrajectoryFile::ReadOptions();
 }
 // -----------------------------------------------------------------------------
@@ -16,9 +18,15 @@ void Exec_Ensemble::Help() const {
   mprintf("\t<file0> {[<start>] [<stop> | last] [offset]} | lastframe\n"
           "\t        [%s]\n", DataSetList::TopArgs);
   mprintf("\t        [trajnames <file1>,<file2>,...,<fileN>]\n"
-          "\t        [remlog <remlogfile> [nstlim <nstlim> ntwx <ntwx>]]\n"
+          "\t        [nosort | [remlog <remlogfile> [nstlim <nstlim> ntwx <ntwx>]]]\n"
           "  Load an ensemble of trajectories starting with <file0> that will be\n"
           "  processed together as an ensemble.\n"
+          "  The default behavior is to sort the ensemble by replica. If 'nosort'\n"
+          "  is specified the incoming ensemble will not be sorted; this is useful\n"
+          "  if the ensemble is already sorted or the trajectories are independent.\n"
+          "  If 'remlog' is specified the ensemble will be sorted by coordinate index;\n"
+          "  'nstlim' specifies the number of steps between exchanges and 'ntwx'\n"
+          "  specifies the number of steps between trajectory writes.\n"
           "  When running in parallel, the 'ensemblesize' command can be used to specify\n"
           "  the number of members in the ensemble, which may improve set-up performance.\n");
 }

--- a/src/Traj_CharmmDcd.cpp
+++ b/src/Traj_CharmmDcd.cpp
@@ -330,8 +330,8 @@ int Traj_CharmmDcd::readDcdHeader() {
     }
   } else
     boxBytes_ = 0;
-  // Timestep
-  float timestep = buffer.f[9];
+  // Timestep - convert from AKMA to ps
+  float timestep = buffer.f[9] / Constants::AMBERTIME_TO_PS;
   if (debug_>0) mprintf("\tTimestep is %f\n",timestep);
   // Read end size of first block, should also be 84
   if (ReadBlock(84)<0) return 1;

--- a/test/Makefile
+++ b/test/Makefile
@@ -103,6 +103,7 @@ test.cluster:
 	@-cd Test_Cluster_Kmeans && ./RunTest.sh $(OPT)
 	@-cd Test_Cluster_SymmRMSD && ./RunTest.sh $(OPT)
 	@-cd Test_Cluster_TrajWrites && ./RunTest.sh $(OPT)
+	@-cd Test_Cluster_Dpeaks && ./RunTest.sh $(OPT)
 
 test.ired:
 	@-cd Test_IRED && ./RunTest.sh $(OPT)
@@ -362,6 +363,9 @@ test.volume:
 test.setvelocity:
 	@-cd Test_SetVelocity && ./RunTest.sh $(OPT)
 
+test.remlog:
+	@-cd Test_Remlog && ./RunTest.sh $(OPT)
+
 # Only non-time-consuming tests should go here.
 SHORT_TESTS=test.general \
           test.strip \
@@ -453,7 +457,8 @@ SHORT_TESTS=test.general \
           test.fiximagedbonds \
           test.distance \
           test.volume \
-          test.setvelocity
+          test.setvelocity \
+          test.remlog
 
 # Every test should go here.
 COMPLETETESTS=test.general \
@@ -571,7 +576,8 @@ COMPLETETESTS=test.general \
               test.fiximagedbonds \
               test.distance \
               test.volume \
-              test.setvelocity
+              test.setvelocity \
+              test.remlog
 
 test: test.all 
 


### PR DESCRIPTION
- Automatically search for replica logs when `nrep` not specified.
- Fix sorting by coordinate with CHARMM replica log data.
- Fix output of CHARMM timestep when debugging (time variable still not used).

Also clean up and fix help text, and enable two previously skipped tests that should be run.