### PR TITLE
Do not use 'dacdif' for test comparisons in AmberTools

### DIFF
--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -79,7 +79,7 @@ DESCRIP=''               # Current test/unit name for CheckEnv routine.
 # TestHeader() <outfile>
 #   Write test header (working directory) to specified file.
 TestHeader() {
-  echo "**************************************************************" > $1
+  echo "********************************************************************************" > $1
   echo "TEST: $TEST_WORKDIR" >> $1
 }
 

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -851,8 +851,6 @@ SkipTest() {
   echo "  SKIP: $1"
   if [ -z "$CPPTRAJ_DACDIF" ] ; then
     OUT "  SKIP: $1"
-  else
-    echo "  SKIP: $1"
   fi
   echo ""
   TEST_SKIPPED=1
@@ -866,8 +864,6 @@ SkipCheck() {
   echo "  Skipped test: $1"
   if [ -z "$CPPTRAJ_DACDIF" ] ; then
     OUT "  Skipped test: $1"
-  else
-    echo "  Skipped test: $1"
   fi
   ((SKIPCOUNT++))
   # Reset check count FIXME needed?
@@ -1188,7 +1184,7 @@ if [ -z "$CPPTRAJ_TEST_SETUP" ] ; then
   #fi
   export CPPTRAJ_DACDIF
   export CPPTRAJ_DIFF
-  # If not cleaning see what else needs to be set up. 
+  # If not cleaning see what else needs to be set up.
   if [ $CPPTRAJ_TEST_CLEAN -eq 0 ] ; then
     # Determine binary locations
     SetBinaries

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -10,7 +10,7 @@
 #   AMBPDB               : Set to ambpdb binary being tested.
 #   VALGRIND             : Set to 'valgrind' command if memory check requested.
 #   CPPTRAJ_DIFF         : Command used to check for test differences.
-#   CPPTRAJ_DACDIF       : Set if using 'dacdif' in AmberTools to checkout for test differences.
+#   CPPTRAJ_DACDIF       : Set if testing inside AmberTools.
 #   CPPTRAJ_NDIFF        : Set to Nelson H. F. Beebe's ndiff.awk for numerical diff calc.
 #   CPPTRAJ_NCDUMP       : Set to ncdump command; needed for NcTest()
 #   CPPTRAJ_RM           : Command used to remove files
@@ -106,6 +106,7 @@ OutBoth() {
 #   \return 0 if both present, 1 if either one absent.
 CheckTestFiles() {
   if [ -z "$CPPTRAJ_DACDIF" ] ; then
+    # Standalone output.
     if [ ! -f "$1" ] ; then
       OutBoth "  Save file '$1' not found."
     elif [ ! -f "$2" ] ; then
@@ -156,7 +157,7 @@ DoTest() {
     ((ERRCOUNT++))
   else
     if [ ! -z "$CPPTRAJ_DACDIF" ] ; then
-      # Print AT test header
+      # Print AT test header.
       echo "diffing $F1 with $F2"
     fi
     if [ $USE_NDIFF -eq 0 ] ; then
@@ -189,6 +190,7 @@ DoTest() {
     $CPPTRAJ_RM temp.diff
   fi
   if [ ! -z "$CPPTRAJ_DACDIF" ] ; then
+    # Print AT test footer.
     echo "=============================================================="
   fi
 }
@@ -849,6 +851,8 @@ SkipTest() {
   echo "  SKIP: $1"
   if [ -z "$CPPTRAJ_DACDIF" ] ; then
     OUT "  SKIP: $1"
+  else
+    echo "  SKIP: $1"
   fi
   echo ""
   TEST_SKIPPED=1
@@ -862,6 +866,8 @@ SkipCheck() {
   echo "  Skipped test: $1"
   if [ -z "$CPPTRAJ_DACDIF" ] ; then
     OUT "  Skipped test: $1"
+  else
+    echo "  Skipped test: $1"
   fi
   ((SKIPCOUNT++))
   # Reset check count FIXME needed?
@@ -1165,7 +1171,7 @@ if [ -z "$CPPTRAJ_TEST_SETUP" ] ; then
     STANDALONE=1
     USE_DACDIF=0
   fi
-  # Determine if diff or dacdif will be used.
+  # Determine if diff or dacdif style will be used.
   CPPTRAJ_DIFF=''
   CPPTRAJ_DACDIF=''
   if [ $USE_DACDIF -eq 1 ] ; then
@@ -1289,6 +1295,7 @@ else
     $CPPTRAJ_RM $CPPTRAJ_TEST_RESULTS
   fi
   if [ -z "$CPPTRAJ_DACDIF" ] ; then
+    # Standalone. Only remove previous error file if it exists.
     if [ -f "$CPPTRAJ_TEST_ERROR" ] ; then
       $CPPTRAJ_RM $CPPTRAJ_TEST_ERROR
     fi


### PR DESCRIPTION
`dacdif` is a script in AmberTools which is used to compare saved test output with produced test output and report differences. It is quite versatile, but introduces a significant amount of overhead due to functionality that cpptraj tests do not require.

This PR makes cpptraj tests use the same test framework in AmberTools that it uses when standalone (i.e. it simply uses `diff` instead of `dacdif`). The only difference is that when in AmberTools, `MasterTest.sh` will mimic the output format of `dacdif`. On my desktop this reduces the time taken for cpptraj tests in AmberTools by a factor of ~3.5x. This should address #540 and #546.