### PR TITLE
Fix unsupported read/write formats

### DIFF
--- a/src/Analysis_Clustering.cpp
+++ b/src/Analysis_Clustering.cpp
@@ -98,10 +98,10 @@ void Analysis_Clustering::GetClusterTrajArgs(ArgList& argIn,
                                              TrajectoryFile::TrajFormatType& fmt) const
 {
   trajName = argIn.GetStringKey( trajKey );
-  fmt = TrajectoryFile::GetFormatFromString( argIn.GetStringKey(fmtKey), fmt );
+  fmt = TrajectoryFile::WriteFormatFromString( argIn.GetStringKey(fmtKey), fmt );
   // If file name specified but not format, try to guess from name
   if (!trajName.empty() && fmt == TrajectoryFile::UNKNOWN_TRAJ)
-    fmt = TrajectoryFile::GetTypeFromExtension( trajName, DEF_TRAJ_FMT_ );
+    fmt = TrajectoryFile::WriteFormatFromFname( trajName, DEF_TRAJ_FMT_ );
 }
 
 // Analysis_Clustering::Setup()
@@ -954,7 +954,7 @@ void Analysis_Clustering::WriteClusterTraj( ClusterList const& CList ) {
 void Analysis_Clustering::WriteAvgStruct( ClusterList const& CList ) {
   Topology avgparm = coords_->Top();
   // Get extension for representative frame format 
-  std::string tmpExt = TrajectoryFile::GetExtensionForType(avgfmt_);
+  std::string tmpExt = TrajectoryFile::WriteFormatExtension(avgfmt_);
   // Loop over all clusters
   for (ClusterList::cluster_iterator C = CList.begincluster();
                                      C != CList.endcluster(); ++C)
@@ -1026,7 +1026,7 @@ void Analysis_Clustering::WriteSingleRepTraj( ClusterList const& CList ) {
   */
 void Analysis_Clustering::WriteRepTraj( ClusterList const& CList ) {
   // Get extension for representative frame format 
-  std::string tmpExt = TrajectoryFile::GetExtensionForType(reptrajfmt_);
+  std::string tmpExt = TrajectoryFile::WriteFormatExtension(reptrajfmt_);
   // Use Topology from COORDS DataSet to set up input frame
   Topology* clusterparm = coords_->TopPtr();
   Frame clusterframe = coords_->AllocateFrame();

--- a/src/Analysis_Clustering.h
+++ b/src/Analysis_Clustering.h
@@ -47,6 +47,7 @@ class Analysis_Clustering: public Analysis {
     DataSet* pw_dist_;          ///< Cluster pairwise distance matrix dataset
     DataFile* cpopvtimefile_;   ///< Cluster pop v time file.
     DataFile* pwd_file_;        ///< Data file to write pairwise distance matrix to.
+    // TODO use FileName
     std::string summaryfile_;   ///< Summary file name
     std::string halffile_;      ///< 1st/2nd half summary file name
     std::string clusterfile_;   ///< Cluster trajectory base filename.

--- a/src/Analysis_Hist.cpp
+++ b/src/Analysis_Hist.cpp
@@ -233,7 +233,8 @@ Analysis::RetType Analysis_Hist::Setup(ArgList& analyzeArgs, AnalysisSetup& setu
     return Analysis::ERR;
   }
   traj3dName_ = analyzeArgs.GetStringKey("traj3d");
-  traj3dFmt_ = TrajectoryFile::GetFormatFromString( analyzeArgs.GetStringKey("trajfmt") );
+  traj3dFmt_ = TrajectoryFile::WriteFormatFromString( analyzeArgs.GetStringKey("trajfmt"),
+                                                      TrajectoryFile::AMBERTRAJ );
   parmoutName_ = analyzeArgs.GetStringKey("parmout");
   // Create a DataFile here so any DataFile arguments can be processed. If it
   // turns out later that native output is needed the DataFile will be removed.

--- a/src/Analysis_Modes.cpp
+++ b/src/Analysis_Modes.cpp
@@ -135,7 +135,8 @@ Analysis::RetType Analysis_Modes::Setup(ArgList& analyzeArgs, AnalysisSetup& set
     }
     TrajectoryFile::TrajFormatType tOutFmt = TrajectoryFile::UNKNOWN_TRAJ;
     if ( analyzeArgs.Contains("trajoutfmt") )
-      tOutFmt = TrajectoryFile::GetFormatFromString( analyzeArgs.GetStringKey("trajoutfmt") );
+      tOutFmt = TrajectoryFile::WriteFormatFromString( analyzeArgs.GetStringKey("trajoutfmt"),
+                                                       TrajectoryFile::AMBERTRAJ );
     if (analyzeParm == 0) {
       mprinterr("Error: Could not get topology for output trajectory.\n");
       return Analysis::ERR;

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -82,13 +82,30 @@ const FileTypes::KeyToken DataFile::DF_KeyArray[] = {
   { REMLOG,       "remlog", ".log"   },
   { MDOUT,        "mdout",  ".mdout" },
   { EVECS,        "evecs",  ".evecs" },
-  { VECTRAJ,      "vectraj",".vectraj" },
+  { VECTRAJ,      "vectraj",".vectraj" }, // TODO remove from this array? 
   { XVG,          "xvg",    ".xvg"   },
   { CCP4,         "ccp4",   ".ccp4"  },
   { CMATRIX,      "cmatrix",".cmatrix" },
   { NCCMATRIX,    "nccmatrix", ".nccmatrix" },
   { CHARMMREPD,   "charmmrepd",".exch" },
   { CHARMMOUT,    "charmmout", ".charmmout"},
+  { UNKNOWN_DATA, 0,        0        }
+};
+
+/** Types that support writes. */
+const FileTypes::KeyToken DataFile::DF_WriteKeyArray[] = {
+  { DATAFILE,     "dat",    ".dat"   },
+  { XMGRACE,      "grace",  ".agr"   },
+  { XMGRACE,      "grace",  ".xmgr"  },
+  { GNUPLOT,      "gnu",    ".gnu"   },
+  { XPLOR,        "xplor",  ".xplor" },
+  { XPLOR,        "xplor",  ".grid"  },
+  { OPENDX,       "opendx", ".dx"    },
+  { EVECS,        "evecs",  ".evecs" },
+  { VECTRAJ,      "vectraj",".vectraj" },
+  { CCP4,         "ccp4",   ".ccp4"  },
+  { CMATRIX,      "cmatrix",".cmatrix" },
+  { NCCMATRIX,    "nccmatrix", ".nccmatrix" },
   { UNKNOWN_DATA, 0,        0        }
 };
 

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -82,7 +82,6 @@ const FileTypes::KeyToken DataFile::DF_KeyArray[] = {
   { REMLOG,       "remlog", ".log"   },
   { MDOUT,        "mdout",  ".mdout" },
   { EVECS,        "evecs",  ".evecs" },
-  { VECTRAJ,      "vectraj",".vectraj" }, // TODO remove from this array? 
   { XVG,          "xvg",    ".xvg"   },
   { CCP4,         "ccp4",   ".ccp4"  },
   { CMATRIX,      "cmatrix",".cmatrix" },

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -246,9 +246,9 @@ int DataFile::SetupDatafile(FileName const& fnameIn, ArgList& argIn,
   dfType_ = typeIn;
   // If unknown, first look for keyword, then guess from extension.
   if (dfType_ == UNKNOWN_DATA)
-    dfType_ = (DataFormatType)FileTypes::GetFormatFromArg(DF_KeyArray, argIn, UNKNOWN_DATA );
+    dfType_ = (DataFormatType)FileTypes::GetFormatFromArg(DF_WriteKeyArray, argIn, UNKNOWN_DATA );
   if (dfType_ == UNKNOWN_DATA)
-    dfType_ = (DataFormatType)FileTypes::GetTypeFromExtension(DF_KeyArray, filename_.Ext(),
+    dfType_ = (DataFormatType)FileTypes::GetTypeFromExtension(DF_WriteKeyArray, filename_.Ext(),
                                                               DATAFILE);
   // Set up DataIO based on format.
   dataio_ = (DataIO*)FileTypes::AllocIO( DF_AllocArray, dfType_, false );

--- a/src/DataFile.h
+++ b/src/DataFile.h
@@ -25,12 +25,10 @@ class DataFile {
     static void ReadOptions() { FileTypes::ReadOptions(DF_KeyArray,DF_AllocArray, UNKNOWN_DATA); }
     /// List write options for each format.
     static void WriteOptions(){ FileTypes::WriteOptions(DF_WriteKeyArray,DF_AllocArray,UNKNOWN_DATA); }
-/*
-    /// \return format type from keyword
-    static DataFormatType GetFormatFromArg(ArgList& a) {
-      return (DataFormatType)FileTypes::GetFormatFromArg(DF_KeyArray, a, UNKNOWN_DATA);
+    /// \return Write format type from keyword in ArgList, or default
+    static DataFormatType WriteFormatFromArg(ArgList& a, DataFormatType def) {
+      return (DataFormatType)FileTypes::GetFormatFromArg(DF_WriteKeyArray,a,def);
     }
-*/
     /// \return string corresponding to format.
     static const char* FormatString(DataFormatType t) {
       return FileTypes::FormatDescription(DF_AllocArray, t);

--- a/src/DataFile.h
+++ b/src/DataFile.h
@@ -25,10 +25,12 @@ class DataFile {
     static void ReadOptions() { FileTypes::ReadOptions(DF_KeyArray,DF_AllocArray, UNKNOWN_DATA); }
     /// List write options for each format.
     static void WriteOptions(){ FileTypes::WriteOptions(DF_WriteKeyArray,DF_AllocArray,UNKNOWN_DATA); }
+/*
     /// \return format type from keyword
     static DataFormatType GetFormatFromArg(ArgList& a) {
       return (DataFormatType)FileTypes::GetFormatFromArg(DF_KeyArray, a, UNKNOWN_DATA);
     }
+*/
     /// \return string corresponding to format.
     static const char* FormatString(DataFormatType t) {
       return FileTypes::FormatDescription(DF_AllocArray, t);

--- a/src/DataFile.h
+++ b/src/DataFile.h
@@ -8,6 +8,8 @@ class DataFile {
     static const FileTypes::AllocToken DF_AllocArray[];
     /// For associating keywords/extensions with file types. 
     static const FileTypes::KeyToken DF_KeyArray[];
+    /// Keywords/extensions for types that support writes.
+    static const FileTypes::KeyToken DF_WriteKeyArray[];
   public:
     /// Known data file formats.
     enum DataFormatType {
@@ -22,7 +24,7 @@ class DataFile {
     /// List read options for each format.
     static void ReadOptions() { FileTypes::ReadOptions(DF_KeyArray,DF_AllocArray, UNKNOWN_DATA); }
     /// List write options for each format.
-    static void WriteOptions(){ FileTypes::WriteOptions(DF_KeyArray,DF_AllocArray,UNKNOWN_DATA); }
+    static void WriteOptions(){ FileTypes::WriteOptions(DF_WriteKeyArray,DF_AllocArray,UNKNOWN_DATA); }
     /// \return format type from keyword
     static DataFormatType GetFormatFromArg(ArgList& a) {
       return (DataFormatType)FileTypes::GetFormatFromArg(DF_KeyArray, a, UNKNOWN_DATA);

--- a/src/DataFileList.cpp
+++ b/src/DataFileList.cpp
@@ -129,7 +129,7 @@ DataFile* DataFileList::AddDataFile(FileName const& nameIn, ArgList& argIn,
       return 0;
     }
     // Check for keywords that do not match file type
-    DataFile::DataFormatType kType = DataFile::GetFormatFromArg( argIn );
+    DataFile::DataFormatType kType = DataFile::WriteFormatFromArg( argIn, DataFile::UNKNOWN_DATA );
     if (kType != DataFile::UNKNOWN_DATA && kType != Current->Type())
       mprintf("Warning: %s is type %s but type %s keyword specified; ignoring keyword.\n",
               Current->DataFilename().full(), Current->FormatString(),

--- a/src/DataIO_VecTraj.cpp
+++ b/src/DataIO_VecTraj.cpp
@@ -17,7 +17,8 @@ void DataIO_VecTraj::WriteHelp() {
 }
 
 int DataIO_VecTraj::processWriteArgs(ArgList& argIn) {
-  trajoutFmt_ = TrajectoryFile::GetFormatFromString( argIn.GetStringKey("trajfmt") );
+  trajoutFmt_ = TrajectoryFile::WriteFormatFromString( argIn.GetStringKey("trajfmt"),
+                                                       TrajectoryFile::AMBERTRAJ );
   parmoutName_ = argIn.GetStringKey("parmout");
   includeOrigin_ = !argIn.hasKey("noorigin");
   return 0;

--- a/src/Exec_SequenceAlign.cpp
+++ b/src/Exec_SequenceAlign.cpp
@@ -39,9 +39,9 @@ Exec::RetType Exec_SequenceAlign::Execute(CpptrajState& State, ArgList& argIn) {
     mprinterr("Error: Must specify output file.\n");
     return CpptrajState::ERR;
   }
-  TrajectoryFile::TrajFormatType fmt = TrajectoryFile::GetFormatFromArg(argIn);
-  if (fmt != TrajectoryFile::PDBFILE && fmt != TrajectoryFile::MOL2FILE)
-    fmt = TrajectoryFile::PDBFILE; // Default to PDB
+  // Default to PDB. TODO only allow PDB/Mol2?
+  TrajectoryFile::TrajFormatType fmt =
+    TrajectoryFile::WriteFormatFromArg(argIn, TrajectoryFile::PDBFILE);
   int smaskoffset = argIn.getKeyInt("smaskoffset", 0) + 1;
   int qmaskoffset = argIn.getKeyInt("qmaskoffset", 0) + 1;
 

--- a/src/OutputTrajCommon.cpp
+++ b/src/OutputTrajCommon.cpp
@@ -37,12 +37,12 @@ int OutputTrajCommon::CommonTrajoutSetup(FileName const& tnameIn, ArgList& argIn
   // If a write format was not specified (UNKNOWN_TRAJ) check the argument
   // list to see if format was specified there.
   writeFormat_ = fmtIn;
-  if (writeFormat_==TrajectoryFile::UNKNOWN_TRAJ) {
-    writeFormat_ = TrajectoryFile::GetFormatFromArg(argIn);
+  if (writeFormat_ == TrajectoryFile::UNKNOWN_TRAJ) {
+    writeFormat_ = TrajectoryFile::WriteFormatFromArg(argIn, TrajectoryFile::UNKNOWN_TRAJ);
     // If still UNKNOWN_TRAJ this means no type specified. Check to see if
     // the filename extension is recognized.
     if (writeFormat_ == TrajectoryFile::UNKNOWN_TRAJ) {
-      writeFormat_ = TrajectoryFile::GetTypeFromExtension( trajName_.Ext() );
+      writeFormat_ = TrajectoryFile::WriteFormatFromFname(trajName_, TrajectoryFile::UNKNOWN_TRAJ);
       // Default to Amber trajectory.
       if (writeFormat_ == TrajectoryFile::UNKNOWN_TRAJ) {
         mprintf("Warning: Format not specified and extension '%s' not recognized."

--- a/src/ParmFile.cpp
+++ b/src/ParmFile.cpp
@@ -37,6 +37,12 @@ const FileTypes::KeyToken ParmFile::PF_KeyArray[] = {
   { UNKNOWN_PARM, 0,         0        }
 };
 
+const FileTypes::KeyToken ParmFile::PF_WriteKeyArray[] = {
+  { AMBERPARM,    "amber",   ".parm7" },
+  { CHARMMPSF,    "psf",     ".psf"   },
+  { UNKNOWN_PARM, 0,         0        }
+};
+
 // ParmFile::DetectFormat()
 ParmIO* ParmFile::DetectFormat(FileName const& fname, ParmFormatType& ptype) {
   CpptrajFile file;
@@ -133,10 +139,10 @@ int ParmFile::WriteTopology(Topology const& Top, FileName const& fnameIn,
   ParmFormatType fmt = fmtIn;
   if (fmt == UNKNOWN_PARM) {
     // Check arg list to see if format specified.
-    fmt = (ParmFormatType)FileTypes::GetFormatFromArg(PF_KeyArray, argIn, UNKNOWN_PARM);
+    fmt = (ParmFormatType)FileTypes::GetFormatFromArg(PF_WriteKeyArray, argIn, UNKNOWN_PARM);
     // If still UNKNOWN check file extension. Default to AMBERPARM
     if (fmt == UNKNOWN_PARM)
-      fmt = (ParmFormatType)FileTypes::GetTypeFromExtension(PF_KeyArray, parmName_.Ext(),
+      fmt = (ParmFormatType)FileTypes::GetTypeFromExtension(PF_WriteKeyArray, parmName_.Ext(),
                                                             AMBERPARM);
   }
   ParmIO* parmio = (ParmIO*)FileTypes::AllocIO(PF_AllocArray, fmt, true);

--- a/src/ParmFile.h
+++ b/src/ParmFile.h
@@ -13,7 +13,7 @@ class ParmFile {
     enum ParmFormatType { AMBERPARM=0, PDBFILE, MOL2FILE, CHARMMPSF, CIFFILE,
                           GMXTOP, SDFFILE, TINKER, UNKNOWN_PARM };
     static void ReadOptions() { FileTypes::ReadOptions(PF_KeyArray,PF_AllocArray,UNKNOWN_PARM); }
-    static void WriteOptions(){ FileTypes::WriteOptions(PF_KeyArray,PF_AllocArray,UNKNOWN_PARM);} 
+    static void WriteOptions(){ FileTypes::WriteOptions(PF_WriteKeyArray,PF_AllocArray,UNKNOWN_PARM);}
     ParmFile() {}
     int ReadTopology(Topology&, FileName const&, ArgList const&,int);
     int ReadTopology(Topology& t, FileName const& n, int d) {

--- a/src/ParmFile.h
+++ b/src/ParmFile.h
@@ -7,6 +7,8 @@ class ParmFile {
     static const FileTypes::AllocToken PF_AllocArray[];
     /// For associating keywords/extensions with file types. 
     static const FileTypes::KeyToken PF_KeyArray[];
+    /// Topologies for which writes are supported.
+    static const FileTypes::KeyToken PF_WriteKeyArray[];
   public :
     enum ParmFormatType { AMBERPARM=0, PDBFILE, MOL2FILE, CHARMMPSF, CIFFILE,
                           GMXTOP, SDFFILE, TINKER, UNKNOWN_PARM };

--- a/src/TrajectoryFile.cpp
+++ b/src/TrajectoryFile.cpp
@@ -87,6 +87,30 @@ const FileTypes::KeyToken TrajectoryFile::TF_KeyArray[] = {
   { SDF,            "sdf",       ".sdf"     },
   { UNKNOWN_TRAJ,   0,           0          }
 };
+
+const FileTypes::KeyToken TrajectoryFile::TF_WriteKeyArray[] = {
+  { AMBERNETCDF,    "netcdf",    ".nc"      },
+  { AMBERNETCDF,    "cdf",       ".nc"      },
+  { AMBERRESTARTNC, "ncrestart", ".ncrst"   },
+  { AMBERRESTARTNC, "restartnc", ".ncrst"   },
+# ifdef ENABLE_SINGLE_ENSEMBLE
+  { AMBERNCENSEMBLE,"ncensemble",".ncens"   },
+# endif
+  { PDBFILE,        "pdb",       ".pdb"     },
+  { MOL2FILE,       "mol2",      ".mol2"    },
+  { CHARMMDCD,      "dcd",       ".dcd"     },
+  { CHARMMDCD,      "charmm",    ".dcd"     },
+  { GMXTRX,         "trr",       ".trr"     },
+  { GMXXTC,         "xtc",       ".xtc"     },
+  { BINPOS,         "binpos",    ".binpos"  },
+  { AMBERRESTART,   "restart",   ".rst7"    },
+  { AMBERRESTART,   "restrt",    ".rst7"    },
+  { AMBERRESTART,   "rest",      ".rst7"    },
+  { AMBERTRAJ,      "crd",       ".crd"     },
+  { SQM,            "sqm",       ".sqm"     },
+  { UNKNOWN_TRAJ,   0,           0          }
+};
+
 // -----------------------------------------------------------------------------
 
 // TrajectoryFile::DetectFormat()

--- a/src/TrajectoryFile.h
+++ b/src/TrajectoryFile.h
@@ -37,13 +37,17 @@ class TrajectoryFile {
     static TrajFormatType WriteFormatFromString(std::string const& s, TrajFormatType def) {
       return (TrajFormatType)FileTypes::GetFormatFromString(TF_WriteKeyArray,s,def);
     }
-    /// \return write format type corresonding to extension of give filename, or default.
+    /// \return write format type corresponding to extension of give filename, or default.
     static TrajFormatType WriteFormatFromFname(FileName const& f, TrajFormatType def) {
       return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_WriteKeyArray,f.Ext(),def);
     }
     /// \return default filename extension for given write format type.
     static std::string WriteFormatExtension(TrajFormatType t) {
       return FileTypes::GetExtensionForType(TF_WriteKeyArray, t);
+    }
+    /// \return write format type corresponding to keyword in ArgList, or default type.
+    static TrajFormatType WriteFormatFromArg(ArgList& a, TrajFormatType def) {
+      return (TrajFormatType)FileTypes::GetFormatFromArg(TF_WriteKeyArray, a, def);
     }
 /*
     /// \return format type from keyword in ArgList. 

--- a/src/TrajectoryFile.h
+++ b/src/TrajectoryFile.h
@@ -33,6 +33,19 @@ class TrajectoryFile {
     static void ReadOptions() { FileTypes::ReadOptions(TF_KeyArray,TF_AllocArray, UNKNOWN_TRAJ); }
     /// List write options for each format.
     static void WriteOptions(){ FileTypes::WriteOptions(TF_WriteKeyArray,TF_AllocArray,UNKNOWN_TRAJ); }
+    /// \return write format type corresponding to given string, or default if no match.
+    static TrajFormatType WriteFormatFromString(std::string const& s, TrajFormatType def) {
+      return (TrajFormatType)FileTypes::GetFormatFromString(TF_WriteKeyArray,s,def);
+    }
+    /// \return write format type corresonding to extension of give filename, or default.
+    static TrajFormatType WriteFormatFromFname(FileName const& f, TrajFormatType def) {
+      return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_WriteKeyArray,f.Ext(),def);
+    }
+    /// \return default filename extension for given write format type.
+    static std::string WriteFormatExtension(TrajFormatType t) {
+      return FileTypes::GetExtensionForType(TF_WriteKeyArray, t);
+    }
+/*
     /// \return format type from keyword in ArgList. 
     static TrajFormatType GetFormatFromArg(ArgList& a) {
       return (TrajFormatType)FileTypes::GetFormatFromArg(TF_KeyArray, a, UNKNOWN_TRAJ);
@@ -57,6 +70,7 @@ class TrajectoryFile {
     static TrajFormatType GetTypeFromExtension(FileName const& f, TrajFormatType def) {
       return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_KeyArray, f.Ext(), def);
     }
+*/
     /// \return string corresponding to given format.
     static const char* FormatString( TrajFormatType tt ) { return 
       FileTypes::FormatDescription(TF_AllocArray, tt);

--- a/src/TrajectoryFile.h
+++ b/src/TrajectoryFile.h
@@ -49,32 +49,6 @@ class TrajectoryFile {
     static TrajFormatType WriteFormatFromArg(ArgList& a, TrajFormatType def) {
       return (TrajFormatType)FileTypes::GetFormatFromArg(TF_WriteKeyArray, a, def);
     }
-/*
-    /// \return format type from keyword in ArgList. 
-    static TrajFormatType GetFormatFromArg(ArgList& a) {
-      return (TrajFormatType)FileTypes::GetFormatFromArg(TF_KeyArray, a, UNKNOWN_TRAJ);
-    }
-    /// \return format type from keyword. Default to Amber trajectory.
-    static TrajFormatType GetFormatFromString(std::string const& s) {
-      return (TrajFormatType)FileTypes::GetFormatFromString(TF_KeyArray, s, AMBERTRAJ);
-    }
-    /// \return format type from keyword, or given default if keyword is empty.
-    static TrajFormatType GetFormatFromString(std::string const& s, TrajFormatType def) {
-      return (TrajFormatType)FileTypes::GetFormatFromString(TF_KeyArray, s, def);
-    }
-    /// \return standard file extension for trajectory format.
-    static std::string GetExtensionForType(TrajFormatType t) {
-      return FileTypes::GetExtensionForType(TF_KeyArray, t);
-    }
-    /// \return type from extension.
-    static TrajFormatType GetTypeFromExtension(std::string const& e) {
-      return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_KeyArray, e, UNKNOWN_TRAJ);
-    }
-    /// \return type from extension. Default to given format if unknown.
-    static TrajFormatType GetTypeFromExtension(FileName const& f, TrajFormatType def) {
-      return (TrajFormatType)FileTypes::GetTypeFromExtension(TF_KeyArray, f.Ext(), def);
-    }
-*/
     /// \return string corresponding to given format.
     static const char* FormatString( TrajFormatType tt ) { return 
       FileTypes::FormatDescription(TF_AllocArray, tt);

--- a/src/TrajectoryFile.h
+++ b/src/TrajectoryFile.h
@@ -16,6 +16,8 @@ class TrajectoryFile {
     static const FileTypes::AllocToken TF_AllocArray[];
     /// For associating keywords/extensions with file types. 
     static const FileTypes::KeyToken TF_KeyArray[];
+    /// Trajectories for which writes are supported
+    static const FileTypes::KeyToken TF_WriteKeyArray[];
   public:
     /// Known trajectory formats.
     enum TrajFormatType {
@@ -30,7 +32,7 @@ class TrajectoryFile {
     /// List read options for each format.
     static void ReadOptions() { FileTypes::ReadOptions(TF_KeyArray,TF_AllocArray, UNKNOWN_TRAJ); }
     /// List write options for each format.
-    static void WriteOptions(){ FileTypes::WriteOptions(TF_KeyArray,TF_AllocArray,UNKNOWN_TRAJ); }
+    static void WriteOptions(){ FileTypes::WriteOptions(TF_WriteKeyArray,TF_AllocArray,UNKNOWN_TRAJ); }
     /// \return format type from keyword in ArgList. 
     static TrajFormatType GetFormatFromArg(ArgList& a) {
       return (TrajFormatType)FileTypes::GetFormatFromArg(TF_KeyArray, a, UNKNOWN_TRAJ);

--- a/src/Trajout_Single.cpp
+++ b/src/Trajout_Single.cpp
@@ -42,9 +42,9 @@ int Trajout_Single::InitEnsembleTrajWrite(FileName const& tnameIn, ArgList const
   // Try to determine format here, before extension is potentially modified.
   TrajectoryFile::TrajFormatType fmt = fmtIn;
   if (fmt == TrajectoryFile::UNKNOWN_TRAJ)
-    fmt = TrajectoryFile::GetFormatFromArg( args );
+    fmt = TrajectoryFile::WriteFormatFromArg( args, TrajectoryFile::UNKNOWN_TRAJ );
   if (fmt == TrajectoryFile::UNKNOWN_TRAJ)
-    fmt = TrajectoryFile::GetTypeFromExtension( tnameIn.Ext() );
+    fmt = TrajectoryFile::WriteFormatFromFname( tnameIn, TrajectoryFile::UNKNOWN_TRAJ );
   int err = 0;
   if (ensembleNum > -1)
     err = InitTrajWrite( AppendNumber(tnameIn.Full(), ensembleNum), args, fmt );


### PR DESCRIPTION
This PR addresses cpptraj attempting to use IO formats that are not supported for either read or write. For example, when writing a topology file a '.top' file was treated as Gromacs topology, even though writing Gromacs topologies is not supported (see #558). This PR adds a separate keyword/extension array for write formats for topologies, trajectories, and data files - only supported formats will be searched for. Also make it so the default format always has to be specified internally to make things more transparent.