### PR TITLE
Fix 'autoimage moveanchor' for non-orthorhombic cells

### DIFF
--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -309,7 +309,7 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
         // New anchor is previous fixed mol
         anchorcenter = minImage;
       } else {
-        anchorcenter = framecenter;
+        Vec3 newAnchor = framecenter;
         Trans = Image::Nonortho(framecenter, truncoct_, origin_, ucell, recip, fcom, -1.0);
         // If molecule was imaged, determine whether imaged position is closer to anchor.
         if (Trans[0] != 0 || Trans[1] != 0 || Trans[2] != 0) {
@@ -323,9 +323,10 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
           if (imageddist2 < framedist2) {
             // Imaging these atoms moved them closer to anchor. Update coords in currentFrame.
             frm.ModifyFrm().Translate(Trans, firstAtom, lastAtom);
-            anchorcenter = imagedcenter;
+            newAnchor = imagedcenter;
           }
         }
+        anchorcenter = newAnchor;
       }
     }
   } else {

--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -249,7 +249,8 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
   Vec3 bp, bm, offset(0.0);
   Vec3 Trans, framecenter, imagedcenter, anchorcenter;
 
-  if (!ortho_) frm.Frm().BoxCrd().ToRecip(ucell, recip);
+  Box const& box = frm.Frm().BoxCrd();
+  if (!ortho_) box.ToRecip(ucell, recip);
   // Store anchor point in fcom for now.
   if (useMass_)
     fcom = frm.Frm().VCenterOfMass( anchorMask_ );
@@ -265,7 +266,7 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
     // Center on box center
     if (ortho_ || truncoct_)
       // Center is box xyz over 2
-      anchorcenter = frm.Frm().BoxCrd().Center();
+      anchorcenter = box.Center();
     else
       // Center in frac coords is (0.5,0.5,0.5)
       anchorcenter = ucell.TransposeMult(Vec3(0.5));
@@ -276,7 +277,7 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
   // Setup imaging, and image everything in current Frame
   // according to mobileList_.
   if (ortho_) {
-    if (Image::SetupOrtho(frm.Frm().BoxCrd(), bp, bm, origin_)) {
+    if (Image::SetupOrtho(box, bp, bm, origin_)) {
       mprintf("Warning: Frame %i imaging failed, box lengths are zero.\n",frameNum+1);
       // TODO: Return OK for now so next frame is tried; eventually indicate SKIP?
       return Action::OK; // FIXME return MODIFY_COORDS instead?
@@ -345,7 +346,7 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
         framecenter = frm.Frm().VGeometricCenter(firstAtom, lastAtom);
       // Determine if molecule would be imaged.
       if (ortho_)
-        Trans = Image::Ortho(framecenter, bp, bm, frm.Frm().BoxCrd());
+        Trans = Image::Ortho(framecenter, bp, bm, box);
       else
         Trans = Image::Nonortho(framecenter, truncoct_, origin_, ucell, recip, fcom, -1.0);
       // If molecule was imaged, determine whether imaged position is closer to anchor.

--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -229,19 +229,6 @@ Action::RetType Action_AutoImage::Setup(ActionSetup& setup) {
   return Action::OK;
 }
 
-/// Round floating point to nearest whole number.
-static inline double ANINT(double xIn) {
-  double fpart, ipart;
-  fpart = modf(xIn, &ipart);
-  if (fpart < 0.0) fpart = -fpart;
-  if (fpart < 0.5)
-    return ipart;
-  if (xIn > 0.0)
-    return ipart + 1.0;
-  else
-    return ipart - 1.0;
-}
-
 // Action_AutoImage::DoAction()
 Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
   Matrix_3x3 ucell, recip;
@@ -307,7 +294,7 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
 
       // Determine direction from molecule to anchor
       Vec3 delta = anchorcenter - framecenter;
-//      mprintf("DEBUG: anchorcenter - framecenter = %g %g %g\n", delta[0], delta[1], delta[2]);
+      //mprintf("DEBUG: anchorcenter - framecenter = %g %g %g\n", delta[0], delta[1], delta[2]);
       // Determine distance in terms of box lengths
       Vec3 Dxyz, minTrans;
       if (ortho_) {
@@ -315,12 +302,14 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
         minTrans[1] = floor(delta[1]/box.BoxY()+0.5)*box.BoxY();
         minTrans[2] = floor(delta[2]/box.BoxZ()+0.5)*box.BoxZ();
       } else {
-        Dxyz = recip * delta;
-        minTrans = ucell.TransposeMult( Vec3(ANINT(Dxyz[0]),
-                                             ANINT(Dxyz[1]),
-                                             ANINT(Dxyz[2])) );
+        Vec3 fDelta = (recip * delta) + 0.5;
+        fDelta[0] = floor(fDelta[0]);
+        fDelta[1] = floor(fDelta[1]);
+        fDelta[2] = floor(fDelta[2]);
+        //fDelta.Print("floor(fDelta+0.5)");
+        minTrans = ucell.TransposeMult( fDelta );
+        //minTrans.Print("minTrans");
       }
-//      Dxyz.Print("Dxyz");
       Vec3 minImage = framecenter + minTrans;
 //      mprintf("DBG: %5i %3u %6i %6i {%8.2f %8.2f %8.2f}\n",
 //              frameNum, (atom1-fixedList_.begin())/2, firstAtom+1, lastAtom,

--- a/src/Action_AutoImage.cpp
+++ b/src/Action_AutoImage.cpp
@@ -311,10 +311,9 @@ Action::RetType Action_AutoImage::DoAction(int frameNum, ActionFrame& frm) {
       // Determine distance in terms of box lengths
       Vec3 Dxyz, minTrans;
       if (ortho_) {
-        Dxyz = delta / frm.Frm().BoxCrd().Lengths();
-        minTrans = Vec3(ANINT(Dxyz[0]) * frm.Frm().BoxCrd().BoxX(),
-                        ANINT(Dxyz[1]) * frm.Frm().BoxCrd().BoxY(),
-                        ANINT(Dxyz[2]) * frm.Frm().BoxCrd().BoxZ());
+        minTrans[0] = floor(delta[0]/box.BoxX()+0.5)*box.BoxX();
+        minTrans[1] = floor(delta[1]/box.BoxY()+0.5)*box.BoxY();
+        minTrans[2] = floor(delta[2]/box.BoxZ()+0.5)*box.BoxZ();
       } else {
         Dxyz = recip * delta;
         minTrans = ucell.TransposeMult( Vec3(ANINT(Dxyz[0]),


### PR DESCRIPTION
Switching from Cartesian to fractional coordinate systems can "stretch" distances, so the approach used to determine the closest translation vector for orthorhombic cells with the `moveanchor` option did not always work for non-orthorhombic cells. Also simplifies the orthorhombic case - no longer need the pseudo `ANINT` call - just use `floor()`.