### PR TITLE
Updates for CUDA 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a C++ rewrite of the PTRAJ trajectory analysis code from Amber.
 The official AmberTools release version of CPPTRAJ can be found
 at the [Amber website](http://ambermd.org).
 
-See whats [new in CPPTRAJ](https://github.com/Amber-MD/cpptraj/wiki).
+See what's [new in CPPTRAJ](https://github.com/Amber-MD/cpptraj/wiki).
 
 For more information see the following publication:
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ libraries:
 * Bzip2
 * Gzip
 
-For NetCDF trajectory output when processing trajectories in parallel,
-parallel NetCDF is also required (MPI build only).
+The following libraries are optional:
+
+* Parallel NetCDF (-mpi build only, for NetCDF trajectory output)
+* CUDA (-cuda build only)
 
 `./configure gnu` should be adequate to set up compilation for most systems.
-For systems without BLAS/LAPACK/ARPACK and/or NETCDF libraries installed,
+For systems without BLAS/LAPACK/ARPACK and/or NetCDF libraries installed,
 the `-amberlib` flag can be specified to use the ones already compiled in
 an AmberTools installation (`$AMBERHOME` must be set), e.g.
 `./configure -amberlib gnu`. For multicore systems, the `-openmp` flag can
@@ -59,19 +61,23 @@ be specified to enable OpenMP parallelization, e.g. `./configure -openmp gnu`.
 An MPI-parallelized version of CPPTRAJ can also be built using the `-mpi` flag.
 CPPTRAJ can be built with both MPI and OpenMP; when running this build users 
 should take care to properly set OMP_NUM_THREADS if using more than 1 MPI
-thread per node.
+thread per node. A CUDA build is now also available via the `-cuda` flag.
+Any combination of `-cuda`, `-mpi`, and `-openmp` may be used.
 
 The configure script by default sets everything up to link dynamically. The
 `-static` flag can be used to force static linking. If linking errors are
 encountered you may need to specify library locations using the `--with-LIB=`
 options. For example, to use NetCDF compiled in `/opt/netcdf` use the option 
 `--with-netcdf=/opt/netcdf`. Alternatively, individual libraries can be 
-disabled with the `-no<LIB>` options.
+disabled with the `-no<LIB>` options. The `-libstatic` flag
+can be used to static link only libraries that have been specified. 
 
 After `configure` has been successfully run, `make install` will
-compile and place the cpptraj binary in the `bin/` subdirectory. It is highly
-recommended that `make check` be run as well to test the basic functionality
-of CPPTRAJ.
+compile and place the cpptraj binary in the `bin/` subdirectory. Note that
+on multithreaded systems `make -j X install` (where X is an integer > 1
+and less than the max # cores on your system) will run much faster.
+After installation, It is highly recommended that `make check` be run as
+well to test the basic functionality of CPPTRAJ.
 
 CPPTRAJ Authors
 ===============

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ a C++ rewrite of the PTRAJ trajectory analysis code from Amber.
 The official AmberTools release version of CPPTRAJ can be found
 at the [Amber website](http://ambermd.org).
 
+See whats [new in CPPTRAJ](https://github.com/Amber-MD/cpptraj/wiki).
+
 For more information see the following publication:
 
 [Daniel R. Roe and Thomas E. Cheatham, III, "PTRAJ and CPPTRAJ: Software for
@@ -28,7 +30,7 @@ PYTRAJ Compatibility Status
 Disclaimer and Copyright
 ========================
 
-CPPTRAJ is Copyright (c) 2010-2016 Daniel R. Roe.
+CPPTRAJ is Copyright (c) 2010-2017 Daniel R. Roe.
 The terms for using, copying, modifying, and distributing CPPTRAJ are 
 specified in the file LICENSE.
 

--- a/configure
+++ b/configure
@@ -1290,12 +1290,15 @@ if [[ $USECUDA -eq 1 ]] ; then
     sm30flags='-gencode arch=compute_30,code=sm_30'
     #SM2.0 = All GF variants = C2050, 2075, M2090, GTX480, GTX580 etc.
     sm20flags='-gencode arch=compute_20,code=sm_20'
-    if [ "$CUDA_VERSION" = "8.0" ]; then
+    if [ "$CUDA_VERSION" = '9.0' ] ; then
+      echo "Configuring for SM3.0, SM5.0, SM5.2, SM5.3, SM6.0 and SM6.1"
+      NVCCFLAGS="$sm30flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags"
+    elif [ "$CUDA_VERSION" = '8.0' ] ; then
       echo "Configuring for SM2.0, SM3.0, SM5.0, SM5.2, SM5.3, SM6.0 and SM6.1"
       NVCCFLAGS="$sm20flags $sm30flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags"
     else
       echo "Configuring for SM2.0, SM3.0, SM5.0, SM5.2 and SM5.3"
-      echo "BE AWARE: CUDA 7.5 does not support GTX-1080, Titan-XP, DGX-1 or other Pascal based GPUs."
+      echo "BE AWARE: CUDA < 8.0 does not support GTX-1080, Titan-XP, DGX-1 or other Pascal based GPUs."
       NVCCFLAGS="$sm20flags $sm30flags $sm50flags $sm52flags $sm53flags"
     fi
   fi

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -113,11 +113,12 @@ int Cpptraj::RunCpptraj(int argc, char** argv) {
   total_time.Start();
 # ifdef CUDA
   int nGPUs = 0;
-  if ( cudaGetDeviceCount( &nGPUs ) != cudaSuccess ) {
-    mprinterr("Error: Could not get # of GPU devices.\n");
-    return 1;
-  }
-  if (nGPUs < 1) {
+  cudaError_t cerr = cudaGetDeviceCount( &nGPUs );
+  if ( cerr == cudaErrorNoDevice )
+    mprinterr("Error: No CUDA-capable devices present.\n");
+  else if ( cerr == cudaErrorInsufficientDriver )
+    mprinterr("Error: NVIDIA driver version is insufficient for this version of CUDA.\n");
+  if (nGPUs < 1 || cerr != cudaSuccess) {
     mprinterr("Error: No CUDA-capable devices found.\n");
     return 1;
   }

--- a/src/FileIO_Gzip.cpp
+++ b/src/FileIO_Gzip.cpp
@@ -52,10 +52,10 @@ off_t FileIO_Gzip::Size(const char *filename) {
   fseek(infile, -4, SEEK_END);
 
   b1=0; b2=0; b3=0; b4=0;
-  fread(&b4,1,1,infile);
-  fread(&b3,1,1,infile);
-  fread(&b2,1,1,infile);
-  fread(&b1,1,1,infile);
+  if (fread(&b4,1,1,infile) != 1) return -1L;
+  if (fread(&b3,1,1,infile) != 1) return -1L;
+  if (fread(&b2,1,1,infile) != 1) return -1L;
+  if (fread(&b1,1,1,infile) != 1) return -1L;
 
   val = 0;
   temp = (off_t) b1;


### PR DESCRIPTION
CUDA 9 does not support shader model 2.0. Also update the README build instructions.