### PR TITLE
Add detailed Run phase timings in parallel when TIMER defined.

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -18,5 +18,5 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.3.8"
+#define CPPTRAJ_INTERNAL_VERSION "V4.3.9"
 #endif


### PR DESCRIPTION
For testing purposes. Similar to serial runs, in across-trajectory parallel runs each thread will now report timing breakdowns for trajectory read, action, and trajectory write.