### PR TITLE
Negative input trajectory start argument now means "# of frames before"

### DIFF
--- a/src/TrajFrameCounter.cpp
+++ b/src/TrajFrameCounter.cpp
@@ -49,9 +49,25 @@ int TrajFrameCounter::CheckFrameArgs(int nframes, ArgList &argIn) {
   }
   // Check that start argument is valid.
   if (start_ != 1) {
-    if (start_ < 1) {
-      mprintf("Warning: start argument %i < 1, setting to 1.\n", start_);
+    if (start_ == 0) {
+      mprintf("Warning: start argument is 0, setting to 1.\n", start_);
       start_ = 1; //start_ = 0;
+    } else if (start_ < 0) {
+      // Negative start means we want that many frames before stop
+      if (stop_ == -1) {
+        if (total_frames_ >=0)
+          stop_ = total_frames_;
+        else {
+          mprinterr("Error: For start < 0, stop argument must be specified when # frames unknown.\n");
+          return 1;
+        }
+      }
+      mprintf("\tStarting %i frames before frame %i\n", -start_, stop_);
+      start_ = stop_ + start_;
+      if (start_ < 1) {
+        mprintf("Warning: would start before frame 1, setting start to 1.\n");
+        start_ = 1;
+      }
     } else if (total_frames_ >= 0 && start_ > total_frames_) {
       // start_==stop_ and greater than # frames, archaic 'lastframe'.
       if (start_ == stop_) {

--- a/src/Version.h
+++ b/src/Version.h
@@ -20,5 +20,5 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.4.0"
+#define CPPTRAJ_INTERNAL_VERSION "V4.4.1"
 #endif

--- a/test/Test_TrajinOffset/RunTest.sh
+++ b/test/Test_TrajinOffset/RunTest.sh
@@ -3,7 +3,8 @@
 . ../MasterTest.sh
 
 # Clean
-CleanFiles cpptraj.offset.in rem.crd.combined gzip.rem.crd.combined bzip2.rem.crd.combined
+CleanFiles cpptraj.offset.in rem.crd.combined gzip.rem.crd.combined \
+           bzip2.rem.crd.combined phi.dat.save phi.dat
 
 TESTNAME='Trajectory read with offset tests'
 Requires maxthreads 13
@@ -53,9 +54,23 @@ trajin rem.crd.003.bz2 1 10 5
 trajout bzip2.rem.crd.combined 
 EOF
   INPUT="-i cpptraj.offset.in"
-  RunCpptraj "Bzip2ed trajectory read with offsets."
+  RunCpptraj "$UNITNAME"
   DoTest rem.crd.save bzip2.rem.crd.combined
 fi
+
+# Test 4
+UNITNAME='Start argument offset'
+cat > cpptraj.offset.in <<EOF
+parm ala2.99sb.mbondi2.parm7
+trajin rem.crd.000 5 10
+dihedral phi0 :1@C :2@N :2@CA :2@C out phi.dat.save noheader
+run
+clear trajin
+trajin rem.crd.000 -5
+dihedral phi1 :1@C :2@N :2@CA :2@C out phi.dat noheader
+EOF
+RunCpptraj "$UNITNAME"
+DoTest phi.dat.save phi.dat
 
 EndTest
 


### PR DESCRIPTION
The `<start>` argument for `trajin` and `ensemble` can now be negative. When it is, it means "Start `<start>` frames before `<stop>`". Also add a test for this functionality. Addresses #553.