### PR TITLE
Improve speed of GIST nonbonded calculation for non-orthogonal cells

### DIFF
--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -410,7 +410,7 @@ Action::RetType Action_GIST::Setup(ActionSetup& setup) {
     doOrder_ = false;
   }
   // Allocate space for saving indices of water atoms that are on the grid
-  // Estimate how man solvent molecules can possibly fit onto the grid.
+  // Estimate how many solvent molecules can possibly fit onto the grid.
   // Add some extra voxels as a buffer.
   double max_voxels = (double)MAX_GRID_PT_ + (1.10 * (double)MAX_GRID_PT_);
   double totalVolume = max_voxels * gO_->VoxelVolume();
@@ -878,7 +878,7 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
         N_hydrogens_[ (int)gO_->CalcIndex(bin_i, bin_j, bin_k) ]++;
       if (gO_->CalcBins( H2_XYZ[0], H2_XYZ[1], H2_XYZ[2], bin_i, bin_j, bin_k ) )
         N_hydrogens_[ (int)gO_->CalcIndex(bin_i, bin_j, bin_k) ]++;
-    }
+    } // END water is within 1.5 Ang of grid
   } // END loop over each solvent molecule
 
   // Do energy calculation if requested

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -539,7 +539,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
 # ifdef _OPENMP
   } // END omp parallel
 # endif
-  gist_nonbond_UV_.Start();
+  gist_nonbond_UV_.Stop();
 
   // ----- On-grid solvent to on-grid solvent ----
   gist_nonbond_VV_.Start();
