### PR TITLE
Fix use of exclusion list when only part of the system is selected.

### DIFF
--- a/src/Action_Pairwise.cpp
+++ b/src/Action_Pairwise.cpp
@@ -172,6 +172,8 @@ int Action_Pairwise::SetupNonbondParm(AtomMask const& maskIn, Topology const& Pa
   for (AtomMask::const_iterator at0 = maskIn.begin(); at0 != maskIn.end(); ++at0) {
     Atom::excluded_iterator ex = ParmIn[*at0].excludedbegin();
     for (AtomMask::const_iterator at1 = at0 + 1; at1 != maskIn.end(); ++at1) {
+      // Advance excluded list up to current selected atom
+      while (ex != ParmIn[*at0].excludedend() && *ex < *at1) ++ex;
       if (ex != ParmIn[*at0].excludedend() && *at1 == *ex)
         // Atom 1 is excluded from Atom0; just increment to next excluded atom.
         ++ex;
@@ -301,6 +303,9 @@ void Action_Pairwise::NonbondEnergy(Frame const& frameIn, Topology const& parmIn
     for (int idx2 = idx1 + 1; idx2 != maskIn.Nselected(); idx2++)
     {
       int maskatom2 = maskIn[idx2];
+      // Advance excluded list up to current selected atom
+      while (excluded_atom != parmIn[maskatom1].excludedend() && *excluded_atom < maskatom2)
+        ++excluded_atom;
       // If atom is excluded, just increment to next excluded atom;
       // otherwise perform energy calc.
       if ( excluded_atom != parmIn[maskatom1].excludedend() && maskatom2 == *excluded_atom )

--- a/src/Energy.cpp
+++ b/src/Energy.cpp
@@ -206,27 +206,35 @@ double Energy_Amber::Calc_14_Energy(Frame const& fIn, DihedralArray const& Dihed
 // -----------------------------------------------------------------------------
 // Energy_Amber::E_Nonbond()
 double Energy_Amber::E_Nonbond(Frame const& fIn, Topology const& tIn, AtomMask const& mask,
-                               double& Eelec)
+                               double& EelecOut)
 {
   time_NB_.Start();
   double Evdw = 0.0;
-  Eelec = 0.0;
-  for (AtomMask::const_iterator atom1 = mask.begin(); atom1 != mask.end(); ++atom1)
+  double Eelec = 0.0;
+  int idx1;
+# ifdef _OPENMP
+# pragma omp parallel private(idx1) reduction(+ : Eelec, Evdw)
   {
+# pragma omp for
+# endif
+  for (idx1 = 0; idx1 < mask.Nselected(); idx1++)
+  {
+    int atom1 = mask[idx1];
     // Set up coord for this atom
-    const double* crd1 = fIn.XYZ( *atom1 );
+    const double* crd1 = fIn.XYZ( atom1 );
     // Set up exclusion list for this atom
-    Atom::excluded_iterator excluded_atom = tIn[*atom1].excludedbegin();
-    for (AtomMask::const_iterator atom2 = atom1 + 1; atom2 != mask.end(); ++atom2)
+    Atom::excluded_iterator excluded_atom = tIn[atom1].excludedbegin();
+    for (int idx2 = idx1 + 1; idx2 < mask.Nselected(); idx2++)
     {
+      int atom2 = mask[idx2];
       // If atom is excluded, just increment to next excluded atom.
-      if (excluded_atom != tIn[*atom1].excludedend() && *atom2 == *excluded_atom)
+      if (excluded_atom != tIn[atom1].excludedend() && atom2 == *excluded_atom)
         ++excluded_atom;
       else {
-        double rij2 = DIST2_NoImage( crd1, fIn.XYZ( *atom2 ) );
+        double rij2 = DIST2_NoImage( crd1, fIn.XYZ( atom2 ) );
         double rij = sqrt( rij2 );
         // VDW
-        NonbondType const& LJ = tIn.GetLJparam(*atom1, *atom2);
+        NonbondType const& LJ = tIn.GetLJparam(atom1, atom2);
         double r2    = 1.0 / rij2;
         double r6    = r2 * r2 * r2;
         double r12   = r6 * r6;
@@ -235,19 +243,23 @@ double Energy_Amber::E_Nonbond(Frame const& fIn, Topology const& tIn, AtomMask c
         double e_vdw = f12 - f6;      // (A/r^12)-(B/r^6)
         Evdw += e_vdw;
         // Coulomb
-        double qiqj = QFAC * tIn[*atom1].Charge() * tIn[*atom2].Charge();
+        double qiqj = QFAC * tIn[atom1].Charge() * tIn[atom2].Charge();
         double e_elec = qiqj / rij;
         Eelec += e_elec;
 #       ifdef DEBUG_ENERGY
         mprintf("\tEVDW  %4i -- %4i: A=  %12.5e  B=  %12.5e  r2= %12.5f  E= %12.5e\n",
-                *atom1+1, *atom2+1, LJ.A(), LJ.B(), rij2, e_vdw);
+                atom1+1, atom2+1, LJ.A(), LJ.B(), rij2, e_vdw);
         mprintf("\tEELEC %4i -- %4i: q1= %12.5e  q2= %12.5e  r=  %12.5f  E= %12.5e\n",
-                *atom1, *atom2, tIn[*atom1].Charge(), tIn[*atom2].Charge(),
+                atom1+1, atom2+1, tIn[atom1].Charge(), tIn[atom2].Charge(),
                 rij, e_elec);
 #       endif
       }
     }
   }
+# ifdef _OPENMP
+  } // END omp parallel
+# endif
+  EelecOut = Eelec;
   time_NB_.Stop();
   return Evdw;
 }

--- a/src/Energy.cpp
+++ b/src/Energy.cpp
@@ -227,6 +227,8 @@ double Energy_Amber::E_Nonbond(Frame const& fIn, Topology const& tIn, AtomMask c
     for (int idx2 = idx1 + 1; idx2 < mask.Nselected(); idx2++)
     {
       int atom2 = mask[idx2];
+      // Advance excluded list up to current selected atom
+      while (excluded_atom != tIn[atom1].excludedend() && *excluded_atom < atom2) ++excluded_atom;
       // If atom is excluded, just increment to next excluded atom.
       if (excluded_atom != tIn[atom1].excludedend() && atom2 == *excluded_atom)
         ++excluded_atom;
@@ -285,6 +287,8 @@ double Energy_Amber::E_VDW(Frame const& fIn, Topology const& tIn, AtomMask const
     for (int idx2 = idx1 + 1; idx2 < mask.Nselected(); idx2++)
     {
       int atom2 = mask[idx2];
+      // Advance excluded list up to current selected atom
+      while (excluded_atom != tIn[atom1].excludedend() && *excluded_atom < atom2) ++excluded_atom;
       // If atom is excluded, just increment to next excluded atom.
       if (excluded_atom != tIn[atom1].excludedend() && atom2 == *excluded_atom)
         ++excluded_atom;
@@ -334,6 +338,8 @@ double Energy_Amber::E_Elec(Frame const& fIn, Topology const& tIn, AtomMask cons
     for (int idx2 = idx1 + 1; idx2 < mask.Nselected(); idx2++)
     {
       int atom2 = mask[idx2];
+      // Advance excluded list up to current selected atom
+      while (excluded_atom != tIn[atom1].excludedend() && *excluded_atom < atom2) ++excluded_atom;
       // If atom is excluded, just increment to next excluded atom.
       if (excluded_atom != tIn[atom1].excludedend() && atom2 == *excluded_atom)
         ++excluded_atom;


### PR DESCRIPTION
Addresses #525.

The way exclusion lists were being used in calculation loops, the inner loop was expected to traverse all atoms from the current atom on. Solution is to iterate exclusion list up to or beyond the current atom before the exclusion check.

This PR also adds OpenMP to the nonbonded routines in Energy.