### PR TITLE
Ensure compatibility with recent Amber NetCDF changes

### DIFF
--- a/src/Action_CreateReservoir.cpp
+++ b/src/Action_CreateReservoir.cpp
@@ -99,7 +99,7 @@ Action::RetType Action_CreateReservoir::Init(ArgList& actionArgs, ActionInit& in
   trajIsOpen_ = false;
   nframes_ = 0;
   // Setup output reservoir file
-  //reservoir_.SetDebug( debugIn );
+  reservoir_.SetDebug( debugIn );
   // Set title
   title_ = actionArgs.GetStringKey("title");
   if (title_.empty())

--- a/src/AmbPDB.cpp
+++ b/src/AmbPDB.cpp
@@ -202,8 +202,14 @@ int main(int argc, char** argv) {
   if (ctr_origin) 
     TrajFrame.CenterOnOrigin(false);
   // Output coords
+  
   Trajout_Single trajout;
-  trajArgs.SetList( aatm + bres + pqr + title + ter_opt + box + sybyltype + writeconect, " " );
+  std::string ARGS;
+  if (fmt == TrajectoryFile::MOL2FILE)
+    ARGS = title + sybyltype;
+  else
+    ARGS =  aatm + bres + pqr + title + ter_opt + box +  writeconect;
+  trajArgs.SetList( ARGS, " " );
   if ( trajout.PrepareStdoutTrajWrite(trajArgs, &parm, cInfo, 1, fmt) ) return 1;
   trajout.WriteSingle(0, TrajFrame);
   trajout.EndTraj();

--- a/src/CoordinateInfo.cpp
+++ b/src/CoordinateInfo.cpp
@@ -11,6 +11,8 @@ CoordinateInfo::CoordinateInfo() :
   has_pH_(false),
   hasRedox_(false),
   hasTime_(false),
+  hasrepidx_(false),
+  hascrdidx_(false),
   useRemdValues_(false)
 {}
 
@@ -25,6 +27,8 @@ CoordinateInfo::CoordinateInfo(Box const& b, bool v, bool t, bool m) :
   has_pH_(false),
   hasRedox_(false),
   hasTime_(m),
+  hasrepidx_(false),
+  hascrdidx_(false),
   useRemdValues_(false)
 {}
 
@@ -39,12 +43,15 @@ CoordinateInfo::CoordinateInfo(Box const& b, bool c, bool v, bool f, bool m) :
   has_pH_(false),
   hasRedox_(false),
   hasTime_(m),
+  hasrepidx_(false),
+  hascrdidx_(false),
   useRemdValues_(false)
 {}
 
 /** Constructor - All */
 CoordinateInfo::CoordinateInfo(int e, ReplicaDimArray const& r, Box const& b,
-                               bool c, bool v, bool f, bool t, bool p, bool o, bool m, bool u) :
+                               bool c, bool v, bool f, bool t, bool p, bool o, bool m, 
+                               bool ri, bool ci, bool u) :
   remdDim_(r),
   box_(b),
   ensembleSize_(e),
@@ -55,6 +62,8 @@ CoordinateInfo::CoordinateInfo(int e, ReplicaDimArray const& r, Box const& b,
   has_pH_(p),
   hasRedox_(o),
   hasTime_(m),
+  hasrepidx_(ri),
+  hascrdidx_(ci),
   useRemdValues_(u)
 {}
 
@@ -69,6 +78,8 @@ void CoordinateInfo::PrintCoordInfo(const char* name, const char* parm) const {
   if (has_pH_) mprintf(", pH");
   if (hasRedox_) mprintf(", redox");
   if (hasTime_) mprintf(", times");
+  if (hasrepidx_) mprintf(", repidx");
+  if (hascrdidx_) mprintf(", crdidx");
   if (ensembleSize_ > 0) mprintf(", ensemble size %i", ensembleSize_);
   mprintf(" }\n");
 }
@@ -91,6 +102,8 @@ std::string CoordinateInfo::InfoString() const {
   if ( HasRedOx() )       Append(meta, "redox");
   if ( HasTime() )        Append(meta, "time");
   if ( HasReplicaDims() ) Append(meta, "replicaDims");
+  if ( HasRepIdx() )      Append(meta, "replica indices");
+  if ( HasCrdIdx() )      Append(meta, "coordinate indices");
   if ( HasBox() )         Append(meta, "box");
   return meta;
 }

--- a/src/CoordinateInfo.cpp
+++ b/src/CoordinateInfo.cpp
@@ -142,7 +142,7 @@ int CoordinateInfo::SyncCoordInfo(Parallel::Comm const& commIn) {
     hasFrc_        = (bool)iArray[4];
     has_pH_        = (bool)iArray[5];
     hasRedox_      = (bool)iArray[6];
-    useRemdValues_ = (bool)iArray[7]
+    useRemdValues_ = (bool)iArray[7];
     remdDim_.clear();
     unsigned int ii = CINFOMPISIZE;
     for (int ir = 0; ir != iArray[8]; ir++, ii++)

--- a/src/CoordinateInfo.cpp
+++ b/src/CoordinateInfo.cpp
@@ -1,6 +1,60 @@
 #include "CoordinateInfo.h"
 #include "CpptrajStdio.h"
 
+/** Default constructor. */
+CoordinateInfo::CoordinateInfo() :
+  ensembleSize_(0),
+  hasCrd_(true),
+  hasVel_(false),
+  hasTemp_(false),
+  has_pH_(false),
+  hasRedox_(false),
+  hasTime_(false),
+  hasFrc_(false)
+{}
+
+/** Box, velocity, temperature, time. TODO pH, redox? */
+CoordinateInfo::CoordinateInfo(Box const& b, bool v, bool t, bool m) :
+  box_(b),
+  ensembleSize_(0),
+  hasCrd_(true),
+  hasVel_(v),
+  hasTemp_(t),
+  has_pH_(false),
+  hasRedox_(false),
+  hasTime_(m),
+  hasFrc_(false)
+{}
+
+/** Box, coords, velocity, force, time. */
+CoordinateInfo::CoordinateInfo(Box const& b, bool c, bool v, bool f, bool m) :
+  box_(b),
+  ensembleSize_(0),
+  hasCrd_(c),
+  hasVel_(v),
+  hasTemp_(false),
+  has_pH_(false),
+  hasRedox_(false),
+  hasTime_(m),
+  hasFrc_(f)
+{}
+
+/** Constructor - All */
+CoordinateInfo::CoordinateInfo(int e, ReplicaDimArray const& r, Box const& b,
+                               bool c, bool v, bool t, bool m, bool f) :
+  remdDim_(r),
+  box_(b),
+  ensembleSize_(e),
+  hasCrd_(c),
+  hasVel_(v),
+  hasTemp_(t),
+  has_pH_(false),
+  hasRedox_(false),
+  hasTime_(m),
+  hasFrc_(f)
+{}
+
+/** DEBUG: Print info to stdout. */
 void CoordinateInfo::PrintCoordInfo(const char* name, const char* parm) const {
   mprintf("DBG: '%s' parm '%s' CoordInfo={ box type %s", name, parm, box_.TypeName());
   if (remdDim_.Ndims() > 0) mprintf(", %i rep dims", remdDim_.Ndims());
@@ -19,6 +73,7 @@ static inline void Append(std::string& meta, std::string const& str) {
     meta.append(", " + str);
 }
 
+/** \return String describing elements that are present. */
 std::string CoordinateInfo::InfoString() const {
   std::string meta;
   if ( HasCrd() )         Append(meta, "coordinates");

--- a/src/CoordinateInfo.cpp
+++ b/src/CoordinateInfo.cpp
@@ -6,11 +6,11 @@ CoordinateInfo::CoordinateInfo() :
   ensembleSize_(0),
   hasCrd_(true),
   hasVel_(false),
+  hasFrc_(false),
   hasTemp_(false),
   has_pH_(false),
   hasRedox_(false),
-  hasTime_(false),
-  hasFrc_(false)
+  hasTime_(false)
 {}
 
 /** Box, velocity, temperature, time. TODO pH, redox? */
@@ -19,11 +19,11 @@ CoordinateInfo::CoordinateInfo(Box const& b, bool v, bool t, bool m) :
   ensembleSize_(0),
   hasCrd_(true),
   hasVel_(v),
+  hasFrc_(false),
   hasTemp_(t),
   has_pH_(false),
   hasRedox_(false),
-  hasTime_(m),
-  hasFrc_(false)
+  hasTime_(m)
 {}
 
 /** Box, coords, velocity, force, time. */
@@ -32,36 +32,39 @@ CoordinateInfo::CoordinateInfo(Box const& b, bool c, bool v, bool f, bool m) :
   ensembleSize_(0),
   hasCrd_(c),
   hasVel_(v),
+  hasFrc_(f),
   hasTemp_(false),
   has_pH_(false),
   hasRedox_(false),
-  hasTime_(m),
-  hasFrc_(f)
+  hasTime_(m)
 {}
 
 /** Constructor - All */
 CoordinateInfo::CoordinateInfo(int e, ReplicaDimArray const& r, Box const& b,
-                               bool c, bool v, bool t, bool m, bool f) :
+                               bool c, bool v, bool f, bool t, bool p, bool o, bool m) :
   remdDim_(r),
   box_(b),
   ensembleSize_(e),
   hasCrd_(c),
   hasVel_(v),
+  hasFrc_(f),
   hasTemp_(t),
-  has_pH_(false),
-  hasRedox_(false),
-  hasTime_(m),
-  hasFrc_(f)
+  has_pH_(p),
+  hasRedox_(o),
+  hasTime_(m)
 {}
 
 /** DEBUG: Print info to stdout. */
 void CoordinateInfo::PrintCoordInfo(const char* name, const char* parm) const {
   mprintf("DBG: '%s' parm '%s' CoordInfo={ box type %s", name, parm, box_.TypeName());
   if (remdDim_.Ndims() > 0) mprintf(", %i rep dims", remdDim_.Ndims());
+  if (hasCrd_) mprintf(", coords");
   if (hasVel_) mprintf(", velocities");
-  if (hasTemp_) mprintf(", temps");
-  if (hasTime_) mprintf(", times");
   if (hasFrc_) mprintf(", forces");
+  if (hasTemp_) mprintf(", temps");
+  if (has_pH_) mprintf(", pH");
+  if (hasRedox_) mprintf(", redox");
+  if (hasTime_) mprintf(", times");
   if (ensembleSize_ > 0) mprintf(", ensemble size %i", ensembleSize_);
   mprintf(" }\n");
 }
@@ -80,6 +83,8 @@ std::string CoordinateInfo::InfoString() const {
   if ( HasVel() )         Append(meta, "velocities");
   if ( HasForce() )       Append(meta, "forces");
   if ( HasTemp() )        Append(meta, "temperature");
+  if ( Has_pH() )         Append(meta, "pH");
+  if ( HasRedOx() )       Append(meta, "redox");
   if ( HasTime() )        Append(meta, "time");
   if ( HasReplicaDims() ) Append(meta, "replicaDims");
   if ( HasBox() )         Append(meta, "box");

--- a/src/CoordinateInfo.cpp
+++ b/src/CoordinateInfo.cpp
@@ -109,7 +109,7 @@ std::string CoordinateInfo::InfoString() const {
 }
 
 #ifdef MPI
-#define CINFOMPISIZE 9
+#define CINFOMPISIZE 11
 int CoordinateInfo::SyncCoordInfo(Parallel::Comm const& commIn) {
   // ensSize, hasvel, hastemp, hastime, hasfrc, NrepDims, Dim1, ..., DimN, 
   int* iArray;
@@ -118,15 +118,17 @@ int CoordinateInfo::SyncCoordInfo(Parallel::Comm const& commIn) {
     iSize = remdDim_.Ndims() + CINFOMPISIZE;
     commIn.MasterBcast( &iSize, 1, MPI_INT );
     iArray = new int[ iSize ];
-    iArray[0] = ensembleSize_;
-    iArray[1] = (int)hasVel_;
-    iArray[2] = (int)hasTemp_;
-    iArray[3] = (int)hasTime_;
-    iArray[4] = (int)hasFrc_;
-    iArray[5] = (int)has_pH_;
-    iArray[6] = (int)hasRedox_;
-    iArray[7] = (int)useRemdValues_;
-    iArray[8] = remdDim_.Ndims();
+    iArray[0]  = ensembleSize_;
+    iArray[1]  = (int)hasVel_;
+    iArray[2]  = (int)hasTemp_;
+    iArray[3]  = (int)hasTime_;
+    iArray[4]  = (int)hasFrc_;
+    iArray[5]  = (int)has_pH_;
+    iArray[6]  = (int)hasRedox_;
+    iArray[7]  = (int)useRemdValues_;
+    iArray[8]  = (int)hasrepidx_;
+    iArray[9]  = (int)hascrdidx_;
+    iArray[10] = remdDim_.Ndims();
     unsigned int ii = CINFOMPISIZE;
     for (int ir = 0; ir != remdDim_.Ndims(); ir++, ii++)
       iArray[ii] = remdDim_[ir];
@@ -143,9 +145,11 @@ int CoordinateInfo::SyncCoordInfo(Parallel::Comm const& commIn) {
     has_pH_        = (bool)iArray[5];
     hasRedox_      = (bool)iArray[6];
     useRemdValues_ = (bool)iArray[7];
+    hasrepidx_     = (bool)iArray[8];
+    hascrdidx_     = (bool)iArray[9];
     remdDim_.clear();
     unsigned int ii = CINFOMPISIZE;
-    for (int ir = 0; ir != iArray[8]; ir++, ii++)
+    for (int ir = 0; ir != iArray[10]; ir++, ii++)
       remdDim_.AddRemdDimension( iArray[ii] );
   }
   delete[] iArray;

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -29,6 +29,7 @@ class CoordinateInfo {
     bool HasForce()            const { return hasFrc_;                  }
     bool HasReplicaDims()      const { return (remdDim_.Ndims() != 0);  }
     ReplicaDimArray const& ReplicaDimensions() const { return remdDim_; }
+    bool UseRemdValues()       const { return useRemdValues_;           }
     void SetTime(bool m)        { hasTime_ = m; }
     void SetTemperature(bool t) { hasTemp_ = t; }
     void SetCrd(bool c)         { hasCrd_ = c;  }

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -15,14 +15,16 @@ class CoordinateInfo {
     CoordinateInfo(Box const&, bool, bool, bool);
     /// CONSTRUCTOR - box, coord, velocity, force, time TODO merge with above? 
     CoordinateInfo(Box const&, bool, bool, bool, bool);
-    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, temp., time, force 
-    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool);
+    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, force, temp., pH, redox, time
+    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool, bool, bool);
     bool HasBox()              const { return box_.HasBox();            }
     const Box& TrajBox()       const { return box_;                     }
     int EnsembleSize()         const { return ensembleSize_;            }
     bool HasCrd()              const { return hasCrd_;                  }
     bool HasVel()              const { return hasVel_;                  }
     bool HasTemp()             const { return hasTemp_;                 }
+    bool Has_pH()              const { return has_pH_;                  }
+    bool HasRedOx()            const { return hasRedox_;                }
     bool HasTime()             const { return hasTime_;                 }
     bool HasForce()            const { return hasFrc_;                  }
     bool HasReplicaDims()      const { return (remdDim_.Ndims() != 0);  }
@@ -54,10 +56,10 @@ class CoordinateInfo {
     int ensembleSize_;        ///< If coordinate ensemble, total # of replicas.
     bool hasCrd_;             ///< True if coords present. Now only relevant for NetCDF traj.
     bool hasVel_;             ///< True if coords have associated velocities.
+    bool hasFrc_;             ///< True if coords have associated forces.
     bool hasTemp_;            ///< True if coords include temp info.
     bool has_pH_;             ///< True if coords include pH info.
     bool hasRedox_;          ///< True if coords include RedOx potential info.
     bool hasTime_;            ///< True if coords include time info.
-    bool hasFrc_;             ///< True if coords have associated forces.
 };
 #endif

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -10,20 +10,13 @@
 class CoordinateInfo {
   public:
     /// CONSTRUCTOR
-    CoordinateInfo() : ensembleSize_(0), hasCrd_(true), hasVel_(false),
-                       hasTemp_(false), hasTime_(false), hasFrc_(false) {}
+    CoordinateInfo();
     /// CONSTRUCTOR - box, velocity, temperature, time
-    CoordinateInfo(Box const& b, bool v, bool t, bool m) :
-      box_(b), ensembleSize_(0), hasCrd_(true), hasVel_(v),
-      hasTemp_(t), hasTime_(m), hasFrc_(false) {}
-    /// CONSTRUCTOR - all except ensemble size
-    CoordinateInfo(ReplicaDimArray const& r, Box const& b, bool v, bool t, bool m, bool f) :
-      remdDim_(r), box_(b), ensembleSize_(0), hasCrd_(true), hasVel_(v),
-      hasTemp_(t), hasTime_(m), hasFrc_(f) {}
-    /// CONSTRUCTOR - All
-    CoordinateInfo(int e, ReplicaDimArray const& r, Box const& b, bool v, bool t, bool m, bool f) :
-      remdDim_(r), box_(b), ensembleSize_(e), hasCrd_(true), hasVel_(v),
-      hasTemp_(t), hasTime_(m), hasFrc_(f) {}
+    CoordinateInfo(Box const&, bool, bool, bool);
+    /// CONSTRUCTOR - box, coord, velocity, force, time TODO merge with above? 
+    CoordinateInfo(Box const&, bool, bool, bool, bool);
+    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, temp., time, force 
+    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool);
     bool HasBox()              const { return box_.HasBox();            }
     const Box& TrajBox()       const { return box_;                     }
     int EnsembleSize()         const { return ensembleSize_;            }
@@ -62,6 +55,8 @@ class CoordinateInfo {
     bool hasCrd_;             ///< True if coords present. Now only relevant for NetCDF traj.
     bool hasVel_;             ///< True if coords have associated velocities.
     bool hasTemp_;            ///< True if coords include temp info.
+    bool has_pH_;             ///< True if coords include pH info.
+    bool hasRedox_;          ///< True if coords include RedOx potential info.
     bool hasTime_;            ///< True if coords include time info.
     bool hasFrc_;             ///< True if coords have associated forces.
 };

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -15,19 +15,21 @@ class CoordinateInfo {
     CoordinateInfo(Box const&, bool, bool, bool);
     /// CONSTRUCTOR - box, coord, velocity, force, time TODO merge with above? 
     CoordinateInfo(Box const&, bool, bool, bool, bool);
-    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, force, temp., pH, redox, time, use remd values
-    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool, bool, bool, bool);
+    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, force, temp., pH, redox, time, has repidx, has crdidx, use remd values
+    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool);
     bool HasBox()              const { return box_.HasBox();            }
     const Box& TrajBox()       const { return box_;                     }
     int EnsembleSize()         const { return ensembleSize_;            }
     bool HasCrd()              const { return hasCrd_;                  }
     bool HasVel()              const { return hasVel_;                  }
+    bool HasForce()            const { return hasFrc_;                  }
     bool HasTemp()             const { return hasTemp_;                 }
     bool Has_pH()              const { return has_pH_;                  }
     bool HasRedOx()            const { return hasRedox_;                }
     bool HasTime()             const { return hasTime_;                 }
-    bool HasForce()            const { return hasFrc_;                  }
     bool HasReplicaDims()      const { return (remdDim_.Ndims() != 0);  }
+    bool HasRepIdx()           const { return hasrepidx_;               }
+    bool HasCrdIdx()           const { return hascrdidx_;               }
     ReplicaDimArray const& ReplicaDimensions() const { return remdDim_; }
     bool UseRemdValues()       const { return useRemdValues_;           }
     void SetTime(bool m)        { hasTime_ = m; }
@@ -62,6 +64,8 @@ class CoordinateInfo {
     bool has_pH_;             ///< True if coords include pH info.
     bool hasRedox_;           ///< True if coords include RedOx potential info.
     bool hasTime_;            ///< True if coords include time info.
+    bool hasrepidx_;          ///< True if coords have replica indices
+    bool hascrdidx_;          ///< True if coords have coordinate indices
     bool useRemdValues_;      ///< True if using remd_values in netcdf file
 };
 #endif

--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -15,8 +15,8 @@ class CoordinateInfo {
     CoordinateInfo(Box const&, bool, bool, bool);
     /// CONSTRUCTOR - box, coord, velocity, force, time TODO merge with above? 
     CoordinateInfo(Box const&, bool, bool, bool, bool);
-    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, force, temp., pH, redox, time
-    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool, bool, bool);
+    /// CONSTRUCTOR - ensemble size, remd dims, box, coords, velocity, force, temp., pH, redox, time, use remd values
+    CoordinateInfo(int, ReplicaDimArray const&, Box const&, bool, bool, bool, bool, bool, bool, bool, bool);
     bool HasBox()              const { return box_.HasBox();            }
     const Box& TrajBox()       const { return box_;                     }
     int EnsembleSize()         const { return ensembleSize_;            }
@@ -59,7 +59,8 @@ class CoordinateInfo {
     bool hasFrc_;             ///< True if coords have associated forces.
     bool hasTemp_;            ///< True if coords include temp info.
     bool has_pH_;             ///< True if coords include pH info.
-    bool hasRedox_;          ///< True if coords include RedOx potential info.
+    bool hasRedox_;           ///< True if coords include RedOx potential info.
     bool hasTime_;            ///< True if coords include time info.
+    bool useRemdValues_;      ///< True if using remd_values in netcdf file
 };
 #endif

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -87,6 +87,7 @@ int CpptrajState::SetTrajMode(TrajModeType modeIn, std::string const& fnameIn,
     if (Parallel::SetupComms( 1 )) return 1;
 #   endif
   }
+  if (argIn.CheckForMoreArgs()) return 1;
   return 0;
 }
 
@@ -130,6 +131,7 @@ int CpptrajState::AddOutputTrajectory( ArgList& argIn ) {
     err = trajoutList_.AddTrajout( fname, argIn, top );
   else if (mode_ == ENSEMBLE)
     err = ensembleOut_.AddEnsembleOut( fname, argIn, top, trajinList_.EnsembleSize() );
+  if (argIn.CheckForMoreArgs()) return 1;
   return err;
 }
 

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -87,7 +87,6 @@ int CpptrajState::SetTrajMode(TrajModeType modeIn, std::string const& fnameIn,
     if (Parallel::SetupComms( 1 )) return 1;
 #   endif
   }
-  if (argIn.CheckForMoreArgs()) return 1;
   return 0;
 }
 
@@ -131,7 +130,6 @@ int CpptrajState::AddOutputTrajectory( ArgList& argIn ) {
     err = trajoutList_.AddTrajout( fname, argIn, top );
   else if (mode_ == ENSEMBLE)
     err = ensembleOut_.AddEnsembleOut( fname, argIn, top, trajinList_.EnsembleSize() );
-  if (argIn.CheckForMoreArgs()) return 1;
   return err;
 }
 

--- a/src/Exec_Traj.cpp
+++ b/src/Exec_Traj.cpp
@@ -6,11 +6,22 @@ void Exec_Trajin::Help() const {
           "\t           [%s]\n", DataSetList::TopArgs);
   mprintf("\t           [mdvel <velocities>] [mdfrc <forces>]\n"
           "\t           [ <Format Options> ]\n"
-          "\t           [ remdtraj [remdtrajtemp <T> | remdtrajidx <#>]\n"
-          "\t             [trajnames <rep1>,<rep2>,...,<repN> ] ]\n"
+          "\t           [ remdtraj {remdtrajtemp <T> |\n"
+          "\t                       remdtrajidx <indices list> |\n"
+          "\t                       remdtrajvalues <values list>}\n"
+          "\t             [trajnames <rep1>,<rep2>,...,<repN>] ]\n"
           "  Load trajectory specified by <filename> to the input trajectory list.\n"
           "  If desired, additional velocity or force information can be read from\n"
-          "  files specified by 'mdvel' and/or 'mdfrc'.\n");
+          "  files specified by 'mdvel' and/or 'mdfrc'.\n"
+          "  The 'remdtraj' keyword can be used to extract frames for a specific replica\n"
+          "  from an ensemble of replica trajectories. In this case, if only <filename> is\n"
+          "  specified it is assumed <filename> has format <name>.<ext> where <ext> is\n"
+          "  a numerical suffix; other members of the ensemble will be automatically\n"
+          "  searched for. Otherwise, additional members can be specified with 'trajnames'.\n"
+          "  'remdtrajtemp' can be used to extract frames from 1D T-REMD simulations.\n"
+          "  'remdtrajidx' and 'remdtrajvalues' can be used to extract frames from multi-\n"
+          "  dimensional REMD simulations; <indices list> and <values list> are comma-\n"
+          "  separated lists.\n");
   TrajectoryFile::ReadOptions();
 }
 // -----------------------------------------------------------------------------

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -19,6 +19,8 @@ Frame::Frame( ) :
   X_(0),
   V_(0),
   F_(0),
+  repidx_(0),
+  crdidx_(0),
   memIsExternal_(false)
 {}
 
@@ -44,6 +46,8 @@ Frame::Frame(int natomIn) :
   X_(0),
   V_(0),
   F_(0),
+  repidx_(0),
+  crdidx_(0),
   Mass_(natomIn, 1.0),
   memIsExternal_(false)
 {
@@ -63,6 +67,8 @@ Frame::Frame(std::vector<Atom> const& atoms) :
   X_(0),
   V_(0),
   F_(0),
+  repidx_(0),
+  crdidx_(0),
   memIsExternal_(false)
 {
   if (ncoord_ > 0) {
@@ -87,6 +93,8 @@ Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) :
   V_(0),
   F_(0),
   remd_indices_(frameIn.remd_indices_),
+  repidx_(0),
+  crdidx_(0),
   memIsExternal_(false)
 {
   if (ncoord_ > 0) {
@@ -158,6 +166,8 @@ Frame::Frame(const Frame& rhs) :
   V_(0),
   F_(0),
   remd_indices_(rhs.remd_indices_),
+  repidx_(rhs.repidx_),
+  crdidx_(rhs.crdidx_),
   Mass_(rhs.Mass_),
   memIsExternal_(false)
 {
@@ -184,6 +194,8 @@ void Frame::swap(Frame &first, Frame &second) {
   swap(first.maxnatom_, second.maxnatom_);
   swap(first.ncoord_, second.ncoord_);
   swap(first.T_, second.T_);
+  swap(first.repidx_, second.repidx_);
+  swap(first.crdidx_, second.crdidx_);
   swap(first.pH_, second.pH_);
   swap(first.redox_, second.redox_);
   swap(first.time_, second.time_);
@@ -210,6 +222,8 @@ Frame &Frame::operator=(Frame rhs) {
     ncoord_ = rhs.ncoord_;
     box_ = rhs.box_;
     T_ = rhs.T_;
+    repidx_ = rhs.repidx_;
+    crdidx_ = rhs.crdidx_;
     pH_ = rhs.pH_;
     redox_ = rhs.redox_;
     time_ = rhs.time_;
@@ -540,6 +554,8 @@ void Frame::SetCoordinates(Frame const& frameIn, AtomMask const& maskIn) {
   ncoord_ = natom_ * 3;
   box_ = frameIn.box_;
   T_ = frameIn.T_;
+  repidx_ = frameIn.repidx_;
+  crdidx_ = frameIn.crdidx_;
   pH_ = frameIn.pH_;
   redox_ = frameIn.redox_;
   time_ = frameIn.time_;
@@ -594,6 +610,8 @@ void Frame::SetFrame(Frame const& frameIn, AtomMask const& maskIn) {
   // Copy T/box
   box_ = frameIn.box_;
   T_ = frameIn.T_;
+  repidx_ = frameIn.repidx_;
+  crdidx_ = frameIn.crdidx_;
   pH_ = frameIn.pH_;
   redox_ = frameIn.redox_;
   time_ = frameIn.time_;
@@ -651,6 +669,8 @@ void Frame::SetCoordinatesByMap(Frame const& tgtIn, std::vector<int> const& mapI
   ncoord_ = natom_ * 3;
   box_ = tgtIn.box_;
   T_ = tgtIn.T_;
+  repidx_ = tgtIn.repidx_;
+  crdidx_ = tgtIn.crdidx_;
   pH_ = tgtIn.pH_;
   redox_ = tgtIn.redox_;
   time_ = tgtIn.time_;
@@ -705,6 +725,8 @@ void Frame::StripUnmappedAtoms(Frame const& refIn, std::vector<int> const& mapIn
   }
   box_ = refIn.box_;
   T_ = refIn.T_;
+  repidx_ = refIn.repidx_;
+  crdidx_ = refIn.crdidx_;
   pH_ = refIn.pH_;
   redox_ = refIn.redox_;
   time_ = refIn.time_;
@@ -737,6 +759,8 @@ void Frame::ModifyByMap(Frame const& frameIn, std::vector<int> const& mapIn) {
   }
   box_ = frameIn.box_;
   T_ = frameIn.T_;
+  repidx_ = frameIn.repidx_;
+  crdidx_ = frameIn.crdidx_;
   pH_ = frameIn.pH_;
   redox_ = frameIn.redox_;
   time_ = frameIn.time_;
@@ -1329,6 +1353,8 @@ int Frame::SendFrame(int recvrank, Parallel::Comm const& commIn) {
   commIn.Send( &redox_,           1,       MPI_DOUBLE, recvrank, 1220 );
   commIn.Send( &time_,            1,       MPI_DOUBLE, recvrank, 1217 );
   commIn.Send( &remd_indices_[0], remd_indices_.size(), MPI_INT, recvrank, 1216 );
+  commIn.Send( &repidx_,          1,       MPI_INT,    recvrank, 1221 );
+  commIn.Send( &crdidx_,          1,       MPI_INT,    recvrank, 1222 );
   return 0;
 }
 
@@ -1346,6 +1372,8 @@ int Frame::RecvFrame(int sendrank, Parallel::Comm const& commIn) {
   commIn.Recv( &redox_,           1,       MPI_DOUBLE, sendrank, 1220 );
   commIn.Recv( &time_,            1,       MPI_DOUBLE, sendrank, 1217 );
   commIn.Recv( &remd_indices_[0], remd_indices_.size(), MPI_INT, sendrank, 1216 );
+  commIn.Recv( &repidx_,          1,       MPI_INT,    sendrank, 1221 );
+  commIn.Recv( &crdidx_,          1,       MPI_INT,    sendrank, 1222 );
   return 0;
 }
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -79,6 +79,7 @@ Frame::Frame(Frame const& frameIn, AtomMask const& maskIn) :
   V_(0),
   F_(0),
   remd_indices_(frameIn.remd_indices_),
+  remd_values_(frameIn.remd_values_),
   memIsExternal_(false)
 {
   if (ncoord_ > 0) {
@@ -148,6 +149,7 @@ Frame::Frame(const Frame& rhs) :
   V_(0),
   F_(0),
   remd_indices_(rhs.remd_indices_),
+  remd_values_(rhs.remd_values_),
   Mass_(rhs.Mass_),
   memIsExternal_(false)
 {
@@ -179,6 +181,7 @@ void Frame::swap(Frame &first, Frame &second) {
   swap(first.V_, second.V_);
   swap(first.F_, second.F_);
   first.remd_indices_.swap(second.remd_indices_);
+  first.remd_values_.swap(second.remd_values_);
   first.Mass_.swap(second.Mass_);
   swap(first.memIsExternal_, second.memIsExternal_);
   first.box_.swap( second.box_ );
@@ -200,6 +203,7 @@ Frame &Frame::operator=(Frame rhs) {
     T_ = rhs.T_;
     time_ = rhs.time_;
     remd_indices_ = rhs.remd_indices_;
+    remd_values_ = rhs.remd_values_;
     Mass_ = rhs.Mass_;
     memIsExternal_ = false;
     if (X_ != 0) delete[] X_;
@@ -310,6 +314,7 @@ void Frame::Info(const char *msg) const {
   mprintf("%i atoms, %i coords",natom_, ncoord_);
   if (V_!=0) mprintf(", with Velocities");
   if (!remd_indices_.empty()) mprintf(", with replica indices");
+  if (!remd_values_.empty()) mprintf(", with replica values");
   mprintf("\n");
 }
 
@@ -445,6 +450,8 @@ int Frame::SetupFrameV(std::vector<Atom> const& atoms, CoordinateInfo const& cin
   box_ = cinfo.TrajBox();
   // Replica indices
   remd_indices_.assign( cinfo.ReplicaDimensions().Ndims(), 0 );
+  // Replica values
+  remd_values_.assign( cinfo.ReplicaDimensions().Ndims(), 0 );
   return 0;
 }
 
@@ -528,6 +535,7 @@ void Frame::SetCoordinates(Frame const& frameIn, AtomMask const& maskIn) {
   T_ = frameIn.T_;
   time_ = frameIn.time_;
   remd_indices_ = frameIn.remd_indices_;
+  remd_values_ = frameIn.remd_values_;
   double* newXptr = X_;
   for (AtomMask::const_iterator atom = maskIn.begin(); atom != maskIn.end(); ++atom)
   {
@@ -580,6 +588,7 @@ void Frame::SetFrame(Frame const& frameIn, AtomMask const& maskIn) {
   T_ = frameIn.T_;
   time_ = frameIn.time_;
   remd_indices_ = frameIn.remd_indices_;
+  remd_values_ = frameIn.remd_values_;
   double* newXptr = X_;
   Darray::iterator mass = Mass_.begin();
   // Copy coords/mass
@@ -635,6 +644,7 @@ void Frame::SetCoordinatesByMap(Frame const& tgtIn, std::vector<int> const& mapI
   T_ = tgtIn.T_;
   time_ = tgtIn.time_;
   remd_indices_ = tgtIn.remd_indices_;
+  remd_values_ = tgtIn.remd_values_;
   // Copy Coords/Mass
   double* newXptr = X_;
   Darray::iterator newmass = Mass_.begin();
@@ -687,6 +697,7 @@ void Frame::StripUnmappedAtoms(Frame const& refIn, std::vector<int> const& mapIn
   T_ = refIn.T_;
   time_ = refIn.time_;
   remd_indices_ = refIn.remd_indices_;
+  remd_values_ = refIn.remd_values_;
 
   double* newXptr = X_;
   double* refptr = refIn.X_;
@@ -717,6 +728,7 @@ void Frame::ModifyByMap(Frame const& frameIn, std::vector<int> const& mapIn) {
   T_ = frameIn.T_;
   time_ = frameIn.time_;
   remd_indices_ = frameIn.remd_indices_;
+  remd_values_ = frameIn.remd_values_;
 
   double* Xptr = X_;
   for (std::vector<int>::const_iterator oldatom = mapIn.begin(); 
@@ -1303,6 +1315,7 @@ int Frame::SendFrame(int recvrank, Parallel::Comm const& commIn) {
   commIn.Send( &T_,               1,       MPI_DOUBLE, recvrank, 1214 );
   commIn.Send( &time_,            1,       MPI_DOUBLE, recvrank, 1217 );
   commIn.Send( &remd_indices_[0], remd_indices_.size(), MPI_INT, recvrank, 1216 );
+  commIn.Send( &remd_values_[0], remd_values_.size(), MPI_DOUBLE, recvrank, 1217 );
   return 0;
 }
 
@@ -1318,6 +1331,7 @@ int Frame::RecvFrame(int sendrank, Parallel::Comm const& commIn) {
   commIn.Recv( &T_,               1,       MPI_DOUBLE, sendrank, 1214 );
   commIn.Recv( &time_,            1,       MPI_DOUBLE, sendrank, 1217 );
   commIn.Recv( &remd_indices_[0], remd_indices_.size(), MPI_INT, sendrank, 1216 );
+  commIn.Recv( &remd_values_[0], remd_values_.size(), MPI_DOUBLE, sendrank, 1217 );
   return 0;
 }
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -77,6 +77,8 @@ class Frame {
     int size()                        const { return ncoord_;        }
     int NrepDims()                    const { return (int)remd_indices_.size(); } // TODO: deprecate
     double Temperature()              const { return T_;             }
+    double pH()                       const { return pH_;            }
+    double RedOx()                    const { return redox_;         }
     double Time()                     const { return time_;          }
     /// \return pointer to start of XYZ coords for given atom.
     const double* XYZ(int atnum)      const { return X_ + (atnum*3); } 
@@ -92,16 +94,18 @@ class Frame {
     const Box& BoxCrd()               const { return box_;           }
     /// \return replica indices
     RemdIdxType const& RemdIndices()  const { return remd_indices_;  }
-    /// \return replica values
-    RemdValType const& RemdValues()   const { return remd_values_;   }
     /// Set box alpha, beta, and gamma
     inline void SetBoxAngles(const double*);
     /// Set box
     void SetBox( Box const& b ) { box_ = b; }
     /// Set temperature
-    void SetTemperature(double tIn) { T_ = tIn;   }
+    void SetTemperature(double tIn) { T_ = tIn;     }
+    /// Set pH
+    void Set_pH(double phIn)        { pH_ = phIn;   }
+    /// Set RedOx potential
+    void SetRedOx(double rIn)       { redox_ = rIn; }
     /// Set time
-    void SetTime(double tIn)        {time_ = tIn; }
+    void SetTime(double tIn)        { time_ = tIn;  }
     /// Set masses
     void SetMass(std::vector<Atom> const&);
     // ----- Access to internal data pointers ----
@@ -112,7 +116,6 @@ class Frame {
     inline double* tAddress() { return &T_;               }
     inline double* mAddress() { return &time_;            }
     inline int* iAddress()    { return &remd_indices_[0]; }
-    inline double* rvAddress(){ return &remd_values_[0];  }
     inline const double* xAddress() const { return X_;                }
     inline const double* vAddress() const { return V_;                }
     inline const double* fAddress() const { return F_;                }
@@ -120,7 +123,6 @@ class Frame {
     inline const double* tAddress() const { return &T_;               }
     inline const double* mAddress() const { return &time_;            }
     inline const int* iAddress()    const { return &remd_indices_[0]; }
-    inline const double* rvAddress()const { return &remd_values_[0];  }
     // ----- Frame memory allocation routines ----
     /// Allocate frame for given # atoms, no mass or velocity.
     int SetupFrame(int);
@@ -240,12 +242,13 @@ class Frame {
     int ncoord_;    ///< Number of coordinates stored in frame (natom * 3).
     Box box_;       ///< Box coords, 3xlengths, 3xangles
     double T_;      ///< Temperature
+    double pH_;     ///< pH
+    double redox_;  ///< RedOx potential
     double time_;   ///< Time FIXME Should this be float?
     double* X_;     ///< Coord array, X0 Y0 Z0 X1 Y1 Z1 ...
     double* V_;     ///< Velocities (same arrangement as Coords).
     double* F_;     ///< Frame (same arrangement as Coords).
     RemdIdxType remd_indices_; ///< replica indices.
-    RemdValType remd_values_; ///< replica values.
     Darray Mass_;   ///< Masses.
     bool memIsExternal_; ///< True if Frame is not responsible for freeing memory.
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -94,6 +94,10 @@ class Frame {
     const Box& BoxCrd()               const { return box_;           }
     /// \return replica indices
     RemdIdxType const& RemdIndices()  const { return remd_indices_;  }
+    /// \return overall replica index
+    int RepIdx()                      const { return repidx_;        }
+    /// \return overall coordinate index
+    int CrdIdx()                      const { return crdidx_;        }
     /// Set box alpha, beta, and gamma
     inline void SetBoxAngles(const double*);
     /// Set box
@@ -249,6 +253,8 @@ class Frame {
     double* V_;     ///< Velocities (same arrangement as Coords).
     double* F_;     ///< Frame (same arrangement as Coords).
     RemdIdxType remd_indices_; ///< replica indices.
+    int repidx_;    ///< overall replica index
+    int crdidx_;    ///< overall coordinate index.
     Darray Mass_;   ///< Masses.
     bool memIsExternal_; ///< True if Frame is not responsible for freeing memory.
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -44,6 +44,7 @@ class Frame {
     Frame(const Frame&);
     Frame& operator=(Frame);
     typedef std::vector<int> RemdIdxType; ///< For dealing with replica indices
+    typedef std::vector<double> RemdValType; /// < For reading replica values
     // -------------------------------------------
     /// This type interfaces with DataSet_Coords_CRD
     typedef std::vector<float> CRDtype;
@@ -91,6 +92,8 @@ class Frame {
     const Box& BoxCrd()               const { return box_;           }
     /// \return replica indices
     RemdIdxType const& RemdIndices()  const { return remd_indices_;  }
+    /// \return replica values
+    RemdValType const& RemdValues()   const { return remd_values_;   }
     /// Set box alpha, beta, and gamma
     inline void SetBoxAngles(const double*);
     /// Set box
@@ -109,6 +112,7 @@ class Frame {
     inline double* tAddress() { return &T_;               }
     inline double* mAddress() { return &time_;            }
     inline int* iAddress()    { return &remd_indices_[0]; }
+    inline double* rvAddress(){ return &remd_values_[0];  }
     inline const double* xAddress() const { return X_;                }
     inline const double* vAddress() const { return V_;                }
     inline const double* fAddress() const { return F_;                }
@@ -116,6 +120,7 @@ class Frame {
     inline const double* tAddress() const { return &T_;               }
     inline const double* mAddress() const { return &time_;            }
     inline const int* iAddress()    const { return &remd_indices_[0]; }
+    inline const double* rvAddress()const { return &remd_values_[0];  }
     // ----- Frame memory allocation routines ----
     /// Allocate frame for given # atoms, no mass or velocity.
     int SetupFrame(int);
@@ -240,6 +245,7 @@ class Frame {
     double* V_;     ///< Velocities (same arrangement as Coords).
     double* F_;     ///< Frame (same arrangement as Coords).
     RemdIdxType remd_indices_; ///< replica indices.
+    RemdValType remd_values_; ///< replica values.
     Darray Mass_;   ///< Masses.
     bool memIsExternal_; ///< True if Frame is not responsible for freeing memory.
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -120,6 +120,8 @@ class Frame {
     inline double* tAddress() { return &T_;               }
     inline double* mAddress() { return &time_;            }
     inline int* iAddress()    { return &remd_indices_[0]; }
+    inline int* repidxPtr()   { return &repidx_;          }
+    inline int* crdidxPtr()   { return &crdidx_;          }
     inline const double* xAddress() const { return X_;                }
     inline const double* vAddress() const { return V_;                }
     inline const double* fAddress() const { return F_;                }
@@ -127,6 +129,8 @@ class Frame {
     inline const double* tAddress() const { return &T_;               }
     inline const double* mAddress() const { return &time_;            }
     inline const int* iAddress()    const { return &remd_indices_[0]; }
+    inline const int* repidxPtr()   const { return &repidx_;          }
+    inline const int* crdidxPtr()   const { return &crdidx_;          }
     // ----- Frame memory allocation routines ----
     /// Allocate frame for given # atoms, no mass or velocity.
     int SetupFrame(int);

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -47,6 +47,7 @@ NetcdfFile::NCTYPE NetcdfFile::GetNetcdfConventions(const char* fname) {
 #define NCREMD_CRDIDX "remd_crdidx"
 #define NCEPTOT "eptot"
 #define NCBINS "bins"
+#define NCREMDVALUES "remd_values"
 
 // CONSTRUCTOR
 NetcdfFile::NetcdfFile() :
@@ -63,7 +64,7 @@ NetcdfFile::NetcdfFile() :
   indicesVID_(-1),
   repidxVID_(-1),
   crdidxVID_(-1),
-  ncdebug_(0),
+  ncdebug_(10),
   frameDID_(-1),
   atomDID_(-1),
   ncatom_(-1),
@@ -256,13 +257,15 @@ int NetcdfFile::SetupTime() {
 
 // NetcdfFile::SetupTemperature()
 /** Determine if Netcdf file contains temperature; set up temperature VID. */
-int NetcdfFile::SetupTemperature() {
-  if ( nc_inq_varid(ncid_,NCTEMPERATURE,&TempVID_) == NC_NOERR ) {
-    if (ncdebug_>0) mprintf("\tNetCDF file has replica temperatures.\n");
-    return 0;
-  } 
-  TempVID_=-1;
-  return 1;
+void NetcdfFile::SetupTemperature() {
+  TempVID_ = -1;
+  RemdValuesVID_ = -1;
+  if ( nc_inq_varid(ncid_, NCTEMPERATURE, &TempVID_) == NC_NOERR ) {
+    if (ncdebug_ > 0) mprintf("\tNetCDF file has replica temperatures.\n");
+  }
+  if ( nc_inq_varid(ncid_, NCREMDVALUES, &RemdValuesVID_) == NC_NOERR ) {
+    if (ncdebug_ > 0) mprintf("\tNetCDF file has replica values.\n");
+  }
 }
 
 // NetcdfFile::SetupMultiD()

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -133,7 +133,7 @@ bool NetcdfFile::HasTemperatures() const {
   return false;
 }
 
-/** \return true if a replica dimension is pH.
+/** \return true if a replica dimension is pH. TODO put inside ReplicaDimArray
   */
 bool NetcdfFile::Has_pH() const {
   if (!remDimType_.empty()) {
@@ -465,8 +465,9 @@ int NetcdfFile::ReadRemdValues(Frame& frm) {
 /** \return Coordinate info corresponding to current setup. */
 CoordinateInfo NetcdfFile::NC_coordInfo() const {
   return CoordinateInfo( ensembleSize_, remDimType_, nc_box_,
-                         HasCoords(), HasVelocities(), HasTemperatures(),
-                         HasTimes(), HasForces() );
+                         HasCoords(), HasVelocities(), HasForces(), 
+                         HasTemperatures(), Has_pH(), HasRedOx(),
+                         HasTimes() );
 }
 
 // NetcdfFile::NC_openRead()
@@ -558,10 +559,8 @@ int NetcdfFile::NC_create(std::string const& Name, NCTYPE type, int natomIn,
   nc_type dataType;
 
   if (ncdebug_>1)
-    mprintf("DEBUG: NC_create: %s  natom=%i V=%i F=%i box=%i  temp=%i  time=%i\n",
-            Name.c_str(),natomIn,(int)coordInfo.HasVel(),
-            (int)coordInfo.HasForce(),(int)coordInfo.HasBox(),
-            (int)coordInfo.HasTemp(),(int)coordInfo.HasTime());
+    mprintf("DEBUG: NC_create: '%s'  natom=%i  %s\n",
+            Name.c_str(),natomIn, coordInfo.InfoString().c_str());
 
   if ( NC::CheckErr( nc_create( Name.c_str(), NC_64BIT_OFFSET, &ncid_) ) )
     return 1;

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -610,17 +610,8 @@ int NetcdfFile::NC_create(std::string const& Name, NCTYPE type, int natomIn,
       return 1;
   }
 
-  // Decide if we are going to use replica values. For backwards compatibility,
-  // if only 1 D and/or we only have temperature, the temp0 variable will be
-  // used.
-  //bool useRepValues = false;
-  //if (coordInfo.HasReplicaDims()) {
-  //  // Determine which dimension types are active.
-
-  //}
-
+  // Ensemble dimension for ensemble
   if (type == NC_AMBERENSEMBLE) {
-    // Ensemble dimension for ensemble
     if (coordInfo.EnsembleSize() < 1) {
       mprinterr("Internal Error: NetcdfFile: ensembleSize < 1\n");
       return 1;
@@ -631,9 +622,9 @@ int NetcdfFile::NC_create(std::string const& Name, NCTYPE type, int natomIn,
     }
     dimensionID[1] = ensembleDID_;
   }
+  // Frame dimension for traj
   ncframe_ = 0;
   if (type == NC_AMBERTRAJ || type == NC_AMBERENSEMBLE) {
-    // Frame dimension for traj
     if ( NC::CheckErr( nc_def_dim( ncid_, NCFRAME, NC_UNLIMITED, &frameDID_)) ) {
       mprinterr("Error: Defining frame dimension.\n");
       return 1;

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -65,7 +65,7 @@ NetcdfFile::NetcdfFile() :
   repidxVID_(-1),
   crdidxVID_(-1),
   ensembleSize_(0),
-  ncdebug_(10),
+  ncdebug_(0),
   frameDID_(-1),
   atomDID_(-1),
   ncatom_(-1),
@@ -355,7 +355,6 @@ int NetcdfFile::SetupMultiD() {
     if (ncdebug_ > 0) mprintf("\tNetCDF file has replica values.\n");
     remValType_.clear();
     if (remd_dimension_ > 0) {
-      RemdValues_.assign( remd_dimension_, 0 );
       remValType_ = remDimType_;
     } else {
       // Probably 1D
@@ -373,8 +372,8 @@ int NetcdfFile::SetupMultiD() {
                   "Error:   but no multi-D replica info present.\n");
         return 1;
       }
-      RemdValues_.assign( ndims, 0 );
     }
+    RemdValues_.assign( remValType_.Ndims(), 0 );
   }
 
   return 0; 

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -1070,8 +1070,8 @@ int NetcdfFile::WriteRemdValues(Frame const& frm) {
 }
 
 // =============================================================================
-// NetcdfFile::WriteIndices()
-void NetcdfFile::WriteIndices() const {
+// NetcdfFile::DebugIndices()
+void NetcdfFile::DebugIndices() const {
   mprintf("DBG: Start={%zu, %zu, %zu, %zu} Count={%zu, %zu, %zu, %zu}\n",
          start_[0], start_[1], start_[2], start_[3],
          count_[0], count_[1], count_[2], count_[3]);

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -263,9 +263,6 @@ void NetcdfFile::SetupTemperature() {
   if ( nc_inq_varid(ncid_, NCTEMPERATURE, &TempVID_) == NC_NOERR ) {
     if (ncdebug_ > 0) mprintf("\tNetCDF file has replica temperatures.\n");
   }
-  if ( nc_inq_varid(ncid_, NCREMDVALUES, &RemdValuesVID_) == NC_NOERR ) {
-    if (ncdebug_ > 0) mprintf("\tNetCDF file has replica values.\n");
-  }
 }
 
 // NetcdfFile::SetupMultiD()
@@ -311,6 +308,10 @@ int NetcdfFile::SetupMultiD(ReplicaDimArray& remdDim) {
   if ( NC::CheckErr(nc_inq_varid(ncid_, NCREMD_INDICES, &indicesVID_)) ) {
     mprinterr("Error: Getting replica indices variable ID.\n");
     return -1;
+  }
+  // Get VID for replica values
+  if ( nc_inq_varid(ncid_, NCREMDVALUES, &RemdValuesVID_) == NC_NOERR ) {
+    if (ncdebug_ > 0) mprintf("\tNetCDF file has replica values.\n");
   }
   // Print info for each dimension
   for (int dim = 0; dim < remd_dimension_; ++dim)
@@ -373,6 +374,20 @@ int NetcdfFile::SetupBox(Box& boxIn, NCTYPE typeIn) {
   }
   // No box information
   return -1;
+}
+
+int NetcdfFile::ReadRemdValues(double* remdValPtr) {
+  if ( RemdValuesVID_ != -1 ) {
+    // FIXME assuming start_ is set
+    count_[0] = 1;               // 1 frame
+    count_[1] = remd_dimension_; // # dimensions
+    if ( NC::CheckErr(nc_get_vara_double(ncid_, RemdValuesVID_, start_, count_, remdValPtr)) )
+    {
+      mprinterr("Error: Getting replica values\n");
+      return 1;
+    }
+  }
+  return 0;
 }
 
 // NetcdfFile::NC_openRead()

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -1075,6 +1075,7 @@ int NetcdfFile::WriteRemdValues(Frame const& frm) {
 }
 
 #ifdef MPI
+#ifdef HAS_PNETCDF
 int NetcdfFile::parallelWriteRemdValues(int set, Frame const& frm) {
   MPI_Offset pstart_[2];
   MPI_Offset pcount_[2];
@@ -1110,6 +1111,7 @@ int NetcdfFile::parallelWriteRemdValues(int set, Frame const& frm) {
   }
   return 0;
 }
+#endif
 #endif
 
 // =============================================================================

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -461,19 +461,20 @@ int NetcdfFile::ReadRemdValues(Frame& frm) {
     {
       if (remValType_.DimType(idx) == ReplicaDimArray::TEMPERATURE) {
         frm.SetTemperature( RemdValues_[idx] );
-        mprintf("DEBUG: T= %g\n", frm.Temperature());
+        //mprintf("DEBUG: T= %g\n", frm.Temperature());
       } else if (remValType_.DimType(idx) == ReplicaDimArray::PH) {
         frm.Set_pH( RemdValues_[idx] );
-        mprintf("DEBUG: pH= %g\n", frm.pH());
+        //mprintf("DEBUG: pH= %g\n", frm.pH());
       } else if (remValType_.DimType(idx) == ReplicaDimArray::REDOX) {
         frm.SetRedOx( RemdValues_[idx] );
-        mprintf("DEBUG: RedOx= %g\n", frm.RedOx());
+        //mprintf("DEBUG: RedOx= %g\n", frm.RedOx());
       }
     }
   }
   return 0;
 }
 
+/** Set up an already opened NetCDF file for reading. */
 int NetcdfFile::NC_setupRead(NCTYPE expectedType, int expectedNatoms,
                              bool useVelAsCoords, bool useFrcAsCoords)
 {
@@ -1043,13 +1044,13 @@ int NetcdfFile::WriteRemdValues(Frame const& frm) {
     {
       if (remValType_.DimType(idx) == ReplicaDimArray::TEMPERATURE) {
         RemdValues_[idx] = frm.Temperature();
-        mprintf("DEBUG: T= %g\n", frm.Temperature());
+        //mprintf("DEBUG: T= %g\n", frm.Temperature());
       } else if (remValType_.DimType(idx) == ReplicaDimArray::PH) {
         RemdValues_[idx] = frm.pH();
-        mprintf("DEBUG: pH= %g\n", frm.pH());
+        //mprintf("DEBUG: pH= %g\n", frm.pH());
       } else if (remValType_.DimType(idx) == ReplicaDimArray::REDOX) {
         RemdValues_[idx] = frm.RedOx();
-        mprintf("DEBUG: RedOx= %g\n", frm.RedOx());
+        //mprintf("DEBUG: RedOx= %g\n", frm.RedOx());
       }
     }
     count_[1] = remd_dimension_; // # dimensions

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -522,7 +522,10 @@ int NetcdfFile::NC_setupRead(NCTYPE expectedType, int expectedNatoms,
   SetupTemperature();
   // Replica Dimensions
   if ( SetupMultiD() == -1 ) return 1;
-
+  // NOTE: TO BE ADDED
+  // labelDID;
+  //int cell_spatialDID, cell_angularDID;
+  //int spatialVID, cell_spatialVID, cell_angularVID;
   return 0;
 }
   

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -75,7 +75,8 @@ NetcdfFile::NetcdfFile() :
   cell_angularDID_(-1),
   spatialVID_(-1),
   cell_spatialVID_(-1),
-  cell_angularVID_(-1)
+  cell_angularVID_(-1),
+  RemdValuesVID_(-1)
 {
   start_[0] = 0;
   start_[1] = 0;

--- a/src/NetcdfFile.cpp
+++ b/src/NetcdfFile.cpp
@@ -125,9 +125,31 @@ std::string NetcdfFile::GetNcTitle() const {
 bool NetcdfFile::HasTemperatures() const {
   if (TempVID_ != -1)
     return true;
-  else if (RemdValuesVID_ != -1) {
+  else if (!remDimType_.empty()) {
     for (int idx = 0; idx != remDimType_.Ndims(); idx++)
       if (remDimType_.DimType(idx) == ReplicaDimArray::TEMPERATURE)
+        return true;
+  }
+  return false;
+}
+
+/** \return true if a replica dimension is pH.
+  */
+bool NetcdfFile::Has_pH() const {
+  if (!remDimType_.empty()) {
+    for (int idx = 0; idx != remDimType_.Ndims(); idx++)
+      if (remDimType_.DimType(idx) == ReplicaDimArray::PH)
+        return true;
+  }
+  return false;
+}
+
+/** \return true if a replica dimension is RedOx.
+  */
+bool NetcdfFile::HasRedOx() const {
+  if (!remDimType_.empty()) {
+    for (int idx = 0; idx != remDimType_.Ndims(); idx++)
+      if (remDimType_.DimType(idx) == ReplicaDimArray::REDOX)
         return true;
   }
   return false;

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -107,7 +107,7 @@ class NetcdfFile {
     std::vector<double> RemdValues_; ///< Hold remd values
     ReplicaDimArray remDimType_;     ///< Type of each dimension (multi-D).
     ReplicaDimArray remValType_;     ///< Type of each value (single or multi-D).
-
+    // TODO audit the dimension IDs, may not need to be class vars.
     Box nc_box_;          ///< Hold box information
     int ncdebug_;
     int ensembleDID_;     ///< Ensemble dimenison ID

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -1,7 +1,7 @@
 #ifndef INC_NETCDFFILE_H
 #define INC_NETCDFFILE_H
 #include <string>
-#include "CoordinateInfo.h"
+#include "Frame.h"
 /// The base interface to NetCDF trajectory files.
 class NetcdfFile {
   public:
@@ -45,7 +45,7 @@ class NetcdfFile {
     /// Read - Set up replica index info if present.
     int SetupMultiD(ReplicaDimArray&);
     /// Read - Remd Values
-    int ReadRemdValues(double* );
+    int ReadRemdValues(Frame&);
     /// Convert given float array to double.
     inline void FloatToDouble(double*,const float*) const;
     /// Convert given double array to float.
@@ -89,6 +89,10 @@ class NetcdfFile {
     int crdidxVID_;      ///< Variable ID for overall coordinate index.
   private:
     int NC_defineTemperature(int*, int);
+
+    std::vector<double> RemdValues_; ///< Hold remd values
+    std::vector<int> remDimIdx_;     ///< Hold dim index for each type
+    ReplicaDimArray remDimType_;     ///< Type of each dimension
 
     int ncdebug_;
     int ensembleDID_;     ///< Ensemble dimenison ID

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -39,7 +39,7 @@ class NetcdfFile {
     /// Convert given double array to float.
     inline void DoubleToFloat(float*,const double*) const; 
     /// DEBUG - Write start and count arrays to STDOUT
-    void WriteIndices() const;
+    void DebugIndices() const;
     /// DEBUG - Write all variable IDs to STDOUT
     void DebugVIDs() const;
 

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -32,6 +32,7 @@ class NetcdfFile {
     void NC_close();
     /// \return Title of NetCDF file.
     std::string GetNcTitle() const;
+    int NC_setupRead(NCTYPE, int, bool, bool);
     /// Read - Set up frame dimension ID and number of frames.
     int SetupFrameDim();
     /// Read - Set up ensemble dimension ID and number of members.
@@ -94,6 +95,8 @@ class NetcdfFile {
     // NC ensemble
     int ensembleSize_;
   private:
+    static const char* ConventionsStr_[];
+
     bool Has_pH() const;
     bool HasRedOx() const;
 

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -92,6 +92,9 @@ class NetcdfFile {
     // NC ensemble
     int ensembleSize_;
   private:
+    bool Has_pH() const;
+    bool HasRedOx() const;
+
     int NC_defineTemperature(int*, int);
 
     std::vector<double> RemdValues_; ///< Hold remd values

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -44,6 +44,8 @@ class NetcdfFile {
     void SetupTemperature();
     /// Read - Set up replica index info if present.
     int SetupMultiD(ReplicaDimArray&);
+    /// Read - Remd Values
+    int ReadRemdValues(double* );
     /// Convert given float array to double.
     inline void FloatToDouble(double*,const float*) const;
     /// Convert given double array to float.
@@ -74,7 +76,6 @@ class NetcdfFile {
     int ncid_;           ///< NetCDF file ID
     int ncframe_;        ///< Total number of frames in file
     int TempVID_;        ///< Temperature variable ID.
-    int RemdValuesVID_;  ///< Replica values variable ID.
     int coordVID_;       ///< Coordinates variable ID.
     int velocityVID_;    ///< Velocity variable ID.
     int frcVID_;         ///< Force variable ID.
@@ -102,6 +103,7 @@ class NetcdfFile {
     int spatialVID_;      ///< Spatial (x, y, z) variable ID
     int cell_spatialVID_; ///< Box lengths variable ID
     int cell_angularVID_; ///< Box angles variable ID
+    int RemdValuesVID_;  ///< Replica values variable ID.
 #   endif /* BINTRAJ */
 };
 #ifdef BINTRAJ

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -34,6 +34,9 @@ class NetcdfFile {
     int ReadRemdValues(Frame&);
     /// Write - Remd Values
     int WriteRemdValues(Frame const&);
+#   ifdef MPI
+    int parallelWriteRemdValues(int, Frame const&);
+#   endif
     /// Convert given float array to double.
     inline void FloatToDouble(double*,const float*) const;
     /// Convert given double array to float.

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -53,11 +53,6 @@ class NetcdfFile {
     inline int Ncatom3()   const { return ncatom3_;             }
     inline int Ncframe()   const { return ncframe_;             }
     inline int CoordVID()  const { return coordVID_;            }
-    bool HasForces()       const { return (frcVID_ != -1);      }
-    bool HasVelocities()   const { return (velocityVID_ != -1); }
-    bool HasCoords()       const { return (coordVID_ != -1);    }
-    bool HasTemperatures() const;
-    bool HasTimes()        const { return (timeVID_ != -1);     }
   protected: // TODO: Make all private
 #   ifdef MPI
     void Sync(Parallel::Comm const&);
@@ -85,6 +80,11 @@ class NetcdfFile {
 
     bool Has_pH() const;
     bool HasRedOx() const;
+    bool HasForces()       const { return (frcVID_ != -1);      }
+    bool HasVelocities()   const { return (velocityVID_ != -1); }
+    bool HasCoords()       const { return (coordVID_ != -1);    }
+    bool HasTemperatures() const;
+    bool HasTimes()        const { return (timeVID_ != -1);     }
 
     /// Read - Set up frame dimension ID and number of frames.
     int SetupFrameDim();

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -41,7 +41,7 @@ class NetcdfFile {
     /// Read - Set up box information if present.
     int SetupBox(Box&, NCTYPE);
     /// Read - Set up temperature information if present.
-    int SetupTemperature();
+    void SetupTemperature();
     /// Read - Set up replica index info if present.
     int SetupMultiD(ReplicaDimArray&);
     /// Convert given float array to double.
@@ -74,6 +74,7 @@ class NetcdfFile {
     int ncid_;           ///< NetCDF file ID
     int ncframe_;        ///< Total number of frames in file
     int TempVID_;        ///< Temperature variable ID.
+    int RemdValuesVID_;  ///< Replica values variable ID.
     int coordVID_;       ///< Coordinates variable ID.
     int velocityVID_;    ///< Velocity variable ID.
     int frcVID_;         ///< Force variable ID.

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -33,20 +33,6 @@ class NetcdfFile {
     /// \return Title of NetCDF file.
     std::string GetNcTitle() const;
     int NC_setupRead(NCTYPE, int, bool, bool);
-    /// Read - Set up frame dimension ID and number of frames.
-    int SetupFrameDim();
-    /// Read - Set up ensemble dimension ID and number of members.
-    int SetupEnsembleDim();
-    /// Read - Set up coordinates, velocities, forces, # atoms
-    int SetupCoordsVelo(bool, bool);
-    /// Read - Set up time variable if present
-    int SetupTime();
-    /// Read - Set up box information if present.
-    int SetupBox(NCTYPE);
-    /// Read - Set up temperature information if present.
-    void SetupTemperature();
-    /// Read - Set up replica index info if present.
-    int SetupMultiD();
     /// Read - Remd Values
     int ReadRemdValues(Frame&);
     /// Write - Remd Values
@@ -99,6 +85,21 @@ class NetcdfFile {
 
     bool Has_pH() const;
     bool HasRedOx() const;
+
+    /// Read - Set up frame dimension ID and number of frames.
+    int SetupFrameDim();
+    /// Read - Set up ensemble dimension ID and number of members.
+    int SetupEnsembleDim();
+    /// Read - Set up coordinates, velocities, forces, # atoms
+    int SetupCoordsVelo(bool, bool);
+    /// Read - Set up time variable if present
+    int SetupTime();
+    /// Read - Set up box information if present.
+    int SetupBox(NCTYPE);
+    /// Read - Set up temperature information if present.
+    void SetupTemperature();
+    /// Read - Set up replica index info if present.
+    int SetupMultiD();
 
     int NC_defineTemperature(int*, int);
     inline void SetRemDimDID(NCTYPE, int, int*) const;

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -48,6 +48,8 @@ class NetcdfFile {
     int SetupMultiD();
     /// Read - Remd Values
     int ReadRemdValues(Frame&);
+    /// Write - Remd Values
+    int WriteRemdValues(Frame const&);
     /// Convert given float array to double.
     inline void FloatToDouble(double*,const float*) const;
     /// Convert given double array to float.

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -6,7 +6,7 @@
 class NetcdfFile {
   public:
     /// For determining NetCDF trajectory file type
-    enum NCTYPE { NC_UNKNOWN = 0, NC_AMBERTRAJ, NC_AMBERRESTART, NC_AMBERENSEMBLE };
+    enum NCTYPE { NC_AMBERTRAJ = 0, NC_AMBERRESTART, NC_AMBERENSEMBLE, NC_UNKNOWN };
     /// \return Type of given file.
     NCTYPE GetNetcdfConventions(const char*);
 #   ifndef BINTRAJ

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -23,13 +23,13 @@ class NetcdfFile {
     int NC_createReservoir(bool, double, int, int&, int&);
     /// Create NetCDF trajectory file of given type.
     int NC_create(std::string const&, NCTYPE, int, 
-                  CoordinateInfo const&, std::string const&);
+                  CoordinateInfo const&, std::string const&, int);
     /// Close NetCDF file, do not reset dimension/variable IDs.
     void NC_close();
     /// \return Title of NetCDF file.
-    std::string GetNcTitle() const;
-    /// Set up open NetCDF file for reading.
-    int NC_setupRead(NCTYPE, int, bool, bool);
+    std::string const& GetNcTitle() const { return nctitle_; }
+    /// Set up NetCDF file for reading.
+    int NC_setupRead(std::string const&, NCTYPE, int, bool, bool, int);
     /// Read - Remd Values
     int ReadRemdValues(Frame&);
     /// Write - Remd Values
@@ -41,9 +41,7 @@ class NetcdfFile {
     /// DEBUG - Write start and count arrays to STDOUT
     void WriteIndices() const;
     /// DEBUG - Write all variable IDs to STDOUT
-    void WriteVIDs() const;
-    /// DEBUG - Write general debug info to STDOUT
-    void NetcdfDebug() const;
+    void DebugVIDs() const;
 
     inline int Ncid()      const { return ncid_;                }
     inline int Ncatom()    const { return ncatom_;              }
@@ -72,6 +70,7 @@ class NetcdfFile {
     int crdidxVID_;      ///< Variable ID for overall coordinate index.
     // NC ensemble
     int ensembleSize_;
+    std::string nctitle_;
   private:
     static const char* ConventionsStr_[];
 

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -91,7 +91,6 @@ class NetcdfFile {
     int NC_defineTemperature(int*, int);
 
     std::vector<double> RemdValues_; ///< Hold remd values
-    std::vector<int> remDimIdx_;     ///< Hold dim index for each type
     ReplicaDimArray remDimType_;     ///< Type of each dimension
 
     int ncdebug_;

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -17,6 +17,8 @@ class NetcdfFile {
     NCTYPE GetNetcdfConventions();
     /// Check NetCDF file conventions version.
     void CheckConventionsVersion();
+    /// \return Coordinate info corresponding to current setup. TODO have in variable?
+    CoordinateInfo NC_coordInfo() const;
     /// Open NetCDF file for reading.
     int NC_openRead(std::string const&);
     /// Open previously created NetCDF file for writing.
@@ -39,11 +41,11 @@ class NetcdfFile {
     /// Read - Set up time variable if present
     int SetupTime();
     /// Read - Set up box information if present.
-    int SetupBox(Box&, NCTYPE);
+    int SetupBox(NCTYPE);
     /// Read - Set up temperature information if present.
     void SetupTemperature();
     /// Read - Set up replica index info if present.
-    int SetupMultiD(ReplicaDimArray&);
+    int SetupMultiD();
     /// Read - Remd Values
     int ReadRemdValues(Frame&);
     /// Convert given float array to double.
@@ -87,12 +89,15 @@ class NetcdfFile {
     int indicesVID_;     ///< Variable ID for replica indices.
     int repidxVID_;      ///< Variable ID for overall replica index.
     int crdidxVID_;      ///< Variable ID for overall coordinate index.
+    // NC ensemble
+    int ensembleSize_;
   private:
     int NC_defineTemperature(int*, int);
 
     std::vector<double> RemdValues_; ///< Hold remd values
     ReplicaDimArray remDimType_;     ///< Type of each dimension
 
+    Box nc_box_;          ///< Hold box information
     int ncdebug_;
     int ensembleDID_;     ///< Ensemble dimenison ID
     int frameDID_;        ///< Frames dimension ID

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -65,7 +65,7 @@ class NetcdfFile {
     bool HasForces()       const { return (frcVID_ != -1);      }
     bool HasVelocities()   const { return (velocityVID_ != -1); }
     bool HasCoords()       const { return (coordVID_ != -1);    }
-    bool HasTemperatures() const { return (TempVID_ != -1);     }
+    bool HasTemperatures() const;
     bool HasTimes()        const { return (timeVID_ != -1);     }
   protected: // TODO: Make all private
 #   ifdef MPI

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -35,7 +35,9 @@ class NetcdfFile {
     /// Write - Remd Values
     int WriteRemdValues(Frame const&);
 #   ifdef MPI
+#   ifdef HAS_PNETCDF
     int parallelWriteRemdValues(int, Frame const&);
+#   endif
 #   endif
     /// Convert given float array to double.
     inline void FloatToDouble(double*,const float*) const;

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -13,10 +13,6 @@ class NetcdfFile {
     NetcdfFile() { }
 #   else 
     NetcdfFile();
-    /// \return NetCDF trajectory type based on conventions.
-    NCTYPE GetNetcdfConventions();
-    /// Check NetCDF file conventions version.
-    void CheckConventionsVersion();
     /// \return Coordinate info corresponding to current setup. TODO have in variable?
     CoordinateInfo NC_coordInfo() const;
     /// Open NetCDF file for reading.
@@ -32,6 +28,7 @@ class NetcdfFile {
     void NC_close();
     /// \return Title of NetCDF file.
     std::string GetNcTitle() const;
+    /// Set up open NetCDF file for reading.
     int NC_setupRead(NCTYPE, int, bool, bool);
     /// Read - Remd Values
     int ReadRemdValues(Frame&);
@@ -78,6 +75,11 @@ class NetcdfFile {
   private:
     static const char* ConventionsStr_[];
 
+    /// \return NetCDF trajectory type based on conventions.
+    NCTYPE GetNetcdfConventions(int);
+    /// Check NetCDF file conventions version.
+    void CheckConventionsVersion();
+
     bool Has_pH() const;
     bool HasRedOx() const;
     bool HasForces()       const { return (frcVID_ != -1);      }
@@ -95,20 +97,21 @@ class NetcdfFile {
     /// Read - Set up time variable if present
     int SetupTime();
     /// Read - Set up box information if present.
-    int SetupBox(NCTYPE);
+    int SetupBox();
     /// Read - Set up temperature information if present.
     void SetupTemperature();
     /// Read - Set up replica index info if present.
     int SetupMultiD();
 
     int NC_defineTemperature(int*, int);
-    inline void SetRemDimDID(NCTYPE, int, int*) const;
+    inline void SetRemDimDID(int, int*) const;
 
     std::vector<double> RemdValues_; ///< Hold remd values
     ReplicaDimArray remDimType_;     ///< Type of each dimension (multi-D).
     ReplicaDimArray remValType_;     ///< Type of each value (single or multi-D).
     // TODO audit the dimension IDs, may not need to be class vars.
     Box nc_box_;          ///< Hold box information
+    NCTYPE myType_;       ///< Current file type.
     int ncdebug_;
     int ensembleDID_;     ///< Ensemble dimenison ID
     int frameDID_;        ///< Frames dimension ID

--- a/src/NetcdfFile.h
+++ b/src/NetcdfFile.h
@@ -96,9 +96,11 @@ class NetcdfFile {
     bool HasRedOx() const;
 
     int NC_defineTemperature(int*, int);
+    inline void SetRemDimDID(NCTYPE, int, int*) const;
 
     std::vector<double> RemdValues_; ///< Hold remd values
-    ReplicaDimArray remDimType_;     ///< Type of each dimension
+    ReplicaDimArray remDimType_;     ///< Type of each dimension (multi-D).
+    ReplicaDimArray remValType_;     ///< Type of each value (single or multi-D).
 
     Box nc_box_;          ///< Hold box information
     int ncdebug_;

--- a/src/ReferenceAction.cpp
+++ b/src/ReferenceAction.cpp
@@ -37,6 +37,11 @@ std::string ReferenceAction::help_ =
 #ifdef MPI
 /** Should be called after InitRef(). */
 int ReferenceAction::SetTrajComm( Parallel::Comm const& commIn ) {
+  // Does not work for previous
+  if (previous_ && commIn.Size() > 1) {
+    mprinterr("Error: 'previous' reference does not work in parallel.\n");
+    return 1;
+  }
   trajComm_ = commIn;
   // Sanity check. Ensure refMode_ matches on all threads.
   std::vector<int> all_modes( trajComm_.Size() );

--- a/src/RemdReservoirNC.cpp
+++ b/src/RemdReservoirNC.cpp
@@ -13,7 +13,7 @@ int RemdReservoirNC::InitReservoir(FileName const& fnameIn, std::string const& t
 # ifdef BINTRAJ
   CoordinateInfo cInfo(cinfoIn.TrajBox(), true, cinfoIn.HasVel(), cinfoIn.HasForce(), false);
   if (NC_create( fnameIn.Full(), NC_AMBERTRAJ, natomsIn, cInfo,
-                 "Cpptraj generated structure reservoir" ))
+                 "Cpptraj generated structure reservoir", debug_ ))
     return 1;
   if (NC_createReservoir(hasBins, tempIn, iseed, eptotVID_, binsVID_))
     return 1;

--- a/src/RemdReservoirNC.cpp
+++ b/src/RemdReservoirNC.cpp
@@ -11,8 +11,7 @@ int RemdReservoirNC::InitReservoir(FileName const& fnameIn, std::string const& t
                                    int natomsIn, bool hasBins, double tempIn, int iseed)
 {
 # ifdef BINTRAJ
-  CoordinateInfo cInfo(ReplicaDimArray(), cinfoIn.TrajBox(), cinfoIn.HasVel(),
-                       false, false, cinfoIn.HasForce());
+  CoordinateInfo cInfo(cinfoIn.TrajBox(), true, cinfoIn.HasVel(), cinfoIn.HasForce(), false);
   if (NC_create( fnameIn.Full(), NC_AMBERTRAJ, natomsIn, cInfo,
                  "Cpptraj generated structure reservoir" ))
     return 1;

--- a/src/RemdReservoirNC.h
+++ b/src/RemdReservoirNC.h
@@ -7,7 +7,7 @@
 class RemdReservoirNC : private NetcdfFile {
   public:
     RemdReservoirNC() : eptotVID_(-1), binsVID_(-1) {}
-    //void SetDebug(int d) { debug_ = d; } // TODO necessary?
+    void SetDebug(int d) { debug_ = d; }
     /// Initialize and open. Filename, title, coordinate info, # atoms, has bins, reservoir temp, seed
     int InitReservoir(FileName const&, std::string const&, CoordinateInfo const&, int, bool, double, int);
     /// Write structure, energy, and bin to reservoir
@@ -22,5 +22,6 @@ class RemdReservoirNC : private NetcdfFile {
     std::vector<float> Coord_; ///< For converting input coords to single precision
     int eptotVID_;             ///< Potential energy variable ID
     int binsVID_;              ///< Cluster bins variable ID
+    int debug_;
 };
 #endif

--- a/src/ReplicaDimArray.h
+++ b/src/ReplicaDimArray.h
@@ -14,7 +14,7 @@ class ReplicaDimArray {
     //       currently match what is defined in Amber for REMD (remd.F90)
     //       EXCEPT RXSGLD, which uses the TEMPERATURE framework in Amber.
     //       Care should be taken to keep these in sync.
-    enum RemDimType { UNKNOWN=0, TEMPERATURE, PARTIAL, HAMILTONIAN, PH, RXSGLD };
+    enum RemDimType { UNKNOWN=0, TEMPERATURE, PARTIAL, HAMILTONIAN, PH, REDOX, RXSGLD };
     int operator[](int idx) const { return (int)remDims_[idx];         }
     int Ndims()             const { return (int)remDims_.size();       }
     void AddRemdDimension(int d)         { remDims_.push_back((RemDimType)d); }
@@ -28,7 +28,8 @@ class ReplicaDimArray {
         case PARTIAL:     return "Partial";     // 2 (UNUSED?)
         case HAMILTONIAN: return "Hamiltonian"; // 3
         case PH:          return "pH";          // 4
-        case RXSGLD:      return "RXSGLD";      // 5
+        case REDOX:       return "RedOx";       // 5
+        case RXSGLD:      return "RXSGLD";      // 6 FIXME placeholder for future traj type
       }
       return 0; // Sanity check, should never reach.
     }

--- a/src/ReplicaDimArray.h
+++ b/src/ReplicaDimArray.h
@@ -18,6 +18,7 @@ class ReplicaDimArray {
     RemDimType DimType(int idx) const { return remDims_[idx]; }
     int operator[](int idx) const { return (int)remDims_[idx];         }
     int Ndims()             const { return (int)remDims_.size();       }
+    bool empty()            const { return remDims_.empty();           }
     void AddRemdDimension(int d)         { remDims_.push_back((RemDimType)d); }
     void AddRemdDimension(RemDimType d)  { remDims_.push_back(d);             }
     void ChangeRemdDim(int d, RemDimType t) { remDims_[d] = t; }

--- a/src/ReplicaDimArray.h
+++ b/src/ReplicaDimArray.h
@@ -47,6 +47,10 @@ class ReplicaDimArray {
         if ( *d0 != *(d1++) ) return true;
       return false;
     }
+#   ifdef MPI
+    void assign( unsigned int n, RemDimType t ) { remDims_.assign(n, t); }
+    int* Ptr() { return (int*)&remDims_[0]; }
+#   endif
   private:
     std::vector<RemDimType> remDims_;
 };

--- a/src/ReplicaDimArray.h
+++ b/src/ReplicaDimArray.h
@@ -15,6 +15,7 @@ class ReplicaDimArray {
     //       EXCEPT RXSGLD, which uses the TEMPERATURE framework in Amber.
     //       Care should be taken to keep these in sync.
     enum RemDimType { UNKNOWN=0, TEMPERATURE, PARTIAL, HAMILTONIAN, PH, REDOX, RXSGLD };
+    RemDimType DimType(int idx) const { return remDims_[idx]; }
     int operator[](int idx) const { return (int)remDims_[idx];         }
     int Ndims()             const { return (int)remDims_.size();       }
     void AddRemdDimension(int d)         { remDims_.push_back((RemDimType)d); }

--- a/src/ReplicaInfo.h
+++ b/src/ReplicaInfo.h
@@ -11,7 +11,9 @@ template <class T> class Map {
     typedef std::map<T, int> RmapType;
   public:
     Map() {}
-    // Create a map from T array to replicas 0->N
+    /// Create a map from T array to replicas 0->N, potentially allow duplicate input values
+    int CreateMap(std::vector<T> const&, bool);
+    /// Create a map from T array to replicas 0->N
     int CreateMap(std::vector<T> const&);
     T const& Duplicate() const { return duplicate_; }
     // Given T, find index in map
@@ -26,12 +28,18 @@ template <class T> class Map {
     T duplicate_;
 };
 // Map::CreateMap()
-template <class T> int Map<T>::CreateMap(std::vector<T> const& Vals) {
+/** Create a map of indices to sorted input values.
+  * \param Vals array of input values.
+  * \param checkForDuplicates If true, return 1 if duplicate values detected in Vals
+  */
+template <class T> int Map<T>::CreateMap(std::vector<T> const& Vals, bool checkForDuplicates)
+{
   std::set<T> tList;
   for (typename std::vector<T>::const_iterator val = Vals.begin(); val != Vals.end(); ++val)
   {
     std::pair<typename std::set<T>::iterator, bool> ret = tList.insert( *val );
-    if (!ret.second) { // Duplicate value detected.
+    if (checkForDuplicates && !ret.second) {
+      // Duplicate value detected.
       duplicate_ = *val;
       return 1;
     }
@@ -42,6 +50,13 @@ template <class T> int Map<T>::CreateMap(std::vector<T> const& Vals) {
   for (typename std::set<T>::const_iterator v0 = tList.begin(); v0 != tList.end(); ++v0, ++repnum)
     repMap_.insert(std::pair<T, int>(*v0, repnum));
   return 0;
+}
+/** Create a map of indices to sorted input values.
+  * \return 0 if map created, 1 if duplicate values detected in Vals.
+  */
+template <class T> int Map<T>::CreateMap(std::vector<T> const& Vals)
+{
+  return CreateMap(Vals, true);
 }
 // Map::FindIndex()
 template <class T> int Map<T>::FindIndex( T const& Val ) const {

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -545,6 +545,9 @@ int Traj_AmberNetcdf::parallelWriteFrame(int set, Frame const& frameOut) {
     if (checkPNCerr(err)) return Parallel::Abort(err);
   }
 
+  // Write Remd Values
+  parallelWriteRemdValues(set, frameOut);
+
   pcount_[2] = 0;
   if (cellLengthVID_ != -1) {
     pcount_[1] = 3;

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -291,7 +291,7 @@ int Traj_AmberNetcdf::readFrame(int set, Frame& frameIn) {
   }
 
   // Read REMD values.
-  if (ReadRemdValues( frameIn.rvAddress() )) return 1;
+  ReadRemdValues(frameIn);
 
   // Read box info 
   if (cellLengthVID_ != -1) {

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -102,18 +102,13 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
   // Setup Time - FIXME: Allowed to fail silently
   SetupTime();
   // Box info
-  Box nc_box;
-  if (SetupBox(nc_box, NC_AMBERTRAJ) == 1) // 1 indicates an error
+  if (SetupBox(NC_AMBERTRAJ) == 1) // 1 indicates an error
     return TRAJIN_ERR;
   // Replica Temperatures - FIXME: Allowed to fail silently
   SetupTemperature();
   // Replica Dimensions
-  ReplicaDimArray remdDim;
-  if ( SetupMultiD(remdDim) == -1 ) return TRAJIN_ERR;
-  CoordinateInfo ncCoordInfo(remdDim, nc_box, HasVelocities(),
-                             HasTemperatures(), HasTimes(), HasForces());
-  ncCoordInfo.SetCrd( HasCoords() );
-  SetCoordInfo( ncCoordInfo ); 
+  if ( SetupMultiD() == -1 ) return TRAJIN_ERR;
+  SetCoordInfo( NC_coordInfo() ); 
   // NOTE: TO BE ADDED
   // labelDID;
   //int cell_spatialDID, cell_angularDID;

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -409,26 +409,11 @@ int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
 void Traj_AmberNetcdf::Info() {
   mprintf("is a NetCDF AMBER trajectory");
   if (readAccess_) {
-    if (!HasCoords()) mprintf(" (no coordinates)");
+    mprintf(" with %s", CoordInfo().InfoString().c_str());
     if (useVelAsCoords_) mprintf(" (using velocities as coordinates)");
     if (useFrcAsCoords_) mprintf(" (using forces as coordinates)");
-    if (HasVelocities() || HasForces() || HasTemperatures()) {
-      mprintf(" with");
-      if (HasVelocities()) mprintf(" velocities");
-      if (HasForces()) mprintf(" forces");
-      if (HasTemperatures()) mprintf(" temperatures");
-    }
-    if (remd_dimension_ > 0) mprintf(" %i replica dimensions", remd_dimension_);
-  } else {
-    if ( !(write_mdcrd_ && write_mdvel_ && write_mdfrc_) ) {
-      if (write_mdcrd_ || write_mdvel_ || write_mdfrc_) {
-        mprintf(" with");
-        if (write_mdcrd_) mprintf(" coordinates");
-        if (write_mdvel_) mprintf(" velocities");
-        if (write_mdfrc_) mprintf(" forces");
-      }
-    }
-  }
+    if (remd_dimension_ > 0) mprintf(", %i replica dimensions", remd_dimension_);
+  } 
 }
 #ifdef MPI
 #ifdef HAS_PNETCDF

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -75,39 +75,12 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
   filename_ = fname;
   if (openTrajin()) return TRAJIN_ERR;
   readAccess_ = true;
-  // Sanity check - Make sure this is a Netcdf trajectory
-  if ( GetNetcdfConventions() != NC_AMBERTRAJ ) {
-    mprinterr("Error: Netcdf file %s conventions do not include \"AMBER\"\n",filename_.base());
+  // Setup for Amber NetCDF trajectory
+  if ( NC_setupRead(NC_AMBERTRAJ, trajParm->Natom(), useVelAsCoords_, useFrcAsCoords_) )
     return TRAJIN_ERR;
-  }
-  // This will warn if conventions are not 1.0 
-  CheckConventionsVersion();
   // Get title
   SetTitle( GetNcTitle() );
-  // Get Frame info
-  if ( SetupFrameDim()!=0 ) return TRAJIN_ERR;
-  if ( Ncframe() < 1 ) {
-    mprinterr("Error: Netcdf file is empty.\n");
-    return TRAJIN_ERR;
-  }
-  // Setup Coordinates/Velocities
-  if ( SetupCoordsVelo( useVelAsCoords_, useFrcAsCoords_ )!=0 ) return TRAJIN_ERR;
-  // Check that specified number of atoms matches expected number.
-  if (Ncatom() != trajParm->Natom()) {
-    mprinterr("Error: Number of atoms in NetCDF file %s (%i) does not\n"
-              "Error:   match number in associated parmtop (%i)!\n", 
-              filename_.base(), Ncatom(), trajParm->Natom());
-    return TRAJIN_ERR;
-  }
-  // Setup Time - FIXME: Allowed to fail silently
-  SetupTime();
-  // Box info
-  if (SetupBox(NC_AMBERTRAJ) == 1) // 1 indicates an error
-    return TRAJIN_ERR;
-  // Replica Temperatures - FIXME: Allowed to fail silently
-  SetupTemperature();
-  // Replica Dimensions
-  if ( SetupMultiD() == -1 ) return TRAJIN_ERR;
+  // Set coordinate info
   SetCoordInfo( NC_coordInfo() ); 
   // NOTE: TO BE ADDED
   // labelDID;

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -73,10 +73,10 @@ int Traj_AmberNetcdf::processReadArgs(ArgList& argIn) {
 int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
 {
   filename_ = fname;
-  if (openTrajin()) return TRAJIN_ERR;
   readAccess_ = true;
   // Setup for Amber NetCDF trajectory
-  if ( NC_setupRead(NC_AMBERTRAJ, trajParm->Natom(), useVelAsCoords_, useFrcAsCoords_) )
+  if ( NC_setupRead(filename_.Full(), NC_AMBERTRAJ, trajParm->Natom(),
+                    useVelAsCoords_, useFrcAsCoords_, debug_) )
     return TRAJIN_ERR;
   // Get title
   SetTitle( GetNcTitle() );
@@ -86,8 +86,6 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
   // float to/from double.
   if (Coord_ != 0) delete[] Coord_;
   Coord_ = new float[ Ncatom3() ];
-  if (debug_>1) NetcdfDebug();
-  closeTraj();
   return Ncframe();
 }
 
@@ -150,10 +148,10 @@ int Traj_AmberNetcdf::setupTrajout(FileName const& fname, Topology* trajParm,
     if (Title().empty())
       SetTitle("Cpptraj Generated trajectory");
     // Create NetCDF file.
-    if (NC_create( filename_.Full(), NC_AMBERTRAJ, trajParm->Natom(), CoordInfo(), Title() ))
+    if (NC_create( filename_.Full(), NC_AMBERTRAJ, trajParm->Natom(), CoordInfo(),
+                   Title(), debug_ ))
       return 1;
-    if (debug_>1) NetcdfDebug();
-    // Close Netcdf file. It will be reopened write.
+    // Close Netcdf file. It will be reopened write. FIXME should NC_create leave it closed?
     NC_close();
     // Allocate memory
     if (Coord_!=0) delete[] Coord_;

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -290,6 +290,9 @@ int Traj_AmberNetcdf::readFrame(int set, Frame& frameIn) {
     //mprintf("\n");
   }
 
+  // Read REMD values.
+  if (ReadRemdValues( frameIn.rvAddress() )) return 1;
+
   // Read box info 
   if (cellLengthVID_ != -1) {
     count_[1] = 3;

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -382,6 +382,9 @@ int Traj_AmberNetcdf::writeFrame(int set, Frame const& frameOut) {
     }
   }
 
+  // Write Remd Values
+  WriteRemdValues(frameOut);
+
   // Write box
   if (cellLengthVID_ != -1) {
     count_[1] = 3;

--- a/src/Traj_AmberNetcdf.cpp
+++ b/src/Traj_AmberNetcdf.cpp
@@ -82,10 +82,6 @@ int Traj_AmberNetcdf::setupTrajin(FileName const& fname, Topology* trajParm)
   SetTitle( GetNcTitle() );
   // Set coordinate info
   SetCoordInfo( NC_coordInfo() ); 
-  // NOTE: TO BE ADDED
-  // labelDID;
-  //int cell_spatialDID, cell_angularDID;
-  //int spatialVID, cell_spatialVID, cell_angularVID;
   // Amber Netcdf coords are float. Allocate a float array for converting
   // float to/from double.
   if (Coord_ != 0) delete[] Coord_;

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -282,12 +282,11 @@ int Traj_AmberRestartNC::writeFrame(int set, Frame const& frameOut) {
 void Traj_AmberRestartNC::Info() {
   mprintf("is a NetCDF AMBER restart file");
   if (readAccess_) {
-    if (CoordInfo().HasVel()) mprintf(", with velocities");
-    if (CoordInfo().HasTemp()) mprintf(", with replica temperature");
-    if (remd_dimension_ > 0) mprintf(", with %i dimensions", remd_dimension_);
-  } else {
-    if (outputTemp_) mprintf(", with temperature");
-  }
+    mprintf(" with %s", CoordInfo().InfoString().c_str());
+    if (useVelAsCoords_) mprintf(" (using velocities as coordinates)");
+    if (useFrcAsCoords_) mprintf(" (using forces as coordinates)");
+    if (remd_dimension_ > 0) mprintf(", %i replica dimensions", remd_dimension_);
+  } 
 }
 #ifdef MPI
 /// Since files are opened on write this does not need to do anything

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -46,7 +46,6 @@ int Traj_AmberRestartNC::openTrajin() {
     mprinterr("Error: Opening Netcdf restart file %s for reading.\n", filename_.base());
     return 1;
   }
-  if (debug_>1) NetcdfDebug();
   return 0;
 }
 
@@ -68,16 +67,15 @@ int Traj_AmberRestartNC::processReadArgs(ArgList& argIn) {
 int Traj_AmberRestartNC::setupTrajin(FileName const& fname, Topology* trajParm)
 {
   filename_ = fname;
-  if (openTrajin()) return TRAJIN_ERR;
   readAccess_ = true;
   // Setup for Amber NetCDF restart.
-  if ( NC_setupRead(NC_AMBERRESTART, trajParm->Natom(), useVelAsCoords_, useFrcAsCoords_) )
+  if ( NC_setupRead(filename_.Full(), NC_AMBERRESTART, trajParm->Natom(),
+                    useVelAsCoords_, useFrcAsCoords_, debug_) )
     return TRAJIN_ERR;
   // Get title
   SetTitle( GetNcTitle() );
   // Set coordinate info 
   SetCoordInfo( NC_coordInfo() );
-  closeTraj();
   // Only 1 frame for NC restarts
   return 1;
 }
@@ -211,7 +209,8 @@ int Traj_AmberRestartNC::writeFrame(int set, Frame const& frameOut) {
   else
     fname = filename_.AppendFileName( "." + integerToString(set+1) );
   // Create Netcdf file 
-  if ( NC_create( fname.full(), NC_AMBERRESTART, n_atoms_, CoordInfo(), Title() ) )
+  if ( NC_create( fname.full(), NC_AMBERRESTART, n_atoms_, CoordInfo(),
+                  Title(), debug_ ) )
     return 1;
   // write coords
   start_[0] = 0;

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -204,6 +204,9 @@ int Traj_AmberRestartNC::readFrame(int set, Frame& frameIn) {
     //mprintf("\n");
   }
 
+  // Read REMD values.
+  ReadRemdValues(frameIn);
+
   // Read box info 
   if (cellLengthVID_ != -1) {
     count_[0] = 3;
@@ -293,6 +296,9 @@ int Traj_AmberRestartNC::writeFrame(int set, Frame const& frameOut) {
       return 1;
     }
   }
+  // Write Remd Values
+  WriteRemdValues(frameOut);
+
   //nc_sync(ncid_); // Necessary? File about to close anyway... 
   // Close file for this set
   closeTraj();

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -70,40 +70,13 @@ int Traj_AmberRestartNC::setupTrajin(FileName const& fname, Topology* trajParm)
   filename_ = fname;
   if (openTrajin()) return TRAJIN_ERR;
   readAccess_ = true;
-  // Sanity check - Make sure this is a Netcdf restart
-  if ( GetNetcdfConventions() != NC_AMBERRESTART ) {
-    mprinterr("Error: Netcdf restart file %s conventions do not include \"AMBERRESTART\"\n",
-              filename_.base());
+  // Setup for Amber NetCDF restart.
+  if ( NC_setupRead(NC_AMBERRESTART, trajParm->Natom(), useVelAsCoords_, useFrcAsCoords_) )
     return TRAJIN_ERR;
-  }
-  // This will warn if conventions are not 1.0 
-  CheckConventionsVersion();
   // Get title
   SetTitle( GetNcTitle() );
-  // Setup Coordinates/Velocities
-  if ( SetupCoordsVelo( useVelAsCoords_, useFrcAsCoords_ )!=0 ) return TRAJIN_ERR;
-  // Check that specified number of atoms matches expected number.
-  if (Ncatom() != trajParm->Natom()) {
-    mprinterr("Error: Number of atoms in NetCDF restart file %s (%i) does not\n",
-              filename_.base(), Ncatom());
-    mprinterr("       match number in associated parmtop (%i)!\n",trajParm->Natom());
-    return TRAJIN_ERR;
-  }
-  // Setup Time - FIXME: allowed to fail silently
-  SetupTime();
-  // Box info
-  if (SetupBox(NC_AMBERRESTART) == 1) // 1 indicates an error
-    return TRAJIN_ERR;
-  // Replica Temperatures - FIXME: allowed to fail silently 
-  SetupTemperature();
-  // Replica Dimensions
-  if ( SetupMultiD() == -1 ) return TRAJIN_ERR;
-  // Set traj info: FIXME - no forces yet
+  // Set coordinate info 
   SetCoordInfo( NC_coordInfo() );
-  // NOTE: TO BE ADDED
-  // labelDID;
-  //int cell_spatialDID, cell_angularDID;
-  //int spatialVID, cell_spatialVID, cell_angularVID;
   closeTraj();
   // Only 1 frame for NC restarts
   return 1;

--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -92,17 +92,14 @@ int Traj_AmberRestartNC::setupTrajin(FileName const& fname, Topology* trajParm)
   // Setup Time - FIXME: allowed to fail silently
   SetupTime();
   // Box info
-  Box nc_box;
-  if (SetupBox(nc_box, NC_AMBERRESTART) == 1) // 1 indicates an error
+  if (SetupBox(NC_AMBERRESTART) == 1) // 1 indicates an error
     return TRAJIN_ERR;
   // Replica Temperatures - FIXME: allowed to fail silently 
   SetupTemperature();
   // Replica Dimensions
-  ReplicaDimArray remdDim;
-  if ( SetupMultiD(remdDim) == -1 ) return TRAJIN_ERR;
+  if ( SetupMultiD() == -1 ) return TRAJIN_ERR;
   // Set traj info: FIXME - no forces yet
-  SetCoordInfo( CoordinateInfo(remdDim, nc_box, HasVelocities(),
-                               HasTemperatures(), HasTimes(), false) );
+  SetCoordInfo( NC_coordInfo() );
   // NOTE: TO BE ADDED
   // labelDID;
   //int cell_spatialDID, cell_angularDID;

--- a/src/Traj_GmxTrX.cpp
+++ b/src/Traj_GmxTrX.cpp
@@ -390,9 +390,8 @@ int Traj_GmxTrX::setupTrajin(FileName const& fname, Topology* trajParm)
   if ( box_size_ > 0 ) {
     if ( ReadBox( box ) ) return TRAJIN_ERR;
   }
-  // Set traj info - No temperature
-  SetCoordInfo( CoordinateInfo(ReplicaDimArray(), Box(box), (v_size_ > 0),
-                               false, true, (f_size_ > 0)) );
+  // Box, coords, velocity, force, time 
+  SetCoordInfo( CoordinateInfo(Box(box), true, (v_size_ > 0), (f_size_ > 0), true) );
   closeTraj();
   return nframes;
 }

--- a/src/Traj_GmxXtc.cpp
+++ b/src/Traj_GmxXtc.cpp
@@ -116,8 +116,8 @@ int Traj_GmxXtc::setupTrajin(FileName const& fnameIn, Topology* trajParm)
     nframes = (int)xtc_frames;
 */
   closeTraj();
-  // No velocity, no temperature, yes time, no force
-  SetCoordInfo( CoordinateInfo(ReplicaDimArray(), tmp.BoxCrd(), false, false, true, false) );
+  // Box, coords, no velocity, no force, yes time
+  SetCoordInfo( CoordinateInfo(tmp.BoxCrd(), true, false, false, true) );
   return nframes;
 }
 

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -140,17 +140,14 @@ int Traj_NcEnsemble::setupTrajin(FileName const& fname, Topology* trajParm)
   // Setup Time - FIXME: Allowed to fail silently
   SetupTime();
   // Box info
-  Box nc_box; 
-  if (SetupBox(nc_box, NC_AMBERENSEMBLE) == 1) // 1 indicates an error
+  if (SetupBox(NC_AMBERENSEMBLE) == 1) // 1 indicates an error
     return TRAJIN_ERR;
   // Replica Temperatures - FIXME: Allowed to fail silently
   SetupTemperature();
   // Replica Dimensions
-  ReplicaDimArray remdDim;
-  if ( SetupMultiD(remdDim) == -1 ) return TRAJIN_ERR;
+  if ( SetupMultiD() == -1 ) return TRAJIN_ERR;
   // Set traj info: FIXME - no forces yet
-  SetCoordInfo( CoordinateInfo(ensembleSize, remdDim, nc_box, HasVelocities(),
-                               HasTemperatures(), HasTimes(), false) ); 
+  SetCoordInfo( NC_coordInfo() ); 
   if (debug_>1) NetcdfDebug();
   //closeTraj();
   // Close single thread for now

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -349,7 +349,7 @@ int Traj_NcEnsemble::writeArray(int set, FramePtrArray const& Farray) {
     start_[1] = member;   // Ensemble
     count_[2] = Ncatom(); // Atoms
     // Write Coords
-    //WriteIndices(); // DEBUG
+    //DebugIndices(); // DEBUG
     DoubleToFloat(Coord_, frm->xAddress());
 #   ifdef HAS_PNETCDF
     if (ncmpi_put_vara_float_all(ncid_, coordVID_, start_, count_, Coord_))

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -252,7 +252,7 @@ int Traj_NcEnsemble::writeFrame(int set, Frame const& frameOut) {
   return 1;
 }
 
-// Traj_NcEnsemble::readArray()
+// Traj_NcEnsemble::readArray() //TODO RemdValues
 int Traj_NcEnsemble::readArray(int set, FrameArray& f_ensemble) {
 # ifdef HAS_PNETCDF
   MPI_Offset pstart_[4];
@@ -365,7 +365,7 @@ int Traj_NcEnsemble::readArray(int set, FrameArray& f_ensemble) {
   return 0;
 }
 
-// Traj_NcEnsemble::writeArray()
+// Traj_NcEnsemble::writeArray() // TODO RemdValues
 int Traj_NcEnsemble::writeArray(int set, FramePtrArray const& Farray) {
 # ifdef HAS_PNETCDF
   MPI_Offset pstart_[4];

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -170,7 +170,7 @@ int Traj_NcEnsemble::setupTrajout(FileName const& fname, Topology* trajParm,
     // Synchronize netcdf info on non-master threads
     Sync(Parallel::World());
     // DEBUG: Print info for all ranks
-    WriteVIDs();
+    DebugVIDs();
 #   endif
     // Allocate memory
     if (Coord_!=0) delete[] Coord_;

--- a/src/Traj_NcEnsemble.cpp
+++ b/src/Traj_NcEnsemble.cpp
@@ -443,10 +443,12 @@ int Traj_NcEnsemble::writeArray(int set, FramePtrArray const& Farray) {
 // Traj_NcEnsemble::Info()
 void Traj_NcEnsemble::Info() {
   mprintf("is a NetCDF Ensemble AMBER trajectory");
-  if (readAccess_ && !HasCoords()) mprintf(" (no coordinates)");
-  //if (HasV()) mprintf(" containing velocities");
-  //if (HasT()) mprintf(" with replica temperatures");
-  if (remd_dimension_ > 0) mprintf(", with %i dimensions", remd_dimension_);
+  if (readAccess_) {
+    mprintf(" with %s", CoordInfo().InfoString().c_str());
+    if (useVelAsCoords_) mprintf(" (using velocities as coordinates)");
+    if (useFrcAsCoords_) mprintf(" (using forces as coordinates)");
+    if (remd_dimension_ > 0) mprintf(", %i replica dimensions", remd_dimension_);
+  } 
 }
 #endif
 #endif

--- a/src/TrajinList.cpp
+++ b/src/TrajinList.cpp
@@ -85,6 +85,7 @@ int TrajinList::AddEnsembleIn(std::string const& fname, Topology* topIn, ArgList
       err++;
       continue;
     }
+    if (args.CheckForMoreArgs()) return 1;
     // Currently all input ensembles must be same size.
     if (ensembleSize_ == -1)
       ensembleSize_ = ensemble->EnsembleCoordInfo().EnsembleSize();
@@ -158,6 +159,7 @@ int TrajinList::AddTrajin(std::string const& fname, Topology* topIn, ArgList con
       err++;
       continue;
     }
+    if (args.CheckForMoreArgs()) return 1;
     // Add to trajin list and update # of frames.
     trajin_.push_back( traj );
     UpdateMaxFrames( traj->Traj() );

--- a/src/Trajin_Multi.cpp
+++ b/src/Trajin_Multi.cpp
@@ -105,14 +105,17 @@ int Trajin_Multi::SetupTrajRead(FileName const& tnameIn, ArgList& argIn, Topolog
         for (int dim = 0; dim != Rdim.Ndims(); dim++)
         {
           ReplicaInfo::Map<double> dMap;
-          mprintf("Initial %s values:", Rdim.Description(dim));
-          for (std::vector<double>::const_iterator it = DimValues[dim].begin();
-                                                   it != DimValues[dim].end(); ++it)
-            mprintf(" %g", *it);
-          mprintf("\n");
+          if (debug_ > 0) {
+            mprintf("DEBUG: Initial %s values:", Rdim.Description(dim));
+            for (std::vector<double>::const_iterator it = DimValues[dim].begin();
+                                                     it != DimValues[dim].end(); ++it)
+              mprintf(" %g", *it);
+            mprintf("\n");
+          }
           dMap.CreateMap(DimValues[dim], false);
           int tIdx = dMap.FindIndex( remdtrajval[dim] );
-          mprintf("\tTARGET INDEX for %g is %i\n", remdtrajval[dim], tIdx);
+          mprintf("\tTarget index for '%s' value %g is %i\n", Rdim.Description(dim),
+                  remdtrajval[dim], tIdx+1);
           if (tIdx < 0) {
             mprinterr("Error: Value %g not found in input ensemble for '%s' dimension (%i)\n",
                       remdtrajval[dim], Rdim.Description(dim), dim);

--- a/src/Trajin_Multi.cpp
+++ b/src/Trajin_Multi.cpp
@@ -20,7 +20,9 @@ int Trajin_Multi::SetupTrajRead(FileName const& tnameIn, ArgList& argIn, Topolog
     mprinterr("%s", TrajIOarray::DEPRECATED_remdout);
     return 1;
   }
+  targetType_ = ReplicaInfo::NONE;
   // Process REMD-specific arguments
+  std::vector<double> remdtrajval;
   if (argIn.Contains("remdtrajidx")) {
     // Looking for specific indices
     ArgList indicesArg(argIn.GetStringKey("remdtrajidx"), ",");
@@ -34,6 +36,17 @@ int Trajin_Multi::SetupTrajRead(FileName const& tnameIn, ArgList& argIn, Topolog
                                  arg != indicesArg.end(); ++arg)
       remdtrajidx_.push_back( convertToInteger( *arg ) );
     targetType_ = ReplicaInfo::INDICES;
+  } else if (argIn.Contains("remdtrajvalues")) {
+    // Looking for target values
+    ArgList valuesArg(argIn.GetStringKey("remdtrajvalues"), ",");
+    if (valuesArg.empty()) {
+      mprinterr("Error: remdtrajvalues expects comma-separated list of target values in each\n"
+                "Error: dimension, '<dim1 val>,<dim2 val>,...,<dimN val>`.\n");
+      return 1;
+    }
+    for (ArgList::const_iterator arg = valuesArg.begin(); // TODO validDouble?
+                                 arg != valuesArg.end(); ++arg)
+      remdtrajval.push_back( convertToDouble( *arg ) );
   } else if (argIn.Contains("remdtrajtemp")) {
     // Looking for target temperature
     remdtrajtemp_ = argIn.getKeyDouble("remdtrajtemp",0.0);
@@ -45,18 +58,104 @@ int Trajin_Multi::SetupTrajRead(FileName const& tnameIn, ArgList& argIn, Topolog
   // Set up TrajectoryIO classes for all file names.
   if (REMDtraj_.SetupIOarray(argIn, SetTraj().Counter(), cInfo_, Traj().Parm())) return 1;
 
-  // Check that replica dimension valid for desired indices.
-  if (targetType_ == ReplicaInfo::INDICES && 
-      cInfo_.ReplicaDimensions().Ndims() != (int)remdtrajidx_.size())
-  {
-    mprinterr("Error: Replica # of dim (%i) not equal to target # dim (%zu)\n",
-              cInfo_.ReplicaDimensions().Ndims(), remdtrajidx_.size());
-    return 1;
+  // Additional setup for replica values.
+  if (cInfo_.UseRemdValues()) {
+    if (!remdtrajval.empty()) {
+      // 'remdtrajvalues' specified.
+      if (!remdtrajidx_.empty()) {
+        mprinterr("Error: Specify either 'remdtrajvalues' or 'remdtrajidx', not both.\n");
+        return 1;
+      }
+      if (cInfo_.HasReplicaDims()) {
+        // Multiple dimensions.
+        ReplicaDimArray const& Rdim = cInfo_.ReplicaDimensions();
+        if (Rdim.Ndims() != (int)remdtrajval.size()) {
+          mprinterr("Error: Replica # of dim (%i) not equal to target # dim (%zu)\n",
+                    Rdim.Ndims(), remdtrajval.size());
+          return 1;
+        }
+        // Get initial values from each trajectory.
+        std::vector< std::vector<double> > DimValues( Rdim.Ndims() );
+        Frame frameIn;
+        frameIn.SetupFrameV( tparmIn->Atoms(), cInfo_ );
+        if (BeginTraj()) return 1;
+        for (TrajIOarray::const_iterator rep = REMDtraj_.begin(); rep != REMDtraj_.end(); ++rep)
+        {
+          if ( (*rep)->readFrame(0, frameIn)) return 1;
+          for (int dim = 0; dim != Rdim.Ndims(); dim++) {
+            switch (Rdim.DimType(dim)) {
+              case ReplicaDimArray::TEMPERATURE :
+                DimValues[dim].push_back( frameIn.Temperature() ); break;
+              case ReplicaDimArray::PH          :
+                DimValues[dim].push_back( frameIn.pH()          ); break;
+              case ReplicaDimArray::REDOX       :
+                DimValues[dim].push_back( frameIn.RedOx()       ); break;
+              case ReplicaDimArray::RXSGLD      :
+                DimValues[dim].push_back( frameIn.Temperature() ); break;
+              default:
+                mprinterr("Error: Dimension '%s' not supported by remdtrajvalues.\n"
+                          "Error: Use 'remdtrajidx' instead.\n", Rdim.Description(dim));
+                return 1;
+            }
+          }
+        }
+        EndTraj();
+        // Determine index of target value in each dimension
+        for (int dim = 0; dim != Rdim.Ndims(); dim++)
+        {
+          ReplicaInfo::Map<double> dMap;
+          mprintf("Initial %s values:", Rdim.Description(dim));
+          for (std::vector<double>::const_iterator it = DimValues[dim].begin();
+                                                   it != DimValues[dim].end(); ++it)
+            mprintf(" %g", *it);
+          mprintf("\n");
+          dMap.CreateMap(DimValues[dim], false);
+          int tIdx = dMap.FindIndex( remdtrajval[dim] );
+          mprintf("\tTARGET INDEX for %g is %i\n", remdtrajval[dim], tIdx);
+          if (tIdx < 0) {
+            mprinterr("Error: Value %g not found in input ensemble for '%s' dimension (%i)\n",
+                      remdtrajval[dim], Rdim.Description(dim), dim);
+            mprinterr("Error: Potential values are:");
+            for (ReplicaInfo::Map<double>::const_iterator it = dMap.begin();
+                                                          it != dMap.end(); ++it)
+              mprinterr(" %g", *it);
+            mprinterr("\n");
+            return 1;
+          }
+          // Replica index arguments start from 1
+          remdtrajidx_.push_back( tIdx+1 );
+        }
+        targetType_ = ReplicaInfo::INDICES;
+      } else {
+        // Single dimension.
+        // FIXME assuming temperature
+        remdtrajtemp_ = remdtrajval.front();
+        targetType_ = ReplicaInfo::TEMP;
+      }
+    }
+  } else {
+    // 'remdtrajvalues' not valid when values not present.
+    if (!remdtrajval.empty()) {
+      mprinterr("Error: 'remdtrajvalues' specified but trajectories do not contain replica values.\n");
+      return 1;
+    }
+    // Check that replica dimension valid for desired indices.
+    if (targetType_ == ReplicaInfo::INDICES &&
+        cInfo_.ReplicaDimensions().Ndims() != (int)remdtrajidx_.size())
+    {
+      mprinterr("Error: Replica # of dim (%i) not equal to target # dim (%zu)\n",
+                cInfo_.ReplicaDimensions().Ndims(), remdtrajidx_.size());
+      return 1;
+    }
+    // If target type is temperature make sure there is temperature info.
+    if (targetType_ == ReplicaInfo::TEMP && !cInfo_.HasTemp()) {
+      mprinterr("Error: Some or all replicas are missing temperature info.\n");
+      return 1;
+    }
   }
-
-  // If target type is temperature make sure there is temperature info.
-  if (targetType_ == ReplicaInfo::TEMP && !cInfo_.HasTemp()) {
-    mprinterr("Error: Some or all replicas are missing temperature info.\n");
+  if (targetType_ == ReplicaInfo::NONE) {
+    mprinterr("Error: With 'remdtraj' must specify either 'remdtrajtemp',\n"
+              "Error: 'remdtrajidx', or 'remdtrajvalues'\n");
     return 1;
   }
 
@@ -98,7 +197,7 @@ int Trajin_Multi::ReadTrajFrame( int currentFrame, Frame& frameIn ) {
       if ( (*rep)->readFrame(currentFrame, frameIn)) return 1;
       if ( frameIn.Temperature() == remdtrajtemp_ ) { replicaFound = true; break; }
     }
-  } else { // Indices
+  } else {
     // Find target indices.
     for (TrajIOarray::const_iterator rep = REMDtraj_.begin(); rep != REMDtraj_.end(); ++rep)
     {
@@ -116,9 +215,13 @@ int Trajin_Multi::ReadTrajFrame( int currentFrame, Frame& frameIn ) {
   }
 
   if (!replicaFound) {
-    mprinterr("Error: Target replica not found. Check that all replica trajectories\n"
-              "Error:   were found and that the target temperature or indices are valid\n"
-              "Error:   for this ensemble.\n");
+    mprinterr("Error: Target replica not found, frame %i.\n", currentFrame+1);
+    mprinterr("Error: Check that all replica trajectories were found and that\n");
+    if (targetType_ == ReplicaInfo::TEMP)
+      mprinterr("Error:  target temperature is valid");
+    else
+      mprinterr("Error:  target indices are valid");
+    mprinterr(" for this ensemble.\n");
     return 1; 
   }
   return 0;

--- a/src/Trajin_Multi.cpp
+++ b/src/Trajin_Multi.cpp
@@ -15,6 +15,7 @@ int Trajin_Multi::SetupTrajRead(FileName const& tnameIn, ArgList& argIn, Topolog
   // Set file name and topology pointer.
   if (SetTraj().SetNameAndParm(tnameIn, tparmIn)) return 1;
   REMDtraj_.ClearIOarray();
+  REMDtraj_.SetDebug( debug_ );
   // Check for deprecated args
   if (argIn.hasKey("remdout")) {
     mprinterr("%s", TrajIOarray::DEPRECATED_remdout);

--- a/src/Trajout_Single.cpp
+++ b/src/Trajout_Single.cpp
@@ -93,6 +93,7 @@ int Trajout_Single::InitTrajout(FileName const& tnameIn, ArgList const& argIn,
     mprinterr("Error: trajout %s: Could not process arguments.\n", traj_.Filename().full());
     return 1;
   }
+  if (trajout_args.CheckForMoreArgs()) return 1;
   // Write is set up for topology in SetupTrajWrite 
   return 0;
 }

--- a/src/Trajout_Single.cpp
+++ b/src/Trajout_Single.cpp
@@ -93,7 +93,6 @@ int Trajout_Single::InitTrajout(FileName const& tnameIn, ArgList const& argIn,
     mprinterr("Error: trajout %s: Could not process arguments.\n", traj_.Filename().full());
     return 1;
   }
-  if (trajout_args.CheckForMoreArgs()) return 1;
   // Write is set up for topology in SetupTrajWrite 
   return 0;
 }

--- a/src/Trajout_Single.h
+++ b/src/Trajout_Single.h
@@ -12,6 +12,7 @@
 // FIXME: Should open state be tracked and error given if setup called
 //        twice for already open traj? Should append be default if
 //        traj is opened twice?
+// FIXME: Should take ArgList&, not const, so we can determine if there are unknown args later.
 class Trajout_Single {
   public:
     Trajout_Single() : trajio_(0), debug_(0) {}

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -231,11 +231,11 @@ NcTest() {
       # the regular expression to ndiff.awk FS without the interpreter giving
       # this error for FS='[ \t,()]':
       # awk: fatal: Invalid regular expression: /'[/
-      $CPPTRAJ_NCDUMP -n nctest $F1 | grep -v "==>\|:programVersion" | sed 's/,/ /g' > nc0.save
-      $CPPTRAJ_NCDUMP -n nctest $F2 | grep -v "==>\|:programVersion" | sed 's/,/ /g' > nc0
+      $CPPTRAJ_NCDUMP -n nctest $F1 | grep -v "==>\|:program" | sed 's/,/ /g' > nc0.save
+      $CPPTRAJ_NCDUMP -n nctest $F2 | grep -v "==>\|:program" | sed 's/,/ /g' > nc0
     else
-      $CPPTRAJ_NCDUMP -n nctest $F1 | grep -v "==>\|:programVersion" > nc0.save
-      $CPPTRAJ_NCDUMP -n nctest $F2 | grep -v "==>\|:programVersion" > nc0
+      $CPPTRAJ_NCDUMP -n nctest $F1 | grep -v "==>\|:program" > nc0.save
+      $CPPTRAJ_NCDUMP -n nctest $F2 | grep -v "==>\|:program" > nc0
     fi
     DoTest $DIFFARGS 
     $CPPTRAJ_RM nc0.save nc0

--- a/test/Test_GromacsXtc/RunTest.sh
+++ b/test/Test_GromacsXtc/RunTest.sh
@@ -58,7 +58,7 @@ EOF
     cat > ptraj.in <<EOF
 parm ../tz2.truncoct.parm7
 trajin ../tz2.truncoct.crd 6 10
-trajout mop.xtc stc append
+trajout mop.xtc xtc append
 EOF
     RunCpptraj "CRD(6-10) => XTC"
     cat > ptraj.in <<EOF

--- a/test/Test_RemdTraj/RunTest.sh
+++ b/test/Test_RemdTraj/RunTest.sh
@@ -64,7 +64,7 @@ EOF
   cat > remd.in <<EOF
 noprogress
 parm ala2.99sb.mbondi2.parm7 
-ensemble rem.crd.000 remdtraj remdtrajtemp 492.20 
+ensemble rem.crd.000
 trajout temp.crd 
 distance d1 out d1.ensemble.dat @1 @21
 EOF


### PR DESCRIPTION
This PR adds full support for the new remd_values field in NetCDF trajectories, as well as remd_repidx and remd_crdidx (overall replica and coordinate indices). To support this more completely the `trajin remdtraj` functionality now has a new keyword, `remdtrajvalues <list>` which can be used to specify values that frames should be extracted at (as opposed to indices). For example, if given a trajectory containing information from 3 replica dimensions, RedOx, pH, and Temperature, then `remdtraj remdtrajvalues 0.2,6.0,300` would extract frames at RedOx potential 0.2, pH 6.0, and temperature 300. Tested and working in parallel as well. Lots of behind-the-scenes cleanup of the NetcdfFile class related to this.

This PR also fixes a bug in writing DCD trajectories in parallel where the type of unit cell was not being properly broadcast leading to incorrect box values being written.