### PR TITLE
Some fixes and add volume-specific functions to 'volmap'

### DIFF
--- a/src/Action_Channel.cpp
+++ b/src/Action_Channel.cpp
@@ -110,9 +110,9 @@ Action::RetType Action_Channel::DoAction(int frameNum, ActionFrame& frm) {
     minPt.Print("min point");
     maxPt.Print("max point");
     long int min_i, min_j, min_k;
-    GRID.BinIndices(minPt[0],minPt[1],minPt[2],min_i,min_j,min_k);
+    GRID.Bin().Indices(minPt[0],minPt[1],minPt[2],min_i,min_j,min_k);
     long int max_i, max_j, max_k;
-    GRID.BinIndices(maxPt[0],maxPt[1],maxPt[2],max_i,max_j,max_k);
+    GRID.Bin().Indices(maxPt[0],maxPt[1],maxPt[2],max_i,max_j,max_k);
     mprintf("\tGrid dims: %li <= i < %li\n", std::max(0L,min_i), std::min(max_i,nx));
     mprintf("\tGrid dims: %li <= j < %li\n", std::max(0L,min_j), std::min(max_j,ny));
     mprintf("\tGrid dims: %li <= k < %li\n", std::max(0L,min_k), std::min(max_k,nz));

--- a/src/Action_Dipole.cpp
+++ b/src/Action_Dipole.cpp
@@ -153,7 +153,7 @@ Action::RetType Action_Dipole::DoAction(int frameNum, ActionFrame& frm) {
     COM -= cXYZ;
     size_t ix, jy, kz;
     //mprintf("CDBG: Solvent %i XYZ %8.3f %8.3f %8.3f\n",solvmol-CurrentParm_->MolStart(),COM[0],COM[1],COM[2]);
-    if (grid_->CalcBins( COM[0], COM[1], COM[2], ix, jy, kz )) {
+    if (grid_->Bin().Calc( COM[0], COM[1], COM[2], ix, jy, kz )) {
       // Point COM is inside the grid. Increment grid and grid the dipole.
       long int bin = grid_->Increment( ix, jy, kz, Increment() );
       dipole_[bin] += dipolar_vector;
@@ -206,7 +206,7 @@ void Action_Dipole::Print() {
         //mprintf("CDBG: %5i %5i %5i %lf\n",i,j,k,density);
         if ( density >= max_density ) {
           // Print Bin Coords
-          Vec3 binCorner = grid_->BinCorner(i, j, k);
+          Vec3 binCorner = grid_->Bin().Corner(i, j, k);
           outfile_->Printf("%8.3f %8.3f %8.3f", binCorner[0], binCorner[1], binCorner[2]);
           // Normalize dipoles by density
           size_t idx = grid_->CalcIndex(i,j,k);

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -290,7 +290,7 @@ Action::RetType Action_GIST::Init(ArgList& actionArgs, ActionInit& init, int deb
     mprintf("\tDistances will not be imaged.\n");
   gO_->GridInfo();
   mprintf("\tNumber of voxels: %zu, voxel volume: %f Ang^3\n",
-          MAX_GRID_PT_, gO_->VoxelVolume());
+          MAX_GRID_PT_, gO_->Bin().VoxelVolume());
   mprintf("#Please cite these papers if you use GIST results in a publication:\n"
           "#    Steven Ramsey, Crystal Nguyen, Romelia Salomon-Ferrer, Ross C. Walker, Michael K. Gilson, and Tom Kurtzman J. Comp. Chem. 37 (21) 2016\n"
           "#    Crystal Nguyen, Michael K. Gilson, and Tom Young, arXiv:1108.4876v1 (2011)\n"
@@ -413,7 +413,7 @@ Action::RetType Action_GIST::Setup(ActionSetup& setup) {
   // Estimate how many solvent molecules can possibly fit onto the grid.
   // Add some extra voxels as a buffer.
   double max_voxels = (double)MAX_GRID_PT_ + (1.10 * (double)MAX_GRID_PT_);
-  double totalVolume = max_voxels * gO_->VoxelVolume();
+  double totalVolume = max_voxels * gO_->Bin().VoxelVolume();
   double max_mols = totalVolume * BULK_DENS_;
   //mprintf("\tEstimating grid can fit a max of %.0f solvent molecules (w/ 10%% buffer).\n",
   //        max_mols);
@@ -715,7 +715,7 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
   OnGrid_XYZ_.clear();
 
   size_t bin_i, bin_j, bin_k;
-  Vec3 const& Origin = gO_->GridOrigin();
+  Vec3 const& Origin = gO_->Bin().GridOrigin();
   // Loop over each solvent molecule
   for (unsigned int sidx = 0; sidx < NSOLVENT_; sidx++)
   {
@@ -738,7 +738,7 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
       const double* H1_XYZ = frm.Frm().XYZ( oidx + 1 );
       const double* H2_XYZ = frm.Frm().XYZ( oidx + 2 );
       // Try to bin the oxygen
-      if ( gO_->CalcBins( O_XYZ[0], O_XYZ[1], O_XYZ[2], bin_i, bin_j, bin_k ) )
+      if ( gO_->Bin().Calc( O_XYZ[0], O_XYZ[1], O_XYZ[2], bin_i, bin_j, bin_k ) )
       {
         // Oxygen is inside the grid. Record the voxel.
         // NOTE hydrogens/EP always assigned to same voxel for energy purposes.
@@ -874,9 +874,9 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
 
       // Water is at most 1.5A away from grid, so we need to check for H
       // even if O is outside grid.
-      if (gO_->CalcBins( H1_XYZ[0], H1_XYZ[1], H1_XYZ[2], bin_i, bin_j, bin_k ) )
+      if (gO_->Bin().Calc( H1_XYZ[0], H1_XYZ[1], H1_XYZ[2], bin_i, bin_j, bin_k ) )
         N_hydrogens_[ (int)gO_->CalcIndex(bin_i, bin_j, bin_k) ]++;
-      if (gO_->CalcBins( H2_XYZ[0], H2_XYZ[1], H2_XYZ[2], bin_i, bin_j, bin_k ) )
+      if (gO_->Bin().Calc( H2_XYZ[0], H2_XYZ[1], H2_XYZ[2], bin_i, bin_j, bin_k ) )
         N_hydrogens_[ (int)gO_->CalcIndex(bin_i, bin_j, bin_k) ]++;
     } // END water is within 1.5 Ang of grid
   } // END loop over each solvent molecule
@@ -949,7 +949,7 @@ void Action_GIST::SumEVV() {
 // Action_GIST::Print()
 void Action_GIST::Print() {
   gist_print_.Start();
-  double Vvox = gO_->VoxelVolume();
+  double Vvox = gO_->Bin().VoxelVolume();
 
   mprintf("    GIST OUTPUT:\n");
   // Calculate orientational entropy
@@ -1222,7 +1222,7 @@ void Action_GIST::Print() {
       O_progress.Update( gr_pt );
       size_t i, j, k;
       gO_->ReverseIndex( gr_pt, i, j, k );
-      Vec3 XYZ = gO_->BinCenter( i, j, k );
+      Vec3 XYZ = gO_->Bin().Center( i, j, k );
       datafile_->Printf("%d %g %g %g %d %g %g %g %g %g %g %g"
                         " %g %g %g %g %g %g %g %g %g %g %g %g \n",
                         gr_pt, XYZ[0], XYZ[1], XYZ[2], N_waters_[gr_pt], gO[gr_pt], gH[gr_pt],

--- a/src/Action_Grid.cpp
+++ b/src/Action_Grid.cpp
@@ -162,9 +162,9 @@ void Action_Grid::Print() {
     mprintf("    GRID: Normalization");
     double dens = 1.0;
     if (normalize_ == TO_DENSITY) {
-      dens = grid_->VoxelVolume() * density_;
+      dens = grid_->Bin().VoxelVolume() * density_;
       mprintf(" to density %g molecules/Ang^3, voxel volume= %g Ang^3, %g mols/voxel,",
-              density_, grid_->VoxelVolume(), dens);
+              density_, grid_->Bin().VoxelVolume(), dens);
     } else
       mprintf(" to");
     mprintf(" number of frames %u", nframes_);
@@ -202,7 +202,7 @@ void Action_Grid::PrintPDB(double gridMax)
       for (size_t i = 0; i < grid_->NX(); ++i) {
         double gridval = grid_->GetElement(i, j, k) * norm;
         if (gridval > max_) {
-          Vec3 cxyz = grid_->BinCenter(i,j,k);
+          Vec3 cxyz = grid_->Bin().Center(i,j,k);
           pdbout.WriteATOM(res++, cxyz[0], cxyz[1], cxyz[2], "GRID", gridval);
         }
       }
@@ -212,7 +212,7 @@ void Action_Grid::PrintPDB(double gridMax)
   for (size_t k = 0; k <= grid_->NZ(); k += grid_->NZ())
     for (size_t j = 0; j <= grid_->NY(); j += grid_->NY())
       for (size_t i = 0; i <= grid_->NX(); i += grid_->NX()) {
-        Vec3 cxyz = grid_->BinCorner(i,j,k);
+        Vec3 cxyz = grid_->Bin().Corner(i,j,k);
         pdbout.WriteHET(res, cxyz[0], cxyz[1], cxyz[2]);
       }
   // DEBUG: Write all grid bin corners
@@ -221,7 +221,7 @@ void Action_Grid::PrintPDB(double gridMax)
     for (size_t k = 0; k <= grid_->NZ(); k++)
       for (size_t j = 0; j <= grid_->NY(); j++)
         for (size_t i = 0; i <= grid_->NX(); i++) {
-          Vec3 cxyz = grid_->BinCorner(i,j,k);
+          Vec3 cxyz = grid_->Bin().Corner(i,j,k);
           pdbout.WriteATOM(res, cxyz[0], cxyz[1], cxyz[2], "BIN", 0.0);
         }
   }

--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -119,6 +119,7 @@ Action::RetType Action_Volmap::Init(ArgList& actionArgs, ActionInit& init, int d
       mprinterr("Error: Currently only works with orthogonal grids.\n");
       return Action::ERR;
     }
+    setname = dsname;
     GridBin_Ortho const& gbo = static_cast<GridBin_Ortho const&>( grid_->Bin() );
     dx_ = gbo.DX();
     dy_ = gbo.DY();
@@ -163,6 +164,9 @@ Action::RetType Action_Volmap::Init(ArgList& actionArgs, ActionInit& init, int d
 # endif
   // Setup output file
   if (outfile != 0) outfile->AddDataSet( grid_ );
+  // Create total volume set
+  total_volume_ = init.DSL().AddSet(DataSet::DOUBLE, MetaData(setname, "totalvol"));
+  if (total_volume_ == 0) return Action::ERR;
 
   // Info
   mprintf("    VOLMAP: Grid spacing will be %.2fx%.2fx%.2f Angstroms\n", dx_, dy_, dz_);
@@ -176,6 +180,7 @@ Action::RetType Action_Volmap::Init(ArgList& actionArgs, ActionInit& init, int d
   if (outfile != 0)
     mprintf("\tDensity will wrtten to '%s'\n", outfile->DataFilename().full());
   mprintf("\tGrid dataset name is '%s'\n", grid_->legend());
+  mprintf("\tTotal grid volume dataset name is '%s'\n", total_volume_->legend());
   if (peakfile_ != 0)
     mprintf("\tDensity peaks above %.3f will be printed to %s in XYZ-format\n",
             peakcut_, peakfile_->Filename().full());
@@ -397,6 +402,7 @@ void Action_Volmap::Print() {
   for (DataSet_GridFlt::iterator gval = grid_->begin(); gval != grid_->end(); ++gval)
     if (*gval > 0.0) ++nOccupiedVoxels;
   double volume_estimate = (double)nOccupiedVoxels * grid_->Bin().VoxelVolume();
+  total_volume_->Add(0, &volume_estimate);
   mprintf("\t%u occupied voxels, voxel volume= %f Ang^3, total volume %f Ang^3\n",
           nOccupiedVoxels, grid_->Bin().VoxelVolume(), volume_estimate);
 

--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -83,11 +83,6 @@ Action::RetType Action_Volmap::Init(ArgList& actionArgs, ActionInit& init, int d
     dz_ = actionArgs.getNextDouble(0.0);
   }
   //std::string density = actionArgs.GetStringKey("density"); // FIXME obsolete?
-  // Get output filename
-  std::string outfilename = actionArgs.GetStringKey("out");
-  if (outfilename.empty())
-    outfilename = actionArgs.GetStringNext(); // Backwards compat.
-  DataFile* outfile = init.DFL().AddDataFile( outfilename, actionArgs );
   // Get the required mask
   std::string reqmask = actionArgs.GetMaskNext();
   if (reqmask.empty()) {
@@ -95,6 +90,11 @@ Action::RetType Action_Volmap::Init(ArgList& actionArgs, ActionInit& init, int d
      return Action::ERR;
   }
   densitymask_.SetMaskString(reqmask);
+  // Get output filename
+  std::string outfilename = actionArgs.GetStringKey("out");
+  if (outfilename.empty())
+    outfilename = actionArgs.GetStringNext(); // Backwards compat.
+  DataFile* outfile = init.DFL().AddDataFile( outfilename, actionArgs );
 
 # ifdef _OPENMP
   // Always need to allocate temp grid space for each thread.

--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -345,7 +345,7 @@ Action::RetType Action_Volmap::DoAction(int frameNum, ActionFrame& frm) {
 # pragma omp for
 # endif
   for (midx = 0; midx < maxidx; midx++) {
-    float rhalf = halfradii_[midx];
+    double rhalf = (double)halfradii_[midx];
     if (rhalf > 0.0) {
       atom = densitymask_[midx];
       Vec3 pt = Vec3(frm.Frm().XYZ(atom));

--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -35,7 +35,7 @@ void Action_Volmap::Help() const {
 void Action_Volmap::RawHelp() const {
   mprintf("\t[out <filename>] <mask> [radscale <factor>]\n"
           "\t{ data <existing set> |\n"
-          "\t  name <setname> <dx> <dy> <dz>\n"
+          "\t  name <setname> <dx> [<dy> <dz>]\n"
           "\t    { size <x,y,z> [center <x,y,z>] |\n"
           "\t      centermask <mask> [buffer <buffer>] }\n"
           "\t}\n"

--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -79,8 +79,13 @@ Action::RetType Action_Volmap::Init(ArgList& actionArgs, ActionInit& init, int d
     }
     // Get grid resolutions
     dx_ = actionArgs.getNextDouble(0.0);
-    dy_ = actionArgs.getNextDouble(0.0);
-    dz_ = actionArgs.getNextDouble(0.0);
+    dy_ = actionArgs.getNextDouble(dx_);
+    dz_ = actionArgs.getNextDouble(dy_);
+    if (dx_ <= 0.0 || dy_ <= 0.0 || dz_ <= 0.0) {
+      mprinterr("Error: At least one of <dx> <dy> <dz> spacings must be specified\n"
+                "Error:   if 'data' not specified.\n");
+      return Action::ERR;
+    }
   }
   //std::string density = actionArgs.GetStringKey("density"); // FIXME obsolete?
   // Get the required mask

--- a/src/Action_Volmap.cpp
+++ b/src/Action_Volmap.cpp
@@ -370,6 +370,14 @@ void Action_Volmap::Print() {
   float nf = (float)Nframes_;
   for (DataSet_GridFlt::iterator gval = grid_->begin(); gval != grid_->end(); ++gval)
     *gval /= nf;
+  // Print volume estimate
+  unsigned int nOccupiedVoxels = 0;
+  for (DataSet_GridFlt::iterator gval = grid_->begin(); gval != grid_->end(); ++gval)
+    if (*gval > 0.0) ++nOccupiedVoxels;
+  double volume_estimate = (double)nOccupiedVoxels * grid_->VoxelVolume();
+  mprintf("\t%u occupied voxels, voxel volume= %f Ang^3, total volume %f Ang^3\n",
+          nOccupiedVoxels, grid_->VoxelVolume(), volume_estimate);
+
 //    grid_.PrintXplor( filename_, "This line is ignored", 
 //                      "rdparm generated grid density" );
   

--- a/src/Action_Volmap.h
+++ b/src/Action_Volmap.h
@@ -22,27 +22,18 @@ class Action_Volmap : public Action {
     double dx_, dy_, dz_;
     /// minimum values in the x-, y-, and z-dimensions
     double xmin_, ymin_, zmin_;
-    /// number of frames we analyzed so we can average at the end
-    int Nframes_;
-    /// If true, set up the grid on first frame based on centermask.
-    bool setupGridOnMask_;
-    /// mask to center the grid on
-    AtomMask centermask_;
-    /// mask of atoms to grid
-    AtomMask densitymask_;
-    /// the grid we are using
-    DataSet_GridFlt* grid_;
+    int Nframes_;           ///< Number of frames we analyzed so we can average at the end
+    bool setupGridOnMask_;  ///< If true, set up the grid on first frame based on centermask.
+    AtomMask centermask_;   ///< Mask to center the grid on
+    AtomMask densitymask_;  ///< Max of atoms to grid.
+    DataSet_GridFlt* grid_; ///< Hold the grid.
     DataSet* total_volume_; ///< Hold total grid volume.
-    /// file name with the peak locations as Carbons in XYZ file format
-    CpptrajFile* peakfile_;
-    /// The value below which to ignore all peaks
-    double peakcut_;
-    /// the atomic radii of each atom in the gridded selection
-    std::vector<float> halfradii_;
-    /// the clearance between the edges of our grid and centermask_
-    double buffer_;
-    /// the scaling factor to divide all radii by
-    double radscale_;
+    CpptrajFile* peakfile_; ///< file name with the peak locations as Carbons in XYZ file format
+    double peakcut_;        ///< The value below which to ignore all peaks
+    std::vector<float> halfradii_; ///< 1/2 the atomic radii of each atom in the gridded selection
+    double buffer_;         ///< Clearance between the edges of our grid and centermask_
+    double radscale_;       ///< The scaling factor to divide all radii by
+    double stepfac_;        ///< Factor for determining how many steps to smear Gaussian
     static const double sqrt_8_pi_cubed;
 #   ifdef _OPENMP
     typedef std::vector< Grid<float> > Garray;

--- a/src/Action_Volmap.h
+++ b/src/Action_Volmap.h
@@ -24,6 +24,7 @@ class Action_Volmap : public Action {
     double xmin_, ymin_, zmin_;
     int Nframes_;           ///< Number of frames we analyzed so we can average at the end
     bool setupGridOnMask_;  ///< If true, set up the grid on first frame based on centermask.
+    bool spheremode_;       ///< If true, grid points farther than rhalf^2 will be skipped
     AtomMask centermask_;   ///< Mask to center the grid on
     AtomMask densitymask_;  ///< Max of atoms to grid.
     DataSet_GridFlt* grid_; ///< Hold the grid.

--- a/src/Action_Volmap.h
+++ b/src/Action_Volmap.h
@@ -18,6 +18,9 @@ class Action_Volmap : public Action {
     void Print();
     void RawHelp() const;
 
+    /// Radii to use
+    enum RadiiType { UNSPECIFIED = 0, VDW, ELEMENT };
+    RadiiType radiiType_;
     /// grid resolutions
     double dx_, dy_, dz_;
     /// minimum values in the x-, y-, and z-dimensions
@@ -31,6 +34,7 @@ class Action_Volmap : public Action {
     DataSet* total_volume_; ///< Hold total grid volume.
     CpptrajFile* peakfile_; ///< file name with the peak locations as Carbons in XYZ file format
     double peakcut_;        ///< The value below which to ignore all peaks
+    std::vector<int> Atoms_; ///< Atoms with radii > 0.0
     std::vector<float> halfradii_; ///< 1/2 the atomic radii of each atom in the gridded selection
     double buffer_;         ///< Clearance between the edges of our grid and centermask_
     double radscale_;       ///< The scaling factor to divide all radii by

--- a/src/Action_Volmap.h
+++ b/src/Action_Volmap.h
@@ -32,6 +32,7 @@ class Action_Volmap : public Action {
     AtomMask densitymask_;
     /// the grid we are using
     DataSet_GridFlt* grid_;
+    DataSet* total_volume_; ///< Hold total grid volume.
     /// file name with the peak locations as Carbons in XYZ file format
     CpptrajFile* peakfile_;
     /// The value below which to ignore all peaks

--- a/src/DataIO_CCP4.cpp
+++ b/src/DataIO_CCP4.cpp
@@ -221,7 +221,7 @@ int DataIO_CCP4::WriteSet3D( DataSetList::const_iterator const& setIn, CpptrajFi
   }
   DataSet_3D const& grid = static_cast<DataSet_3D const&>( *(*setIn) );
   // Check input grid
-  Vec3 OXYZ = grid.GridOrigin();
+  Vec3 OXYZ = grid.Bin().GridOrigin();
   if (OXYZ[0] < 0.0 || OXYZ[1] < 0.0 || OXYZ[2] < 0.0 ||
       OXYZ[0] > 0.0 || OXYZ[1] > 0.0 || OXYZ[2] > 0.0)
     mprintf("Warning: Grid '%s' origin is not 0.0, 0.0, 0.0\n"
@@ -247,7 +247,7 @@ int DataIO_CCP4::WriteSet3D( DataSetList::const_iterator const& setIn, CpptrajFi
   buffer.i[7] = (int)grid.NX();
   buffer.i[8] = (int)grid.NY();
   buffer.i[9] = (int)grid.NZ();
-  Box box( grid.Ucell() );
+  Box box( grid.Bin().Ucell() );
   buffer.f[10] = (float)box[0];
   buffer.f[11] = (float)box[1];
   buffer.f[12] = (float)box[2];

--- a/src/DataIO_OpenDx.cpp
+++ b/src/DataIO_OpenDx.cpp
@@ -247,10 +247,10 @@ int DataIO_OpenDx::WriteGridWrap(DataSet const& setIn, CpptrajFile& outfile) con
   int mesh_z = set.NZ();
   // Origin needs to be shifted half grid spacing, i.e. it is the center of the
   // bin located at -1, -1, -1.
-  Vec3 oxyz = set.BinCenter(-1, -1, -1);
+  Vec3 oxyz = set.Bin().Center(-1, -1, -1);
   // Print the OpenDX header
   WriteDxHeader(outfile, mesh_x+2, mesh_y+2, mesh_z+2, mesh_x, mesh_y, mesh_z,
-                set.Ucell(), oxyz);
+                set.Bin().Ucell(), oxyz);
   // Print out the data. Start at bin -1, end on bin N.
   int nvals = 0; // Keep track of how many values printed on current line.
   if (gridWriteMode_ == WRAP) {
@@ -301,13 +301,13 @@ int DataIO_OpenDx::WriteGridWrap(DataSet const& setIn, CpptrajFile& outfile) con
 
 int DataIO_OpenDx::WriteGrid(DataSet const& setIn, CpptrajFile& outfile) const {
   DataSet_3D const& set = static_cast<DataSet_3D const&>( setIn );
-  Vec3 oxyz = set.GridOrigin();
+  Vec3 oxyz = set.Bin().GridOrigin();
   if (gridWriteMode_ == BIN_CENTER)
     // Origin needs to be shifted to center of bin located at 0,0,0
-    oxyz = set.BinCenter(0,0,0);
+    oxyz = set.Bin().Center(0,0,0);
   // Print the OpenDX header
   WriteDxHeader(outfile, set.NX(), set.NY(), set.NZ(), set.NX(), set.NY(), set.NZ(),
-                set.Ucell(), oxyz);
+                set.Bin().Ucell(), oxyz);
   // Now print out the data.
   size_t gridsize = set.Size();
   if (gridsize == 1)

--- a/src/DataIO_Xplor.cpp
+++ b/src/DataIO_Xplor.cpp
@@ -170,7 +170,7 @@ int DataIO_Xplor::WriteSet3D(DataSet const& setIn, CpptrajFile& outfile) const {
   // Locate the indices of the absolute origin in order to find starting
   // indices for each axis. FIXME: Is this correct?
   long int grid_min_x, grid_min_y, grid_min_z;
-  set.BinIndices(0.0, 0.0, 0.0, grid_min_x, grid_min_y, grid_min_z);
+  set.Bin().Indices(0.0, 0.0, 0.0, grid_min_x, grid_min_y, grid_min_z);
   if (grid_min_x != 0L) grid_min_x = -grid_min_x;
   if (grid_min_y != 0L) grid_min_y = -grid_min_y;
   if (grid_min_z != 0L) grid_min_z = -grid_min_z;
@@ -178,7 +178,7 @@ int DataIO_Xplor::WriteSet3D(DataSet const& setIn, CpptrajFile& outfile) const {
                    set.NX(), grid_min_x, grid_min_x + set.NX() - 1,
                    set.NY(), grid_min_y, grid_min_y + set.NY() - 1,
                    set.NZ(), grid_min_z, grid_min_z + set.NZ() - 1,
-                   set.Ucell());
+                   set.Bin().Ucell());
   // Print grid bins
   for (size_t k = 0; k < set.NZ(); ++k) {
     outfile.Printf("%8i\n", k);

--- a/src/DataSet_3D.cpp
+++ b/src/DataSet_3D.cpp
@@ -13,7 +13,10 @@ DataSet_3D::DataSet_3D(DataSet_3D const& rhs) : DataSet(rhs), gridBin_(0) {
 int DataSet_3D::Allocate_N_O_Box(size_t nx, size_t ny, size_t nz, 
                                  Vec3 const& oxyz, Box const& boxIn)
 {
-  if (nx == 0 || ny == 0 || nz == 0) return 1;
+  if (nx == 0 || ny == 0 || nz == 0) {
+    mprinterr("Error: One or more grid sizes are 0: %zu %zu %zu\n", nx, ny, nz);
+    return 1;
+  }
   if (gridBin_ != 0) delete gridBin_;
   GridBin_Nonortho* gb = new GridBin_Nonortho();
   // Set origin and unit cell params.
@@ -26,7 +29,10 @@ int DataSet_3D::Allocate_N_O_Box(size_t nx, size_t ny, size_t nz,
 int DataSet_3D::Allocate_N_O_D(size_t nx, size_t ny, size_t nz,
                                Vec3 const& oxyz, Vec3 const& dxyz)
 {
-  if (nx == 0 || ny == 0 || nz == 0) return 1;
+  if (nx == 0 || ny == 0 || nz == 0) {
+    mprinterr("Error: One or more grid sizes are 0: %zu %zu %zu\n", nx, ny, nz);
+    return 1;
+  }
   if (gridBin_ != 0) delete gridBin_;
   GridBin_Ortho* gb = new GridBin_Ortho();
   // Set origin and spacing, calculate maximum (for binning).

--- a/src/DataSet_3D.h
+++ b/src/DataSet_3D.h
@@ -46,24 +46,7 @@ class DataSet_3D : public DataSet {
     /// Print grid info.
     void GridInfo() const;
     // -------------------------------------------
-    /// Convert X, Y, and Z coords to indices. Check bounds.
-    bool CalcBins(double x,double y,double z,size_t& i,size_t& j,size_t& k) const { 
-      return gridBin_->CalcBins(x, y, z, i, j, k);
-    }
-    /// Convert X, Y, and Z coords to indices. No bounds check.
-    void BinIndices(double x,double y,double z,long int& i,long int& j,long int& k) const {
-      gridBin_->BinIndices(x, y, z, i, j, k);
-    }
-    /// \return coordinates of specified voxel corner.
-    Vec3 BinCorner(long int i,long int j,long int k) const { return gridBin_->BinCorner(i, j, k); }
-    /// \return coordinates of specified voxel center.
-    Vec3 BinCenter(long int i,long int j,long int k) const { return gridBin_->BinCenter(i, j, k); }
-    /// \return coordinates of grid origin.
-    Vec3 const& GridOrigin()          const { return gridBin_->GridOrigin();       }
-    /// \return unit cell matrix.
-    Matrix_3x3 Ucell()                const { return gridBin_->Ucell();            }
-    /// \return voxel volume.
-    double VoxelVolume()              const { return gridBin_->VoxelVolume();      }
+    GridBin const& Bin() const { return *gridBin_; }
   private:
     /// Check if grid dimension is even; if not, increment it by 1.
     static void CheckEven(size_t&, char);

--- a/src/DataSet_GridDbl.h
+++ b/src/DataSet_GridDbl.h
@@ -50,14 +50,14 @@ class DataSet_GridDbl : public DataSet_3D {
 // DataSet_GridDbl::Increment()
 long int DataSet_GridDbl::Increment(Vec3 const& xyz, double f) {
   size_t i,j,k;
-  if (CalcBins(xyz[0],xyz[1],xyz[2],i,j,k))
+  if (Bin().Calc(xyz[0],xyz[1],xyz[2],i,j,k))
     return grid_.incrementBy(i,j,k,f);
   return -1L; 
 }
 // DataSet_GridDbl::Increment()
 long int DataSet_GridDbl::Increment(const double* xyz, double f) {
   size_t i,j,k;
-  if (CalcBins(xyz[0],xyz[1],xyz[2],i,j,k))
+  if (Bin().Calc(xyz[0],xyz[1],xyz[2],i,j,k))
     return grid_.incrementBy(i,j,k,f);
   return -1L;
 }

--- a/src/DataSet_GridFlt.h
+++ b/src/DataSet_GridFlt.h
@@ -50,14 +50,14 @@ class DataSet_GridFlt : public DataSet_3D {
 // DataSet_GridFlt::Increment()
 long int DataSet_GridFlt::Increment(Vec3 const& xyz, float f) {
   size_t i,j,k;
-  if (CalcBins(xyz[0],xyz[1],xyz[2],i,j,k))
+  if (Bin().Calc(xyz[0],xyz[1],xyz[2],i,j,k))
     return grid_.incrementBy(i,j,k,f);
   return -1L; 
 }
 // DataSet_GridFlt::Increment()
 long int DataSet_GridFlt::Increment(const double* xyz, float f) {
   size_t i,j,k;
-  if (CalcBins(xyz[0],xyz[1],xyz[2],i,j,k))
+  if (Bin().Calc(xyz[0],xyz[1],xyz[2],i,j,k))
     return grid_.incrementBy(i,j,k,f);
   return -1L;
 }

--- a/src/Exec_CompareTop.h
+++ b/src/Exec_CompareTop.h
@@ -10,5 +10,6 @@ class Exec_CompareTop : public Exec {
     RetType Execute(CpptrajState&, ArgList&);
   private:
     void CompareAtoms(Topology const&, Topology const&, CpptrajFile&) const;
+    static inline bool Check(bool,bool,const char*, const char*, const char*);
 };
 #endif

--- a/src/GridBin.h
+++ b/src/GridBin.h
@@ -7,13 +7,13 @@ class GridBin {
     GridBin() : OXYZ_(0.0) {}
     virtual ~GridBin() {}
     /// Given coordinates, set corresponding bin indices; check bounds.
-    virtual bool CalcBins(double, double, double, size_t&, size_t&, size_t&) const = 0;
+    virtual bool Calc(double, double, double, size_t&, size_t&, size_t&) const = 0;
     /// Given coordinates, set corresponding bin indices; no bounds check.
-    virtual void BinIndices(double, double, double, long int&, long int&, long int&) const = 0;
+    virtual void Indices(double, double, double, long int&, long int&, long int&) const = 0;
     /// \return coordinates of bin for given indices; no bound check.
-    virtual Vec3 BinCorner(long int, long int, long int) const = 0;
+    virtual Vec3 Corner(long int, long int, long int) const = 0;
     /// \return coordinates of bin center for given indices; no bounds check.
-    virtual Vec3 BinCenter(long int, long int, long int) const = 0;
+    virtual Vec3 Center(long int, long int, long int) const = 0;
     /// \return unit cell matrix. // TODO: Make const&?
     virtual Matrix_3x3 Ucell() const = 0;
     /// \return true if GridBin type is orthogonal.
@@ -33,8 +33,8 @@ class GridBin_Ortho : public GridBin {
   public:
     GridBin_Ortho() : dx_(-1.0), dy_(-1.0), dz_(-1.0), mx_(0),  my_(0), mz_(0) {}
     GridBin* Copy() const { return (GridBin*)(new GridBin_Ortho(*this)); }
-    bool CalcBins(double x, double y, double z,
-                  size_t& i, size_t& j, size_t& k) const
+    bool Calc(double x, double y, double z,
+              size_t& i, size_t& j, size_t& k) const
     {
       if (x >= OXYZ_[0] && x < mx_) { // X
         if (y >= OXYZ_[1] && y < my_) { // Y
@@ -48,17 +48,17 @@ class GridBin_Ortho : public GridBin {
       }
       return false;
     }
-    void BinIndices(double x, double y, double z, long int& i, long int& j, long int& k) const {
+    void Indices(double x, double y, double z, long int& i, long int& j, long int& k) const {
       i = (long int)((x-OXYZ_[0]) / dx_);
       j = (long int)((y-OXYZ_[1]) / dy_);
       k = (long int)((z-OXYZ_[2]) / dz_);
     }
-    Vec3 BinCorner(long int i, long int j, long int k) const {
+    Vec3 Corner(long int i, long int j, long int k) const {
       return Vec3((double)i*dx_+OXYZ_[0],
                   (double)j*dy_+OXYZ_[1],
                   (double)k*dz_+OXYZ_[2]);
     }
-    Vec3 BinCenter(long int i, long int j, long int k) const {
+    Vec3 Center(long int i, long int j, long int k) const {
       return Vec3((double)i*dx_+OXYZ_[0]+0.5*dx_,
                   (double)j*dy_+OXYZ_[1]+0.5*dy_,
                   (double)k*dz_+OXYZ_[2]+0.5*dz_);
@@ -89,7 +89,7 @@ class GridBin_Nonortho : public GridBin {
   public:
     GridBin_Nonortho() {}
     GridBin* Copy() const { return (GridBin*)(new GridBin_Nonortho(*this)); }
-    bool CalcBins(double x, double y, double z,
+    bool Calc(double x, double y, double z,
                   size_t& i, size_t& j, size_t& k) const
     {
       Vec3 frac = recip_ * Vec3(x - OXYZ_[0], y - OXYZ_[1], z - OXYZ_[2]);
@@ -105,17 +105,17 @@ class GridBin_Nonortho : public GridBin {
       }
       return false;
     }
-    void BinIndices(double x, double y, double z, long int& i, long int& j, long int& k) const {
+    void Indices(double x, double y, double z, long int& i, long int& j, long int& k) const {
       Vec3 frac = recip_ * Vec3(x - OXYZ_[0], y - OXYZ_[1], z - OXYZ_[2]);
       i = (long int)(frac[0] * nx_);
       j = (long int)(frac[1] * ny_);
       k = (long int)(frac[2] * nz_);
     }
-    Vec3 BinCorner(long int i, long int j, long int k) const {
+    Vec3 Corner(long int i, long int j, long int k) const {
       Vec3 frac( (double)i / nx_, (double)j / ny_, (double)k / nz_ );
       return ucell_.TransposeMult( frac );
     }
-    Vec3 BinCenter(long int i, long int j, long int k) const {
+    Vec3 Center(long int i, long int j, long int k) const {
       Vec3 frac_half((1.0 + 2.0 * (double)i) / (2.0 * nx_),  //(0.5 * (1.0 / nx_)) + ((double)i / nx_),
                      (1.0 + 2.0 * (double)j) / (2.0 * ny_), 
                      (1.0 + 2.0 * (double)k) / (2.0 * nz_));

--- a/src/RPNcalc.cpp
+++ b/src/RPNcalc.cpp
@@ -760,12 +760,14 @@ int RPNcalc::Evaluate(DataSetList& DSL) const {
                 return 1;
               }
               // Check if spacing is the same, warn if not.
-              if (G1.GridOrigin() != G2.GridOrigin())
+              if (G1.Bin().GridOrigin() != G2.Bin().GridOrigin())
                 mprintf("Warning: Grid origins do not match. Using origin %g %g %g\n",
-                        G1.GridOrigin()[0], G1.GridOrigin()[1], G1.GridOrigin()[2]);
+                        G1.Bin().GridOrigin()[0], G1.Bin().GridOrigin()[1],
+                        G1.Bin().GridOrigin()[2]);
               tempDS = LocalList.AddSet(DataSet::GRID_FLT, MetaData("TEMP", T-tokens_.begin()));
               DataSet_GridFlt& G0 = static_cast<DataSet_GridFlt&>( *tempDS );
-              G0.Allocate_N_O_Box(G1.NX(), G1.NY(), G1.NZ(), G1.GridOrigin(), Box(G1.Ucell()));
+              G0.Allocate_N_O_Box(G1.NX(), G1.NY(), G1.NZ(), G1.Bin().GridOrigin(),
+                                  Box(G1.Bin().Ucell()));
               G1.GridInfo();
               G0.GridInfo();
               for (unsigned int n = 0; n != G1.Size(); n++)


### PR DESCRIPTION
This PR fixes the behavior of `volmap` when using the `data` keyword, and prints out the correct center if the `center` argument is used.

1. Adds the following new keywords:
- **stepfac <fac>** : Allow custom factor for determining how many steps to smear the Gaussian in each direction (default was/is 4.1).
- **sphere** : When smearing Gaussian, ignore voxels that are farther away than the radius. This is most useful when estimating volume.
- **boxref <reference** : Set up grid from unit cell of given reference coordinates.
- **out <filename>** : Allows output filename to appear anywhere in the command.
- **radii {vdw | element}** : Allows user to specifically choose which radii to use.
2. Adds the calculation of total occupied volume of the grid during the Print() phase via number of occupied voxels time voxel volume. This is saved in a dataset with aspect "totalvol".
3. Improve speed slightly by skipping atoms with 0.0 radius as well as skipping calculation of exponential factors if atom is not on the grid.

PR also includes some minor segfault protections for the `comparetop` command.