### PR TITLE
Add missing NetCDF restart separate force/velocity read routines.

### DIFF
--- a/src/Traj_AmberRestartNC.cpp
+++ b/src/Traj_AmberRestartNC.cpp
@@ -206,6 +206,39 @@ int Traj_AmberRestartNC::readFrame(int set, Frame& frameIn) {
   return 0;
 }
 
+// Traj_AmberRestartNC::readVelocity()
+int Traj_AmberRestartNC::readVelocity(int set, Frame& frameIn) {
+  start_[0] = 0;
+  start_[1] = 0;
+  count_[0] = Ncatom();
+  count_[1] = 3;
+  // Read Velocity
+  if (velocityVID_!=-1 && frameIn.HasVelocity()) {
+    if (NC::CheckErr(nc_get_vara_double(ncid_, velocityVID_, start_, count_, frameIn.vAddress())))
+    {
+      mprinterr("Error: Getting velocities, frame %i.\n", set+1);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+// Traj_AmberRestartNC::readForce()
+int Traj_AmberRestartNC::readForce(int set, Frame& frameIn) {
+  start_[0] = 0;
+  start_[1] = 0;
+  count_[0] = Ncatom();
+  count_[1] = 3;
+  // Read Force
+  if (frcVID_ != -1 && frameIn.HasForce()) {
+    if ( NC::CheckErr(nc_get_vara_double(ncid_, frcVID_, start_, count_, frameIn.fAddress())) ) {
+      mprinterr("Error: Getting forces, frame %i\n", set+1);
+      return 1;
+    }
+  }
+  return 0;
+}
+
 // Traj_AmberRestartNC::writeFrame() 
 int Traj_AmberRestartNC::writeFrame(int set, Frame const& frameOut) {
   // Set up file for this set

--- a/src/Traj_AmberRestartNC.h
+++ b/src/Traj_AmberRestartNC.h
@@ -19,6 +19,8 @@ class Traj_AmberRestartNC : public TrajectoryIO, private NetcdfFile {
     int openTrajin();
     void closeTraj();
     int readFrame(int,Frame&);
+    int readVelocity(int, Frame&);
+    int readForce(int, Frame&);
     int writeFrame(int,Frame const&);
     int processWriteArgs(ArgList&);
     int processReadArgs(ArgList&);
@@ -43,9 +45,6 @@ class Traj_AmberRestartNC : public TrajectoryIO, private NetcdfFile {
     bool readAccess_;
     bool prependExt_;
     FileName filename_;
-
-    int readVelocity(int, Frame&) { return 1; }
-    int readForce(int, Frame&)    { return 1; }
 };
 #endif
 #endif

--- a/src/Version.h
+++ b/src/Version.h
@@ -20,5 +20,5 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.8.0"
+#define CPPTRAJ_INTERNAL_VERSION "V4.8.1"
 #endif


### PR DESCRIPTION
For use with e.g. the `mdvel` and `mdfrc` keywords for the `trajin` command. This should have been part of #631 (addressing #630).