@@ -650,7 +650,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
       double qa1 = topIn[ a1 ].Charge();
       std::vector<Vec3> vImages;
       if (image_.ImageType() == NONORTHO) {
-        // Convert to frac coords TODO nonortho only
+        // Convert to frac coords
         Vec3 vFrac = recip * Vec3( a1XYZ );
         // Wrap to primary unit cell
         vFrac[0] = vFrac[0] - floor(vFrac[0]);

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -468,7 +468,13 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
     // Wrap on-grid water coords back to primary cell TODO openmp
     double* ongrid_xyz = &OnGrid_XYZ_[0];
     int maxXYZ = (int)OnGrid_XYZ_.size();
-    for (int idx = 0; idx < maxXYZ; idx += 3)
+    int idx;
+#   ifdef _OPENMP
+#   pragma omp parallel private(idx)
+    {
+#   pragma omp for
+#   endif
+    for (idx = 0; idx < maxXYZ; idx += 3)
     {
       double* XYZ = ongrid_xyz + idx;
       // Convert to frac coords
@@ -480,6 +486,9 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
       // Convert back to Cartesian
       ucell.TransposeMult( XYZ, XYZ );
     }
+#   ifdef _OPENMP
+    }
+#   endif
   }
 
 //  mprintf("DEBUG: NSolventAtoms= %zu  NwatAtomsOnGrid= %u\n", O_idxs_.size()*nMolAtoms_, N_ON_GRID_);

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -505,7 +505,8 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
     {
       int a2 = OnGrid_idxs_[gidx];              // Index of water on grid
       int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
-      const double* A2_XYZ = frameIn.XYZ( a2 ); // Coord of water on grid
+      //const double* A2_XYZ = frameIn.XYZ( a2 ); // Coord of water on grid
+      const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3;
       // Calculate distance
       gist_nonbond_dist_.Start();
       double rij2 = Dist2( image_.ImageType(), A1_XYZ.Dptr(), A2_XYZ, frameIn.BoxCrd(),
@@ -551,7 +552,8 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
     for (int idx1 = 0; idx1 < nmolatoms; idx1++)
     {
       int a1 = OnGrid_idxs_[vidx1+idx1];
-      const double* a1XYZ = frameIn.XYZ( a1 );
+      //const double* a1XYZ = frameIn.XYZ( a1 );
+      const double* a1XYZ = (&OnGrid_XYZ_[0])+(vidx1+idx1)*3;
       double qa1 = topIn[ a1 ].Charge();
       int a1_voxel = atom_voxel_[a1];               // Voxel of water on grid
       // Inner loop over all other solvent molecules
@@ -561,7 +563,8 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
         for (int idx2 = 0; idx2 < nmolatoms; idx2++)
         {
           int a2 = OnGrid_idxs_[vidx2+idx2];
-          const double* a2XYZ = frameIn.XYZ( a2 );
+          //const double* a2XYZ = frameIn.XYZ( a2 );
+          const double* a2XYZ = (&OnGrid_XYZ_[0])+(vidx2+idx2)*3;
           double qa2 = topIn[ a2 ].Charge();
           int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
           // Calculate distance
@@ -632,7 +635,8 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
         for (int idx2 = 0; idx2 < nmolatoms; idx2++)
         {
           int a2 = OnGrid_idxs_[vidx+idx2];
-          const double* a2XYZ = frameIn.XYZ( a2 );
+          //const double* a2XYZ = frameIn.XYZ( a2 );
+          const double* a2XYZ = (&OnGrid_XYZ_[0])+(vidx+idx2)*3;
           double qa2 = topIn[ a2 ].Charge();
           int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
           // Calculate distance
@@ -698,7 +702,8 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
       if (a1_mol != a2_mol)
       {
         int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
-        const double* A2_XYZ = frameIn.XYZ( a2 ); // Coord of water on grid
+        //const double* A2_XYZ = frameIn.XYZ( a2 ); // Coord of water on grid
+        const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3;
         if ( a1_voxel == SOLUTE_ ) {
           // Solute to solvent on grid energy
           // Calculate distance
@@ -830,6 +835,7 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
   // TODO only !skipE?
   N_ON_GRID_ = 0;
   OffGrid_idxs_.clear();
+  OnGrid_XYZ_.clear();
 
   size_t bin_i, bin_j, bin_k;
   Vec3 const& Origin = gO_->GridOrigin();
@@ -860,9 +866,14 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
         // Oxygen is inside the grid. Record the voxel.
         // NOTE hydrogens/EP always assigned to same voxel for energy purposes.
         int voxel = (int)gO_->CalcIndex(bin_i, bin_j, bin_k);
+        const double* wXYZ = O_XYZ;
         for (unsigned int IDX = 0; IDX != nMolAtoms_; IDX++) {
           atom_voxel_[oidx+IDX] = voxel;
           OnGrid_idxs_[N_ON_GRID_+IDX] = oidx + IDX;
+          OnGrid_XYZ_.push_back( wXYZ[0] );
+          OnGrid_XYZ_.push_back( wXYZ[1] );
+          OnGrid_XYZ_.push_back( wXYZ[2] );
+          wXYZ+=3;
         }
         N_ON_GRID_ += nMolAtoms_;
         //mprintf("DEBUG1: Water atom %i voxel %i\n", oidx, voxel);

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cfloat> // DBL_MAX
 #include "Action_GIST.h"
 #include "CpptrajStdio.h"
 #include "Constants.h"
@@ -9,6 +10,8 @@
 #ifdef _OPENMP
 # include <omp.h>
 #endif
+
+const double Action_GIST::maxD_ = DBL_MAX;
 
 Action_GIST::Action_GIST() :
   gO_(0),
@@ -551,7 +554,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
       //gist_nonbond_dist_.Start();
       double rij2;
       if (image_.ImageType() == NONORTHO) {
-        rij2 = 9999999.0;
+        rij2 = maxD_;
         for (std::vector<Vec3>::const_iterator vCart = vImages.begin();
                                                vCart != vImages.end(); ++vCart)
         {
@@ -635,7 +638,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
           //gist_nonbond_dist_.Start();
           double rij2;
           if (image_.ImageType() == NONORTHO) {
-            rij2 = 9999999.0;
+            rij2 = maxD_;
             for (std::vector<Vec3>::const_iterator vCart = vImages.begin();
                                                    vCart != vImages.end(); ++vCart)
             {
@@ -738,7 +741,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
           //gist_nonbond_dist_.Start();
           double rij2;
           if (image_.ImageType() == NONORTHO) {
-            rij2 = 9999999.0;
+            rij2 = maxD_;
             for (std::vector<Vec3>::const_iterator vCart = vImages.begin();
                                                    vCart != vImages.end(); ++vCart)
             {
@@ -885,8 +888,6 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
 // Action_GIST::Order()
 void Action_GIST::Order(Frame const& frameIn) {
   // Loop over all solvent molecules that are on the grid
-  double maxD = frameIn.BoxCrd().BoxX() + frameIn.BoxCrd().BoxY() + frameIn.BoxCrd().BoxZ();
-  maxD *= maxD;
   for (unsigned int gidx = 0; gidx < N_ON_GRID_; gidx += 3)
   {
     int oidx1 = OnGrid_idxs_[gidx];
@@ -895,10 +896,10 @@ void Action_GIST::Order(Frame const& frameIn) {
     // Find coordinates for 4 closest neighbors to this water (on or off grid).
     // TODO set up overall grid in DoAction.
     Vec3 WAT[4];
-    double d1 = maxD;
-    double d2 = maxD;
-    double d3 = maxD;
-    double d4 = maxD;
+    double d1 = maxD_;
+    double d2 = maxD_;
+    double d3 = maxD_;
+    double d4 = maxD_;
     for (unsigned int sidx2 = 0; sidx2 < NSOLVENT_; sidx2++)
     {
       int oidx2 = O_idxs_[sidx2];

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -507,10 +507,10 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
   double Evdw, Eelec;
 # ifdef GIST_NEW_NONBOND
   // ----- Solute to on-grid solvent -------------
-  gist_nonbond_UV_.Start();
+  //gist_nonbond_UV_.Start();
   int uidx;
   int maxUidx = (int)U_idxs_.size();
-  mprintf("DEBUG: # solute= %i # on grid= %i  off grid= %i\n", maxUidx, N_ON_GRID_, (int)OffGrid_idxs_.size());
+  //mprintf("DEBUG: # solute= %i # on grid= %i  off grid= %i\n", maxUidx, N_ON_GRID_, (int)OffGrid_idxs_.size());
 # ifdef _OPENMP
   int mythread;
 # pragma omp parallel private(uidx, mythread, E_UV_VDW, E_UV_Elec, Evdw, Eelec)
@@ -574,10 +574,10 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
 # ifdef _OPENMP
   } // END omp parallel
 # endif
-  gist_nonbond_UV_.Stop();
+  //gist_nonbond_UV_.Stop();
 
   // ----- On-grid solvent to on-grid solvent ----
-  gist_nonbond_VV_.Start();
+  //gist_nonbond_VV_.Start();
   int vidx1;
   int maxVidx = (int)N_ON_GRID_; // TODO use size()
   int nmolatoms = (int)nMolAtoms_;
@@ -685,10 +685,10 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
         ww_Eij_->UpdateElement(EIJ_V1_[thread][idx], EIJ_V2_[thread][idx], EIJ_EN_[thread][idx]);
   }
 # endif
-  gist_nonbond_VV_.Stop();
+  //gist_nonbond_VV_.Stop();
 
   // ----- Off-grid solvent to on-grid solvent ---
-  gist_nonbond_OV_.Start();
+  //gist_nonbond_OV_.Start();
   int oidx;
   int maxOidx = (int)OffGrid_idxs_.size();
 # ifdef _OPENMP
@@ -766,7 +766,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
 # ifdef _OPENMP
   } // END pragma omp parallel
 # endif
-  gist_nonbond_OV_.Stop();
+  //gist_nonbond_OV_.Stop();
 // ===============================================
 # else /* GIST_NEW_NONBOND */
   int aidx;
@@ -1506,9 +1506,9 @@ void Action_GIST::Print() {
   gist_grid_.WriteTiming(2,    "Grid:   ", gist_action_.Total());
   gist_nonbond_.WriteTiming(2, "Nonbond:", gist_action_.Total());
   //gist_nonbond_dist_.WriteTiming(3, "Dist2:", gist_nonbond_.Total());
-  gist_nonbond_UV_.WriteTiming(3, "UV:", gist_nonbond_.Total());
-  gist_nonbond_VV_.WriteTiming(3, "VV:", gist_nonbond_.Total());
-  gist_nonbond_OV_.WriteTiming(3, "OV:", gist_nonbond_.Total());
+  //gist_nonbond_UV_.WriteTiming(3, "UV:", gist_nonbond_.Total());
+  //gist_nonbond_VV_.WriteTiming(3, "VV:", gist_nonbond_.Total());
+  //gist_nonbond_OV_.WriteTiming(3, "OV:", gist_nonbond_.Total());
   gist_euler_.WriteTiming(2,   "Euler:  ", gist_action_.Total());
   gist_dipole_.WriteTiming(2,  "Dipole: ", gist_action_.Total());
   gist_order_.WriteTiming(2,   "Order: ", gist_action_.Total());

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -808,7 +808,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
       vFrac[0] = vFrac[0] - floor(vFrac[0]);
       vFrac[1] = vFrac[1] - floor(vFrac[1]);
       vFrac[2] = vFrac[2] - floor(vFrac[2]);
-      // Calculate all images of this solvent atom
+      // Calculate all images of this atom
       vImages.reserve(27); 
       for (int ix = -1; ix != 2; ix++)
         for (int iy = -1; iy != 2; iy++)
@@ -817,17 +817,16 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
             vImages.push_back( ucell.TransposeMult( vFrac + Vec3(ix,iy,iz) ) );
     }
     // Loop over all solvent atoms on the grid
-    // TODO skip calculations that do not contribute
     for (unsigned int gidx = 0; gidx < N_ON_GRID_; gidx++)
     {
-      int a2 = OnGrid_idxs_[gidx];              // Index of water on grid
-      int a2_mol = topIn[ a2 ].MolNum();        // Molecule # of atom 2
+      int a2 = OnGrid_idxs_[gidx];              // Index of on-grid solvent
+      int a2_mol = topIn[ a2 ].MolNum();        // Molecule # of on-grid solvent
       if (a1_mol != a2_mol)
       {
-        int a2_voxel = atom_voxel_[a2];                  // Voxel of water on grid
-        const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3; // Coord of water on grid
+        int a2_voxel = atom_voxel_[a2];                  // Voxel of on-grid solvent
+        const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3; // Coord of on-grid solvent
         if ( a1_voxel == SOLUTE_ ) {
-          // Solute to solvent on grid energy
+          // Solute to on-grid solvent energy
           // Calculate distance
           //gist_nonbond_dist_.Start();
           double rij2;
@@ -853,7 +852,7 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
           E_UV_Elec[a2_voxel] += Eelec;
           //gist_nonbond_UV_.Stop();
         } else {
-          // Solvent to solvent on grid energy
+          // Off-grid/on-grid solvent to on-grid solvent energy
           // Only do the energy calculation if not previously done or atom1 not on grid
           if (a2 != a1 && (a2 > a1 || a1_voxel == OFF_GRID_))
           {

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -498,20 +498,19 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
 # endif
   for (uidx = 0; uidx < maxUidx; uidx++)
   {
-    int a1 = U_idxs_[uidx];
-    Vec3 A1_XYZ( frameIn.XYZ( a1 ) );  // Coord of atom1
-    double qA1 = topIn[ a1 ].Charge(); // Charge of atom1
+    int a1 = U_idxs_[uidx];            // Index of solute atom
+    Vec3 A1_XYZ( frameIn.XYZ( a1 ) );  // Coord of solute atom
+    double qA1 = topIn[ a1 ].Charge(); // Charge of solute atom
     for (unsigned int gidx = 0; gidx < N_ON_GRID_; gidx++)
     {
-      int a2 = OnGrid_idxs_[gidx];              // Index of water on grid
-      int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
-      //const double* A2_XYZ = frameIn.XYZ( a2 ); // Coord of water on grid
-      const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3;
+      int a2 = OnGrid_idxs_[gidx];                     // Index of water on grid
+      int a2_voxel = atom_voxel_[a2];                  // Voxel of water on grid
+      const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3; // Coord of water on grid
       // Calculate distance
-      gist_nonbond_dist_.Start();
+      //gist_nonbond_dist_.Start();
       double rij2 = Dist2( image_.ImageType(), A1_XYZ.Dptr(), A2_XYZ, frameIn.BoxCrd(),
                            ucell, recip );
-      gist_nonbond_dist_.Stop();
+      //gist_nonbond_dist_.Stop();
       // Calculate energy
       Ecalc( rij2, qA1, topIn[ a2 ].Charge(), topIn.GetLJparam(a1, a2), Evdw, Eelec );
       E_UV_VDW[a2_voxel]  += Evdw;
@@ -552,10 +551,9 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
     for (int idx1 = 0; idx1 < nmolatoms; idx1++)
     {
       int a1 = OnGrid_idxs_[vidx1+idx1];
-      //const double* a1XYZ = frameIn.XYZ( a1 );
       const double* a1XYZ = (&OnGrid_XYZ_[0])+(vidx1+idx1)*3;
       double qa1 = topIn[ a1 ].Charge();
-      int a1_voxel = atom_voxel_[a1];               // Voxel of water on grid
+      int a1_voxel = atom_voxel_[a1];
       // Inner loop over all other solvent molecules
       for (int vidx2 = vidx1 + nmolatoms; vidx2 < maxVidx; vidx2 += nmolatoms)
       {
@@ -563,14 +561,13 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
         for (int idx2 = 0; idx2 < nmolatoms; idx2++)
         {
           int a2 = OnGrid_idxs_[vidx2+idx2];
-          //const double* a2XYZ = frameIn.XYZ( a2 );
           const double* a2XYZ = (&OnGrid_XYZ_[0])+(vidx2+idx2)*3;
           double qa2 = topIn[ a2 ].Charge();
-          int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
+          int a2_voxel = atom_voxel_[a2];
           // Calculate distance
-          gist_nonbond_dist_.Start();
+          //gist_nonbond_dist_.Start();
           double rij2 = Dist2( image_.ImageType(), a1XYZ, a2XYZ, frameIn.BoxCrd(), ucell, recip);
-          gist_nonbond_dist_.Stop();
+          //gist_nonbond_dist_.Stop();
           // Calculate energy
           Ecalc( rij2, qa1, qa2, topIn.GetLJparam(a1, a2), Evdw, Eelec );
           E_VV_VDW[a1_voxel] += Evdw;
@@ -635,14 +632,13 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
         for (int idx2 = 0; idx2 < nmolatoms; idx2++)
         {
           int a2 = OnGrid_idxs_[vidx+idx2];
-          //const double* a2XYZ = frameIn.XYZ( a2 );
           const double* a2XYZ = (&OnGrid_XYZ_[0])+(vidx+idx2)*3;
           double qa2 = topIn[ a2 ].Charge();
           int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
           // Calculate distance
-          gist_nonbond_dist_.Start();
+          //gist_nonbond_dist_.Start();
           double rij2 = Dist2( image_.ImageType(), a1XYZ, a2XYZ, frameIn.BoxCrd(), ucell, recip);
-          gist_nonbond_dist_.Stop();
+          //gist_nonbond_dist_.Stop();
           // Calculate energy
           Ecalc( rij2, qa1, qa2, topIn.GetLJparam(a1, a2), Evdw, Eelec );
           E_VV_VDW[a2_voxel] += Evdw;
@@ -701,16 +697,15 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
       int a2_mol = topIn[ a2 ].MolNum();        // Molecule # of atom 2
       if (a1_mol != a2_mol)
       {
-        int a2_voxel = atom_voxel_[a2];           // Voxel of water on grid
-        //const double* A2_XYZ = frameIn.XYZ( a2 ); // Coord of water on grid
-        const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3;
+        int a2_voxel = atom_voxel_[a2];                  // Voxel of water on grid
+        const double* A2_XYZ = (&OnGrid_XYZ_[0])+gidx*3; // Coord of water on grid
         if ( a1_voxel == SOLUTE_ ) {
           // Solute to solvent on grid energy
           // Calculate distance
-          gist_nonbond_dist_.Start();
+          //gist_nonbond_dist_.Start();
           double rij2 = Dist2( image_.ImageType(), A1_XYZ.Dptr(), A2_XYZ, frameIn.BoxCrd(),
                                ucell, recip );
-          gist_nonbond_dist_.Stop();
+          //gist_nonbond_dist_.Stop();
           //gist_nonbond_UV_.Start();
           // Calculate energy
           Ecalc( rij2, qA1, topIn[ a2 ].Charge(), topIn.GetLJparam(a1, a2), Evdw, Eelec );
@@ -723,10 +718,10 @@ void Action_GIST::NonbondEnergy(Frame const& frameIn, Topology const& topIn)
           if (a2 != a1 && (a2 > a1 || a1_voxel == OFF_GRID_))
           {
             // Calculate distance
-            gist_nonbond_dist_.Start();
+            //gist_nonbond_dist_.Start();
             double rij2 = Dist2( image_.ImageType(), A1_XYZ.Dptr(), A2_XYZ, frameIn.BoxCrd(),
                                  ucell, recip );
-            gist_nonbond_dist_.Stop();
+            //gist_nonbond_dist_.Stop();
             //gist_nonbond_VV_.Start();
             // Calculate energy
             Ecalc( rij2, qA1, topIn[ a2 ].Charge(), topIn.GetLJparam(a1, a2), Evdw, Eelec );
@@ -1396,9 +1391,9 @@ void Action_GIST::Print() {
   gist_action_.WriteTiming(1,  "Action:", total);
   gist_grid_.WriteTiming(2,    "Grid:   ", gist_action_.Total());
   gist_nonbond_.WriteTiming(2, "Nonbond:", gist_action_.Total());
-  gist_nonbond_dist_.WriteTiming(3, "Dist2:", gist_nonbond_.Total());
-  gist_nonbond_UV_.WriteTiming(3, "UV:", gist_nonbond_.Total());
-  gist_nonbond_VV_.WriteTiming(3, "VV:", gist_nonbond_.Total());
+  //gist_nonbond_dist_.WriteTiming(3, "Dist2:", gist_nonbond_.Total());
+  //gist_nonbond_UV_.WriteTiming(3, "UV:", gist_nonbond_.Total());
+  //gist_nonbond_VV_.WriteTiming(3, "VV:", gist_nonbond_.Total());
   gist_euler_.WriteTiming(2,   "Euler:  ", gist_action_.Total());
   gist_dipole_.WriteTiming(2,  "Dipole: ", gist_action_.Total());
   gist_order_.WriteTiming(2,   "Order: ", gist_action_.Total());

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -62,6 +62,9 @@ class Action_GIST : public Action {
     Iarray A_idxs_;      ///< Atom indices for each solute and solvent atom.+ (energy calc only)
     Iarray N_waters_;    ///< Number of waters (oxygen atoms) in each voxel.*
     Iarray N_hydrogens_; ///< Number of hydrogen atoms in each voxel.*
+
+    Iarray U_idxs_;      ///< Solute atom indices.
+    Iarray OffGrid_idxs_;///< Off-grid solvent atom indices.
 #   ifdef _OPENMP
     std::vector<Iarray> EIJ_V1_; ///< Hold any interaction energy voxel 1 each frame.*
     std::vector<Iarray> EIJ_V2_; ///< Hold any interaction energy voxel 2 each frame.*

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -83,7 +83,7 @@ class Action_GIST : public Action {
     Xarray voxel_Q_;   ///< w4, x4, y4, z4 for all waters in each voxel.*
 
     typedef std::vector<double> Darray;
-    Darray OnGrid_XYZ_;             ///< XYZ coordinates for on-grid waters.
+    Darray OnGrid_XYZ_;             ///< XYZ coordinates for on-grid waters.*
     std::vector<Darray> E_UV_VDW_;  ///< Solute-solvent van der Waals energy for each voxel.*
     std::vector<Darray> E_UV_Elec_; ///< Solute-solvent electrostatic energy for each voxel.*
     std::vector<Darray> E_VV_VDW_;  ///< Solvent-solvent van der Waals energy for each voxel.*

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -63,9 +63,10 @@ class Action_GIST : public Action {
     Iarray A_idxs_;      ///< Atom indices for each solute and solvent atom.+ (energy calc only)
     Iarray N_waters_;    ///< Number of waters (oxygen atoms) in each voxel.*
     Iarray N_hydrogens_; ///< Number of hydrogen atoms in each voxel.*
-
+#   ifdef GIST_NEW_NONBOND
     Iarray U_idxs_;      ///< Solute atom indices.
     Iarray OffGrid_idxs_;///< Off-grid solvent atom indices.
+#   endif
 #   ifdef _OPENMP
     std::vector<Iarray> EIJ_V1_; ///< Hold any interaction energy voxel 1 each frame.*
     std::vector<Iarray> EIJ_V2_; ///< Hold any interaction energy voxel 2 each frame.*

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -81,6 +81,7 @@ class Action_GIST : public Action {
     Xarray voxel_Q_;   ///< w4, x4, y4, z4 for all waters in each voxel.*
 
     typedef std::vector<double> Darray;
+    Darray OnGrid_XYZ_;             ///< XYZ coordinates for on-grid waters.
     std::vector<Darray> E_UV_VDW_;  ///< Solute-solvent van der Waals energy for each voxel.*
     std::vector<Darray> E_UV_Elec_; ///< Solute-solvent electrostatic energy for each voxel.*
     std::vector<Darray> E_VV_VDW_;  ///< Solvent-solvent van der Waals energy for each voxel.*

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -63,10 +63,6 @@ class Action_GIST : public Action {
     Iarray A_idxs_;      ///< Atom indices for each solute and solvent atom.+ (energy calc only)
     Iarray N_waters_;    ///< Number of waters (oxygen atoms) in each voxel.*
     Iarray N_hydrogens_; ///< Number of hydrogen atoms in each voxel.*
-#   ifdef GIST_NEW_NONBOND
-    Iarray U_idxs_;      ///< Solute atom indices.
-    Iarray OffGrid_idxs_;///< Off-grid solvent atom indices.
-#   endif
 #   ifdef _OPENMP
     std::vector<Iarray> EIJ_V1_; ///< Hold any interaction energy voxel 1 each frame.*
     std::vector<Iarray> EIJ_V2_; ///< Hold any interaction energy voxel 2 each frame.*

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -99,6 +99,7 @@ class Action_GIST : public Action {
     Timer gist_nonbond_dist_;
     Timer gist_nonbond_UV_;
     Timer gist_nonbond_VV_;
+    Timer gist_nonbond_OV_;
     Timer gist_euler_;
     Timer gist_dipole_;
     Timer gist_order_;

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -30,6 +30,7 @@ class Action_GIST : public Action {
     static const Vec3 x_lab_;
     static const Vec3 y_lab_;
     static const Vec3 z_lab_;
+    static const double maxD_;
     static const double QFAC_;
     static const int SOLUTE_;
     static const int OFF_GRID_;

--- a/src/Action_GIST.h
+++ b/src/Action_GIST.h
@@ -92,6 +92,7 @@ class Action_GIST : public Action {
     Timer gist_print_;
     Timer gist_grid_;
     Timer gist_nonbond_;
+    Timer gist_nonbond_dist_;
     Timer gist_nonbond_UV_;
     Timer gist_nonbond_VV_;
     Timer gist_euler_;

--- a/test/Test_GIST/RunTest.sh
+++ b/test/Test_GIST/RunTest.sh
@@ -19,8 +19,7 @@ gist doorder doeij refdens 0.033422885325 gridcntr 1.44 0.67 0.29 \
 go
 EOF
 RunCpptraj "GIST water-water interaction test"
-echo "DEBUG: Using absolute error tolerance of 0.00001"
-DoTest Gist1-Eww_ij.dat.save Gist1-Eww_ij.dat -a 0.00001
+DoTest Gist1-Eww_ij.dat.save Gist1-Eww_ij.dat
 
 # GIST test with finer grid for everything else
 cat > gist.in <<EOF

--- a/test/Test_GIST/RunTest.sh
+++ b/test/Test_GIST/RunTest.sh
@@ -19,7 +19,8 @@ gist doorder doeij refdens 0.033422885325 gridcntr 1.44 0.67 0.29 \
 go
 EOF
 RunCpptraj "GIST water-water interaction test"
-DoTest Gist1-Eww_ij.dat.save Gist1-Eww_ij.dat
+echo "DEBUG: Using absolute error tolerance of 0.00001"
+DoTest Gist1-Eww_ij.dat.save Gist1-Eww_ij.dat -a 0.00001
 
 # GIST test with finer grid for everything else
 cat > gist.in <<EOF


### PR DESCRIPTION
Improve speed primarily by pre-cacluating atom images for non-orthogonal cells. Also minor speed improvements from placing on-grid waters into separate array to reduce cache misses. Should use slightly less memory now as well due to better estimation of the maximum number of on-grid solvent molecules.

Example of speedup for 4143 solute atoms, 15022 solvent molecules, truncated octahedron box, grid dimensions 10x10x10 Ang. with 2.0 Ang spacing).
GIST command line:
```
gist doorder doeij refdens 0.033422885325 \
  gridcntr 42.960304 43.125409 43.861148 \
  griddim 10 10 10 gridspacn 2.0 prefix Gist1`
```
```
	/u/droe/Amber/GIT/amber/bin/cpptraj
	  0 BenchTime: 17.12 context switches: 1513 waits: 1 FPS= 0.5875
	  1 BenchTime: 17.00 context switches: 1536 waits: 1 FPS= 0.5914
	  2 BenchTime: 16.96 context switches: 1519 waits: 1 FPS= 0.5931
	/u/droe/Local_work/Cpptraj/cpptraj/bin/cpptraj
	  0 BenchTime: 8.15 context switches: 747 waits: 1 FPS= 1.2422
	  1 BenchTime: 8.14 context switches: 723 waits: 1 FPS= 1.2428
	  2 BenchTime: 8.13 context switches: 721 waits: 1 FPS= 1.2443
  Baseline  :  17.0267
  Benchmark :   8.1400
  Speedup   :   2.09
  %Change   :  52.19 %
```