### PR TITLE
More information for 'trajout'; add 'mdvel' and 'mdfrc' options to Amber ASCII trajout

### DIFF
--- a/src/Action_Outtraj.cpp
+++ b/src/Action_Outtraj.cpp
@@ -104,12 +104,16 @@ int Action_Outtraj::SyncAction() {
 
 // Action_Outtraj::Setup()
 Action::RetType Action_Outtraj::Setup(ActionSetup& setup) {
-  if (!isActive_ || associatedParm_->Pindex() != setup.Top().Pindex())
+  if (!isActive_ || associatedParm_->Pindex() != setup.Top().Pindex()) {
+    mprintf("\tOutput trajectory not active for topology '%s'\n", setup.Top().c_str());
     return Action::SKIP;
+  }
   if (!isSetup_) { // TODO: Trajout IsOpen?
     if (outtraj_.SetupTrajWrite(setup.TopAddress(), setup.CoordInfo(), setup.Nframes()))
       return Action::ERR;
+    mprintf("      "); //TODO this is a kludge; PrintInfo should be a string.
     outtraj_.PrintInfo(0);
+    mprintf("\tHas %s\n", outtraj_.Traj().CoordInfo().InfoString().c_str());
     isSetup_ = true;
   }
   return Action::OK;
@@ -145,5 +149,6 @@ void Action_Outtraj::Print() {
   int frames_written = outtraj_.Traj().NframesWritten();
 # endif
   if (frames_written > 0)
-    mprintf("    OUTTRAJ: [%s] Wrote %i frames.\n",outtraj_.Traj().Filename().base(), frames_written);
+    mprintf("    OUTTRAJ: '%s': Wrote %i frames.\n",
+            outtraj_.Traj().Filename().base(), frames_written);
 }

--- a/src/CoordinateInfo.cpp
+++ b/src/CoordinateInfo.cpp
@@ -12,6 +12,25 @@ void CoordinateInfo::PrintCoordInfo(const char* name, const char* parm) const {
   mprintf(" }\n");
 }
 
+static inline void Append(std::string& meta, std::string const& str) {
+  if (meta.empty())
+    meta.assign( str );
+  else
+    meta.append(", " + str);
+}
+
+std::string CoordinateInfo::InfoString() const {
+  std::string meta;
+  if ( HasCrd() )         Append(meta, "coordinates");
+  if ( HasVel() )         Append(meta, "velocities");
+  if ( HasForce() )       Append(meta, "forces");
+  if ( HasTemp() )        Append(meta, "temperature");
+  if ( HasTime() )        Append(meta, "time");
+  if ( HasReplicaDims() ) Append(meta, "replicaDims");
+  if ( HasBox() )         Append(meta, "box");
+  return meta;
+}
+
 #ifdef MPI
 int CoordinateInfo::SyncCoordInfo(Parallel::Comm const& commIn) {
   // ensSize, hasvel, hastemp, hastime, hasfrc, NrepDims, Dim1, ..., DimN, 

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -1,5 +1,6 @@
 #ifndef INC_COORDINATEINFO_H
 #define INC_COORDINATEINFO_H
+#include <string>
 #include "ReplicaDimArray.h"
 #include "Box.h"
 #ifdef MPI
@@ -43,6 +44,8 @@ class CoordinateInfo {
     void SetReplicaDims(ReplicaDimArray const& r) { remdDim_ = r; }
     /// Print coordinate info to STDOUT
     void PrintCoordInfo(const char*, const char*) const;
+    /// \return string containing info on present metadata
+    std::string InfoString() const;
 #   ifdef MPI
     int SyncCoordInfo(Parallel::Comm const&);
 #   endif

--- a/src/EnsembleOutList.cpp
+++ b/src/EnsembleOutList.cpp
@@ -54,6 +54,7 @@ int EnsembleOutList::AddEnsembleOut(std::string const& fname, ArgList const& arg
   return 0;
 }
 
+// EnsembleOutList::SetupEnsembleOut()
 int EnsembleOutList::SetupEnsembleOut(Topology* CurrentParm, CoordinateInfo const& cInfo,
                                       int Nframes)
 {
@@ -72,7 +73,26 @@ int EnsembleOutList::SetupEnsembleOut(Topology* CurrentParm, CoordinateInfo cons
       active_.push_back( ensout_[i] );
     }
   }
+  ListActive();
   return 0;
+}
+
+/** List only active output trajectories. */
+void EnsembleOutList::ListActive() const {
+  if (!ensout_.empty()) {
+    mprintf(".....................................................\n");
+    if (!active_.empty()) {
+      mprintf("ACTIVE OUTPUT ENSEMBLES (%zu):\n", active_.size());
+      for (EnsArray::const_iterator it = active_.begin(); it != active_.end(); ++it)
+      {
+        mprintf("  %s", (*it)->Traj().Filename().full());
+        std::string meta = (*it)->Traj().CoordInfo().InfoString();
+        if (!meta.empty()) mprintf(" (%s)", meta.c_str());
+        mprintf("\n");
+      }
+    } else
+      mprintf("NO ACTIVE OUTPUT ENSEMBLES.\n");
+  }
 }
 
 /** Go through each active output traj, call write. */
@@ -130,6 +150,7 @@ int EnsembleOutList::ParallelSetupEnsembleOut(Topology* CurrentParm,
       active_.push_back( ensout_[i] );
     }
   }
+  ListActive();
   return 0;
 }
 #endif

--- a/src/EnsembleOutList.h
+++ b/src/EnsembleOutList.h
@@ -24,6 +24,8 @@ class EnsembleOutList {
     int ParallelSetupEnsembleOut(Topology*, CoordinateInfo const&, int, Parallel::Comm const&);
 #   endif
   private:
+    void ListActive() const;
+
     int debug_;
     typedef std::vector<Topology*> TopArray;
     typedef std::vector<EnsembleOut*> EnsArray;

--- a/src/Traj_AmberCoord.cpp
+++ b/src/Traj_AmberCoord.cpp
@@ -471,7 +471,7 @@ int Traj_AmberCoord::parallelSetupTrajout(FileName const& fname, Topology* trajP
       file_.SetupAppend( fname, debug_ );
     else
       file_.SetupWrite( fname, debug_ );
-    if (highPrecision_) outFmt_ = "%8.6f";
+    if (highPrecision_) outfmt_ = "%8.6f";
   }
   // For parallel output we will need to seek. Set up the buffer again with correct offsets.
   // Figure out the size of the written title.

--- a/src/Traj_AmberCoord.h
+++ b/src/Traj_AmberCoord.h
@@ -9,21 +9,7 @@ class Traj_AmberCoord: public TrajectoryIO {
     static BaseIOtype* Alloc() { return (BaseIOtype*)new Traj_AmberCoord(); }
     static void WriteHelp();
   private:
-    int natom3_;          ///< Number of coords (# atoms X 3)
-    // TODO: Replace hasREMD with REMD_HEADER_SIZE/HasT()
-    size_t headerSize_;   ///< REMD header size if present
-    size_t tStart_;       ///< Start position for T-value in header
-    size_t tEnd_;         ///< End position for T-value in header
-    int numBoxCoords_;    ///< Number of box coords, 3 (ortho or truncoct) or 6 (triclinic)
-    const char* outfmt_;  ///< Format string for writing coordinates
-    bool highPrecision_;  ///< If true output format will be 8.6 instead of 8.3
-    bool outputTemp_;     ///< If true temperature will be out to REMD line.
-    BufferedFrame file_;  ///< Buffer reads/writes
-    double boxAngle_[3];  ///< Hold default box angles in case traj has only box lengths
-
-    static const size_t REMD_HEADER_SIZE;
-    static const size_t RXSGLD_HEADER_SIZE;
-
+    enum WriteType { COORDS= 0, VEL, FRC };
     // Inherited functions
     bool ID_TrajFormat(CpptrajFile&);
     int setupTrajin(FileName const&, Topology*);
@@ -35,7 +21,7 @@ class Traj_AmberCoord: public TrajectoryIO {
     void Info();
     int processWriteArgs(ArgList&);
     int readVelocity(int, Frame&);
-    int readForce(int, Frame&)     { return 1; }
+    int readForce(int, Frame&);
     int processReadArgs(ArgList&)  { return 0; }
 #   ifdef MPI
     // Parallel functions
@@ -47,5 +33,20 @@ class Traj_AmberCoord: public TrajectoryIO {
     int parallelWriteFrame(int, Frame const&);
     void parallelCloseTraj();
 #   endif
+
+    static const size_t REMD_HEADER_SIZE;
+    static const size_t RXSGLD_HEADER_SIZE;
+
+    BufferedFrame file_;  ///< Buffer reads/writes
+    const char* outfmt_;  ///< Format string for writing coordinates
+    size_t headerSize_;   ///< REMD header size if present
+    size_t tStart_;       ///< Start position for T-value in header
+    size_t tEnd_;         ///< End position for T-value in header
+    double boxAngle_[3];  ///< Hold default box angles in case traj has only box lengths
+    int natom3_;          ///< Number of coords (# atoms X 3)
+    int numBoxCoords_;    ///< Number of box coords, 3 (ortho or truncoct) or 6 (triclinic)
+    WriteType writeType_; ///< What to write out (coordinates/velocities/forces)
+    bool highPrecision_;  ///< If true output format will be 8.6 instead of 8.3
+    bool outputTemp_;     ///< If true temperature will be out to REMD line.
 };
 #endif

--- a/src/TrajoutList.cpp
+++ b/src/TrajoutList.cpp
@@ -70,7 +70,33 @@ int TrajoutList::SetupTrajout(Topology* CurrentParm, CoordinateInfo const& cInfo
       active_.push_back( trajout_[i] );
     }
   }
+  ListActive();
   return 0;
+}
+
+static inline void Append(std::string& meta, std::string const& str) {
+  if (meta.empty())
+    meta.assign( str );
+  else
+    meta.append(", " + str);
+}
+
+/** List only active output trajectories. */
+void TrajoutList::ListActive() const {
+  if (!trajout_.empty()) {
+    mprintf(".....................................................\n");
+    if (!active_.empty()) {
+      mprintf("ACTIVE OUTPUT TRAJECTORIES (%zu):\n", active_.size());
+      for (ListType::const_iterator it = active_.begin(); it != active_.end(); ++it)
+      {
+        mprintf("  %s", (*it)->Traj().Filename().full());
+        std::string meta = (*it)->Traj().CoordInfo().InfoString();
+        if (!meta.empty()) mprintf(" (%s)", meta.c_str());
+        mprintf("\n");
+      }
+    } else
+      mprintf("NO ACTIVE OUTPUT TRAJECTORIES.\n");
+  }
 }
 
 // TrajoutList::WriteTrajout()
@@ -137,6 +163,7 @@ int TrajoutList::ParallelSetupTrajout(Topology* CurrentParm,
               CurrentParm->c_str());
     }
   }
