### PR TITLE
Fix build with AppleClang in C++11 mode

### DIFF
--- a/src/Analysis_State.h
+++ b/src/Analysis_State.h
@@ -13,8 +13,70 @@ class Analysis_State : public Analysis {
     Analysis::RetType Setup(ArgList&, AnalysisSetup&, int);
     Analysis::RetType Analyze();
   private:
-    class StateType;
-    class Transition;
+    // ----- PRIVATE CLASS DEFINITIONS ---------------------------------------------
+    /// Hold the definition of a state and associated data
+    class StateType {
+      public:
+        StateType() : set_(0), min_(0.0), max_(0.0) {}
+        StateType(std::string const& i, DataSet_1D* d, double m, double x) :
+                  id_(i), set_(d), min_(m), max_(x) {}
+        std::string const& ID() const { return id_; }
+        const char* id()        const { return id_.c_str(); }
+        DataSet_1D const& DS()  const { return *set_; }
+        double Min()            const { return min_; }
+        double Max()            const { return max_; }
+      private:
+        std::string id_;
+        DataSet_1D* set_;
+        double min_;
+        double max_;
+    };
+    /// Hold information about a transition from state0 to state1
+    class Transition {
+      public:
+        Transition() : maxLifetime_(0), sumLifetimes_(0), Nlifetimes_(0), curve_(0) {}
+        Transition(DataSet_double* ds) :
+           maxLifetime_(0), sumLifetimes_(0), Nlifetimes_(0), curve_(ds) {}
+        Transition(int length, DataSet_double* ds) :
+           maxLifetime_(length), sumLifetimes_(length), Nlifetimes_(1), curve_(ds)
+        {
+          DataSet_double& CRV = static_cast<DataSet_double&>( *curve_ );
+          CRV.Resize( length );
+          for (int lc = 0; lc != length; lc++) CRV[lc]++;
+        }
+        void Update(int length) {
+          if (length > maxLifetime_) maxLifetime_ = length;
+          sumLifetimes_ += length;
+          ++Nlifetimes_;
+          DataSet_double& CRV = static_cast<DataSet_double&>( *curve_ );
+          if (length > (int)CRV.Size())
+            CRV.Resize( length );
+          for (int lc = 0; lc != length; lc++)
+            CRV[lc]++;
+        }
+        int Max() const { return maxLifetime_; }
+        int Sum() const { return sumLifetimes_; }
+        int Nlifetimes() const { return Nlifetimes_; }
+        double Avg() const {
+          if (Nlifetimes_ > 0) return (double)sumLifetimes_ / (double)Nlifetimes_;
+          return 0.0;
+        }
+        DataSet_double const& DS() const { return *curve_; }
+        void NormalizeCurve() const {
+          if (curve_->Size() > 0) {
+            DataSet_double& CRV = static_cast<DataSet_double&>( *curve_ );
+            double norm = 1.0 / CRV[0];
+            for (unsigned int i = 0; i != CRV.Size(); i++)
+              CRV[i] *= norm;
+          }
+        }
+      private:
+        int maxLifetime_; ///< Longest time state0 was active before going to state1
+        int sumLifetimes_; ///< Sum of all state0 lifetimes before going to state1
+        int Nlifetimes_; ///< Number of state0 lifetimes before going to state1
+        DataSet_double* curve_; ///< Lifetime curve for state0->state1
+    };
+
     typedef std::vector<StateType> StateArray;
     typedef std::pair<int,int> StatePair;
     typedef std::map<StatePair, Transition> TransMapType;
@@ -35,67 +97,5 @@ class Analysis_State : public Analysis {
     int debug_;
     bool normalize_;
 };
-// ----- PRIVATE CLASS DEFINITIONS ---------------------------------------------
-/// Hold the definition of a state and associated data
-class Analysis_State::StateType {
-  public:
-    StateType() : set_(0), min_(0.0), max_(0.0) {}
-    StateType(std::string const& i, DataSet_1D* d, double m, double x) :
-              id_(i), set_(d), min_(m), max_(x) {}
-    std::string const& ID() const { return id_; }
-    const char* id()        const { return id_.c_str(); }
-    DataSet_1D const& DS()  const { return *set_; }
-    double Min()            const { return min_; }
-    double Max()            const { return max_; }
-  private:
-    std::string id_;
-    DataSet_1D* set_;
-    double min_;
-    double max_;
-};
-/// Hold information about a transition from state0 to state1
-class Analysis_State::Transition {
-  public:
-    Transition() : maxLifetime_(0), sumLifetimes_(0), Nlifetimes_(0), curve_(0) {}
-    Transition(DataSet_double* ds) :
-       maxLifetime_(0), sumLifetimes_(0), Nlifetimes_(0), curve_(ds) {}
-    Transition(int length, DataSet_double* ds) :
-       maxLifetime_(length), sumLifetimes_(length), Nlifetimes_(1), curve_(ds)
-    {
-      DataSet_double& CRV = static_cast<DataSet_double&>( *curve_ );
-      CRV.Resize( length );
-      for (int lc = 0; lc != length; lc++) CRV[lc]++;
-    }
-    void Update(int length) {
-      if (length > maxLifetime_) maxLifetime_ = length;
-      sumLifetimes_ += length;
-      ++Nlifetimes_;
-      DataSet_double& CRV = static_cast<DataSet_double&>( *curve_ );
-      if (length > (int)CRV.Size())
-        CRV.Resize( length );
-      for (int lc = 0; lc != length; lc++)
-        CRV[lc]++;
-    }
-    int Max() const { return maxLifetime_; }
-    int Sum() const { return sumLifetimes_; }
-    int Nlifetimes() const { return Nlifetimes_; }
-    double Avg() const {
-      if (Nlifetimes_ > 0) return (double)sumLifetimes_ / (double)Nlifetimes_;
-      return 0.0;
-    }
-    DataSet_double const& DS() const { return *curve_; }
-    void NormalizeCurve() const {
-      if (curve_->Size() > 0) {
-        DataSet_double& CRV = static_cast<DataSet_double&>( *curve_ );
-        double norm = 1.0 / CRV[0];
-        for (unsigned int i = 0; i != CRV.Size(); i++)
-          CRV[i] *= norm;
-      }
-    }
-  private:
-    int maxLifetime_; ///< Longest time state0 was active before going to state1
-    int sumLifetimes_; ///< Sum of all state0 lifetimes before going to state1
-    int Nlifetimes_; ///< Number of state0 lifetimes before going to state1
-    DataSet_double* curve_; ///< Lifetime curve for state0->state1
-};
+
 #endif

--- a/src/CIFfile.h
+++ b/src/CIFfile.h
@@ -5,8 +5,40 @@
 #include <map>
 /// Used to access CIF files
 class CIFfile {
+  private:
+    typedef std::vector<std::string> Sarray;
+
   public:
-    class DataBlock;
+	/// Used to hold CIF data blocks
+	class DataBlock {
+	  public:
+	    DataBlock() {}
+	    std::string const& Header() const { return dataHeader_;         }
+	    bool empty()                const { return dataHeader_.empty(); }
+	    int AddHeader(std::string const&);
+	    int AddSerialDataRecord(const char*, BufferedLine&);
+	    int AddLoopColumn(const char*, BufferedLine&);
+	    int AddLoopData(const char*, BufferedLine&);
+	    void ListData() const;
+	    int ColumnIndex(std::string const&) const;
+	    /// \return Serial data for given ID
+	    std::string Data(std::string const&) const;
+	    // Iterators
+	    typedef std::vector<Sarray>::const_iterator data_it;
+	    data_it begin() const { return columnData_.begin(); }
+	    data_it end()   const { return columnData_.end();   }
+	  private:
+	    static int ParseData(std::string const&, std::string&, std::string&);
+	    int GetColumnData(int, BufferedLine&, bool);
+
+	    std::string dataHeader_; ///< The data header, e.g. '_atom_site'
+	    Sarray columnHeaders_;   ///< Column headers, e.g. 'label_atom_id'
+	    std::vector<Sarray> columnData_; ///< Array of column data, e.g.:
+	      /*
+	ATOM 1    N N    . SER A 1 1  ? -2.559 9.064   0.084   1.00 0.00 ? ? ? ? ? ? 1  SER A N    1
+	ATOM 2    C CA   . SER A 1 1  ? -3.245 8.118   0.982   1.00 0.00 ? ? ? ? ? ? 1  SER A CA   1
+	       */
+	};
 
     CIFfile() {}
     static bool ID_CIF( CpptrajFile& );
@@ -18,40 +50,10 @@ class CIFfile {
     int AddDataBlock(DataBlock const&);
 
     enum mode { UNKNOWN = 0, SERIAL, LOOP };
-    typedef std::vector<std::string> Sarray;
     BufferedLine file_;
     typedef std::map<std::string, DataBlock> CIF_DataType;
     CIF_DataType cifdata_;
     static const DataBlock emptyblock;
 };
-/// Used to hold CIF data blocks
-class CIFfile::DataBlock {
-  public:
-    DataBlock() {}
-    std::string const& Header() const { return dataHeader_;         }
-    bool empty()                const { return dataHeader_.empty(); }
-    int AddHeader(std::string const&);
-    int AddSerialDataRecord(const char*, BufferedLine&);
-    int AddLoopColumn(const char*, BufferedLine&);
-    int AddLoopData(const char*, BufferedLine&);
-    void ListData() const;
-    int ColumnIndex(std::string const&) const;
-    /// \return Serial data for given ID
-    std::string Data(std::string const&) const;
-    // Iterators
-    typedef std::vector<Sarray>::const_iterator data_it;
-    data_it begin() const { return columnData_.begin(); }
-    data_it end()   const { return columnData_.end();   }
-  private:
-    static int ParseData(std::string const&, std::string&, std::string&);
-    int GetColumnData(int, BufferedLine&, bool);
 
-    std::string dataHeader_; ///< The data header, e.g. '_atom_site'
-    Sarray columnHeaders_;   ///< Column headers, e.g. 'label_atom_id'
-    std::vector<Sarray> columnData_; ///< Array of column data, e.g.:
-      /*
-ATOM 1    N N    . SER A 1 1  ? -2.559 9.064   0.084   1.00 0.00 ? ? ? ? ? ? 1  SER A N    1
-ATOM 2    C CA   . SER A 1 1  ? -3.245 8.118   0.982   1.00 0.00 ? ? ? ? ? ? 1  SER A CA   1
-       */
-};
 #endif


### PR DESCRIPTION
When set to the C++11 standard, AppleClang will not allow you to use forward declarations as template arguments to `std::map` (and others).  This is breaking the CMake build on macs.  I supposed I could set cpptraj to build in C++98 mode, but I feel like we should just fix the issue.  I moved the classes forward in the headers so that the forward declarations are not necessary.