### PR TITLE
Add INSTALL_HEADERS option to CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,15 +48,31 @@ if(NOT INSIDE_AMBER)
 	set(BUNDLE_IDENTIFIER org.ambermd.cpptraj)
 	set(BUNDLE_SIGNATURE CPTJ)
 	include(Packaging)
+	
+	# header installation option
+	option(INSTALL_HEADERS "Copy headers to the include/cpptraj folder of the install directory.  Useful for building with pytraj." FALSE)
+else()
+	set(INSTALL_HEADERS FALSE)
 endif()
 
 # on Windows, make MSVC auto-create import libraries just like MinGW does
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-#NetCDF and FFTW3 are found by the top-level configure script
-
 add_subdirectory(src)
 
+#--------------------------------------------------------------
+if(INSTALL_HEADERS)
+	# grab all .h files from the main directory.
+	file(GLOB CPPTRAJ_HEADERS "src/*.h")
+	
+	# also grab xdrfile headers since some of them are used by cpptraj headers
+	file(GLOB XDRFILE_HEADERS "src/xdrfile/*.h")
+
+	install(FILES ${CPPTRAJ_HEADERS} DESTINATION ${INCDIR}/cpptraj)
+	install(FILES ${XDRFILE_HEADERS} DESTINATION ${INCDIR}/cpptraj/xdrfile)
+endif()
+
+#--------------------------------------------------------------	
 if(NOT INSIDE_AMBER)
 	print_build_report()
 endif()

--- a/src/Action_CheckStructure.cpp
+++ b/src/Action_CheckStructure.cpp
@@ -1,3 +1,5 @@
+#include <algorithm> // min and max
+
 #include "Action_CheckStructure.h"
 #include "CpptrajStdio.h"
 #ifdef MPI

--- a/src/DataIO_Grace.cpp
+++ b/src/DataIO_Grace.cpp
@@ -1,4 +1,5 @@
 #include <cstdio> // sscanf
+#include <algorithm>
 #include "DataIO_Grace.h"
 #include "CpptrajStdio.h"
 #include "BufferedLine.h"

--- a/src/PairList.cpp
+++ b/src/PairList.cpp
@@ -1,4 +1,5 @@
 #include <cmath> // floor
+#include <algorithm> // min and max
 #include "PairList.h"
 #include "CpptrajStdio.h"
 #include "StringRoutines.h" // ByteString()


### PR DESCRIPTION
This make it a bit easier to use pytraj with the CMake build system.  When `INSTALL_HEADERS` is set to `TRUE`, then all of cpptraj's headers will get copied to the installation directory, and someone building pytraj can just set their `CPPTRAJ_HEADERDIR` variable to point there.

Also, I don't know if you followed [this PR](https://github.com/Amber-MD/cmake-buildscripts/issues/29), but the gist of it is that we need to add a few dllimports and dllexports to cpptraj to get it to work properly in Windows (also Pytraj works in Windows now, yay).  Probably this would mean putting something like the following in a central header:
```c
#ifdef _WIN32
# ifdef CPPTRAJ_EXPORTS
#  define EXPORTED_SYMBOL __declspec(dllexport)
# else
#  define EXPORTED_SYMBOL __declspec(dllimport)
# endif
#else
# define EXPORTED_SYMBOL
#endif
```
and then putting the `EXPORTED_SYMBOL` qualifier on every static class member.

This will make it so CMake 3.4+ can be used on Windows.  Apparently, the CMake people are working on fixing the auto-export of constants, but I don't know when or if it will be merged.  So we also have the option of waiting a few months to see if this becomes unnecessary.  However, if you don't mind putting these ugly declarations on your code, I'd prefer to fix the issue now.  Let me know whether you want to add the import declarations, and where to put the above block, and I can get started.