### PR TITLE
FIX pytraj cloning error ("alert protocol version while accessing")

### DIFF
--- a/util/test_pytraj_build.sh
+++ b/util/test_pytraj_build.sh
@@ -10,14 +10,15 @@ cat << EOF | docker run -i \
                         ${DOCKER_IMAGE}\
                         bash || exit $?
 
+
 set -x
 cd /cpptraj/
+git clone https://github.com/amber-md/pytraj
 
 bash configure -shared -openmp gnu
 make libcpptraj -j4
 export CPPTRAJHOME=/cpptraj
 
-git clone https://github.com/amber-md/pytraj
 cd pytraj
 /opt/python/cp35-cp35m/bin/python setup.py install
 # make sure we can run very simple test

--- a/util/test_pytraj_build.sh
+++ b/util/test_pytraj_build.sh
@@ -3,6 +3,10 @@
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/../"; pwd;)
 DOCKER_IMAGE=hainm/pytraj-build-box:17.0
 
+# not clone pytraj inside the docker image
+# https://githubengineering.com/crypto-removal-notice/
+git clone http://github.com/amber-md/pytraj
+
 docker info
 cat << EOF | docker run -i \
                         -v ${FEEDSTOCK_ROOT}:/cpptraj \
@@ -13,7 +17,6 @@ cat << EOF | docker run -i \
 
 set -x
 cd /cpptraj/
-git clone http://github.com/amber-md/pytraj
 
 bash configure -shared -openmp gnu
 make libcpptraj -j4

--- a/util/test_pytraj_build.sh
+++ b/util/test_pytraj_build.sh
@@ -13,7 +13,7 @@ cat << EOF | docker run -i \
 
 set -x
 cd /cpptraj/
-git clone https://github.com/amber-md/pytraj
+git clone http://github.com/amber-md/pytraj
 
 bash configure -shared -openmp gnu
 make libcpptraj -j4


### PR DESCRIPTION
The error happens because the test is using very old centos 5 docker image.
The fix is easy, just clone pytraj outside the image.

https://githubengineering.com/crypto-removal-notice/

@drroe Please squash this PR once you merge (from github button) to avoid my meaningless git comments.