### PR TITLE
Fix Appveyor build failures with CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
     - { os: linux, env: COMPILER=gnu USE_CMAKE=0 BUILD_FLAGS="-mpi" DO_PARALLEL="mpiexec -n 2" BUILD_TYPE=install TEST_TYPE=test.showerrors }
     - { os: osx, env: COMPILER=clang USE_CMAKE=0 BUILD_FLAGS="-macAccelerate --with-fftw3=/usr/local --with-netcdf=/usr/local -noarpack" BUILD_TYPE=install TEST_TYPE=test.showerrors }
     - { os: linux, env: COMPILER=gnu USE_CMAKE=0 BUILD_FLAGS="-openmp -shared" OPT=openmp OMP_NUM_THREADS=1 BUILD_TYPE=libcpptraj TEST_TYPE=test.libcpptraj }
-    - { os: linux, env: COMPILER=gnu USE_CMAKE=1 BUILD_FLAGS="-DOPENMP=TRUE" OMP_NUM_THREADS=4 TEST_TYPE=test.showerrors}
-    - { os: osx, osx_image: xcode9.2, env: COMPILER=clang USE_CMAKE=1 BUILD_FLAGS="" TEST_TYPE=test.showerrors}
+    - { os: linux, env: COMPILER=GNU USE_CMAKE=1 BUILD_FLAGS="-DOPENMP=TRUE" OMP_NUM_THREADS=4 TEST_TYPE=test.showerrors}
+    - { os: osx, osx_image: xcode9.2, env: COMPILER=CLANG USE_CMAKE=1 BUILD_FLAGS="" TEST_TYPE=test.showerrors}
 
 #shell_session_update() { echo "Overriding shell_session_update"; };
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 os: Windows Server 2012
 
+clone_folder: c:\projects\cpptraj
+
 environment:
   matrix:
     - USE_CMAKE: "0"      

--- a/devtools/ci/appveyor/build.bat
+++ b/devtools/ci/appveyor/build.bat
@@ -10,7 +10,7 @@ if %USE_CMAKE% equ 1 (
 	cd build
 	
 	rem make sure to pick up netcdf in /usr/local
-	cmake .. "-GMinGW Makefiles" -DCMAKE_LIBRARY_PATH=C:/msys64/mingw64/lib;C:/msys64/usr/local/lib -DFORCE_DISABLE_LIBS=arpack -DCMAKE_INCLUDE_PATH=C:/msys64/mingw64/include;C:/msys64/usr/local/include "-DCMAKE_SH=" -DPACKAGE_TYPE=ARCHIVE -DPRINT_PACKAGING_REPORT=TRUE -DARCHIVE_FORMAT=ZIP -DINSTALL_HEADERS=TRUE -DCOMPILER=manual -DCMAKE_INSTALL_PREFIX=%SRCDIR% || exit /b
+	cmake .. "-GMinGW Makefiles" -DCMAKE_LIBRARY_PATH=C:/msys64/mingw64/lib;C:/msys64/usr/local/lib -DFORCE_DISABLE_LIBS=arpack -DCMAKE_INCLUDE_PATH=C:/msys64/mingw64/include;C:/msys64/usr/local/include "-DCMAKE_SH=" -DPACKAGE_TYPE=ARCHIVE -DPRINT_PACKAGING_REPORT=TRUE -DARCHIVE_FORMAT=ZIP -DINSTALL_HEADERS=TRUE -DCOMPILER=MANUAL -DCMAKE_INSTALL_PREFIX=%SRCDIR% || exit /b
 	mingw32-make -j2 install || exit /b
 	mingw32-make -j2 package || exit /b
 	cd ..


### PR DESCRIPTION
I noticed that the Appveyor CMake build has been acting like a random number generator casted to boolean lately, and I finally figured out why.  It turns out that Appveyor is sometimes appending a random suffix to the build folder.  The Appveyor CMake build script needs this to have that path defined in a variable with forward slashes:
```bat
set SRCDIR=C:/projects/cpptraj
```

So, when cloned into `C:\projects\cpptraj-aof9y`, it was installing to the wrong place, and dying.

I just put a block into appveyor.yml that should force it to go to the right directory.

I also updated the CMake submodule, and fixed the scripts to be compatible with it.