+  ListActive();
   return 0;
 }
 #endif

--- a/src/TrajoutList.h
+++ b/src/TrajoutList.h
@@ -24,6 +24,8 @@ class TrajoutList {
     int ParallelSetupTrajout(Topology*, CoordinateInfo const&, int, Parallel::Comm const&);
 #   endif
   private:
+    void ListActive() const;
+
     int debug_;
     typedef std::vector<Topology*> TopArray;
     typedef std::vector<Trajout_Single*> ListType;

--- a/test/Test_Density/RunTest.sh
+++ b/test/Test_Density/RunTest.sh
@@ -8,7 +8,7 @@ out2=mass_density.dat
 out3=charge_density.dat
 out4=electron_density.dat
 
-CleanFiles $in $out1 $out2 $out3 $out4
+CleanFiles $in $out1 $out2 $out3 $out4 total.dat
 
 INPUT="-i $in"
 NotParallel "Density test."

--- a/test/Test_VelFrc/RunTest.sh
+++ b/test/Test_VelFrc/RunTest.sh
@@ -2,7 +2,7 @@
 
 . ../MasterTest.sh
 
-CleanFiles cpptraj.in CrdFrcVel.nc Vel.crd Frc.crd
+CleanFiles cpptraj.in CrdFrcVel.nc Vel.crd Frc.crd Vel1.crd Frc1.crd
 
 NotParallel "Separate velocity/force"
 if [ "$?" -eq 1 ] ; then
@@ -30,11 +30,27 @@ DoTest Vel.crd.save Vel.crd
 
 cat > cpptraj.in <<EOF
 parm ../tz2.nhe.parm7
+trajin CrdFrcVel.nc
+trajout Vel1.crd mdvel
+EOF
+RunCpptraj "Test writing velocities (MDVEL)"
+DoTest Vel.crd.save Vel1.crd
+
+cat > cpptraj.in <<EOF
+parm ../tz2.nhe.parm7
 trajin CrdFrcVel.nc usefrcascoords
 trajout Frc.crd
 EOF
 RunCpptraj "Test using forces as coordinates."
 DoTest Frc.crd.save Frc.crd
+
+cat > cpptraj.in <<EOF
+parm ../tz2.nhe.parm7
+trajin CrdFrcVel.nc
+trajout Frc1.crd mdfrc
+EOF
+RunCpptraj "Test writing forces (MDFRC)"
+DoTest Frc.crd.save Frc1.crd
 
 EndTest
 exit 0


### PR DESCRIPTION
This PR adds some more information written to STDOUT when an output trajectory is setup that states what information is being passed to the output trajectory, e.g.
```
.....................................................
ACTIVE OUTPUT TRAJECTORIES (1):
  CrdFrcVel.nc (coordinates, velocities, forces, time)
```
Note that this only states what the output trajectory *can* write out, not what it will actually write out. If that becomes confusing may need to add a clarification.

Also adds two new keywords for Amber ASCII trajout: `mdvel` and `mdfrc` to write velocities and forces respectively instead of coordinates.