### PR TITLE
Fix potential PME issue. Improve configure for math libraries/FFTW

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ UsageFull() {
   echo "    -nolfs     : Do not enable large file support."
   echo "    -shared    : Configure for generating libcpptraj (implies -nosanderlib)."
   echo "    -fftw3     : Use FFTW instead of pubfft for FFT."
-  echo "    -windows   : Set up for use with MinGW compilers for a native Windows build"
+  echo "    -windows   : Set up for use with MinGW compilers for a native Windows build."
   echo "  LIBRARY OPTIONS"
   echo "    -<lib>             : Enable library."
   echo "    --with-<lib>=<DIR> : Use library in specified directory."
@@ -51,9 +51,10 @@ UsageFull() {
   echo "    -static        : Use static linking."
   echo "    -libstatic     : Use static linking only for specified libraries."
   echo "    -mkl           : Use Intel MKL for BLAS/LAPACK (requires MKL_HOME/MKLROOT set)."
-  echo "    -openblas      : Use OpenBLAS for BLAS/LAPACK/ARPACK (may require '--with-blas' or '-lblas')"
-  echo "    -macAccelerate : Use Accelerate framework for BLAS/LAPACK"
-  echo "    -libsci        : Use Cray LibSci for BLAS/LAPACK"
+  echo "    -openblas      : Use OpenBLAS for BLAS/LAPACK (may require '--with-blas' or '-lblas')."
+  echo "                     May also want to specify '-larpack' if included in OpenBLAS."
+  echo "    -macAccelerate : Use Accelerate framework for BLAS/LAPACK."
+  echo "    -libsci        : Use Cray LibSci for BLAS/LAPACK."
   echo "  ENVIRONMENT VARIABLES (can also be passed to configure as <VAR>=<VALUE>):"
   echo "    CXX          : Name of the C++ compiler."
   echo "    CC           : Name of the C compiler."
@@ -84,7 +85,7 @@ UsageFull() {
   echo "    --compile-verbose : Turn on compile details."
   echo "    -profile          : Use Gnu compiler profiling (>= V4.5)*"
   echo "    -gprofile         : Use Gnu compiler GLIBC profiling (>= V4.5)*"
-  echo "    -vtune            : Enable options for use with Intel Vtune"
+  echo "    -vtune            : Enable options for use with Intel Vtune."
   echo "    -single-ensemble  : Enable support for reading/writing single ensemble trajectories."
   echo ""
   echo "*NOTE: -profile and -gprofile are mutually exclusive."
@@ -1094,6 +1095,7 @@ SetupProfiling() {
 #-------------------------------------------------------------------------------
 # Basic compiler tests
 TestCompilers() {
+  echo ""
   # C++ OpenMP
   if [ $USE_OPENMP -eq 1 ] ; then
     cat > testp.cpp <<EOF

--- a/configure
+++ b/configure
@@ -51,7 +51,7 @@ UsageFull() {
   echo "    -static        : Use static linking."
   echo "    -libstatic     : Use static linking only for specified libraries."
   echo "    -mkl           : Use Intel MKL for BLAS/LAPACK (requires MKL_HOME/MKLROOT set)."
-  echo "    -openblas      : Use OpenBLAS for BLAS/LAPACK/ARPACK (may require '--with-blas')"
+  echo "    -openblas      : Use OpenBLAS for BLAS/LAPACK/ARPACK (may require '--with-blas' or '-lblas')"
   echo "    -macAccelerate : Use Accelerate framework for BLAS/LAPACK"
   echo "    -libsci        : Use Cray LibSci for BLAS/LAPACK"
   echo "  ENVIRONMENT VARIABLES (can also be passed to configure as <VAR>=<VALUE>):"
@@ -346,7 +346,7 @@ TestProgram() {
   if [ $? -ne 0 ] ; then
     if [ $silent -eq 0 ] ; then
       echo ""
-      echo "Compile failed: $COMPILELINE" > /dev/stderr
+      echo "Test compile failed: $COMPILELINE" > /dev/stderr
       echo "Error follows:" > /dev/stderr
       cat compile.err > /dev/stderr
       exit 1
@@ -359,7 +359,7 @@ TestProgram() {
     ./testp > /dev/null
     if [ $? -ne 0 ] ; then
       echo ""
-      echo "Program failed, compiled with: $COMPILELINE" > /dev/stderr
+      echo "Run of test program failed, compiled with: $COMPILELINE" > /dev/stderr
       exit 1
     fi
   fi
@@ -685,11 +685,16 @@ SetupLibraries() {
     LIB_STAT[$LLAPACK]='off'
     LIB_FLAG[$LLAPACK]=''
   elif [ "$BLAS_TYPE" = 'openblas' ] ; then
-    LIB_FLAG[$LBLAS]='-lopenblas'
+    if [ "${LIB_STAT[$LBLAS]}" != 'direct' ] ; then
+      LIB_FLAG[$LBLAS]='-lopenblas'
+    fi
+    if [ -z "${LIB_HOME[$LBLAS]}" ] ; then
+      echo "Warning: '-openblas' may require specifying location with '--with-blas=<DIR>' or '-lblas='"
+    fi
     LIB_STAT[$LLAPACK]='off'
     LIB_FLAG[$LLAPACK]=''
-    LIB_STAT[$LARPACK]='enabled'
-    LIB_HOME[$LARPACK]=''
+    #LIB_STAT[$LARPACK]='enabled' DBG
+    #LIB_HOME[$LARPACK]='' DBG
   elif [ "$BLAS_TYPE" = 'macAccelerate' ] ; then
     LIB_FLAG[$LBLAS]='-framework Accelerate'
     LIB_STAT[$LLAPACK]='off'

--- a/configure
+++ b/configure
@@ -439,7 +439,7 @@ DetermineFlink() {
       else
         report='quiet'
       fi
-      echo "DEBUG: Testing flink $use_flink pthread $use_pthread $report"
+      #echo "DEBUG: Testing $desc flink $use_flink pthread $use_pthread $report"
       TestProgram $report "$desc" "$CXX" "$CXXFLAGS" testp.cpp "$libs_to_use"
       if [ $? -eq 0 ] ; then
         # Compile/run worked.
@@ -453,6 +453,7 @@ DetermineFlink() {
         if [ "$report" = 'quiet' ] ; then
           echo "$desc: OK"
         fi
+        return 0
       fi
     done
   done
@@ -460,6 +461,7 @@ DetermineFlink() {
     # Sanity check. Should not make it here.
     exit 1
   fi
+  return 0
 }
     
 TestMathlib() {

--- a/configure
+++ b/configure
@@ -51,6 +51,7 @@ UsageFull() {
   echo "    -static        : Use static linking."
   echo "    -libstatic     : Use static linking only for specified libraries."
   echo "    -mkl           : Use Intel MKL for BLAS/LAPACK (requires MKL_HOME/MKLROOT set)."
+  echo "    -nomklfftw     : Prevent use of FFTW from MKL."
   echo "    -openblas      : Use OpenBLAS for BLAS/LAPACK (may require '--with-blas' or '-lblas')."
   echo "                     May also want to specify '-larpack' if included in OpenBLAS."
   echo "    -macAccelerate : Use Accelerate framework for BLAS/LAPACK."
@@ -114,7 +115,7 @@ USE_CUDA=0        # 0 = no CUDA, 1 = CUDA
 USE_OPT=1         # 0 = no optimization, 1 = use compiler optimizations, 2 = optimize/tune.
 BLAS_TYPE='other' # other=normal BLAS, mkl, libsci (cray) etc
 MKL_TYPE='mkl'    # mkl = -mkl for Intel compilers, line = link-line advisor style
-MKL_FFTW=''       # If yes, use FFTW from MKL if not otherwise specified.
+MKL_FFTW=''       # If yes, use FFTW from MKL if not otherwise specified. If 'no' prevent this.
 USE_DEBUG=0       # 0 = no debug info, 1 = enable compiler debug info
 USE_STATIC=0      # 0 = dynamic linking, 1 = static linking, 2 = static link for specified libraries
 USE_SHARED=0      # 1 = Use flag for position-independent code (required for libcpptraj)
@@ -1238,7 +1239,7 @@ SetupMKL() {
   LIB_STAT[$LLAPACK]='off'
   LIB_FLAG[$LLAPACK]=''
   # If no FFTW, try using MKL
-  if [ "${LIB_STAT[$LFFTW3]}" = 'off' ] ; then
+  if [ "${LIB_STAT[$LFFTW3]}" = 'off' -a "$MKL_FFTW" != 'no' ] ; then
     MKL_FFTW='yes'
     LIB_STAT[$LFFTW3]='enabled'
     LIB_FLAG[$LFFTW3]=''
@@ -1518,6 +1519,7 @@ while [ ! -z "$1" ] ; do
     '-cuda'          ) SetupCUDA ;;
     '-cray'          ) PLATFORM='cray' ;;
     '-mkl'           ) BLAS_TYPE='mkl' ;;
+    '-nomklfftw'     ) MKL_FFTW='no' ;;
     '-libsci'        ) BLAS_TYPE='libsci' ;;
     '-openblas'      ) BLAS_TYPE='openblas' ;;
     '-macAccelerate' ) BLAS_TYPE='macAccelerate' ;;

--- a/configure
+++ b/configure
@@ -1824,7 +1824,7 @@ EXE=$EXE
 
 EOF
 if [ $COMPILE_VERBOSE -eq 1 ] ; then
-  cat >> config.h <<EOF
+  cat > buildrules.h <<EOF
 .cpp.o:
 	\$(CXX) \$(DIRECTIVES) \$(INCLUDE) \$(CXXFLAGS) -c -o \$@ \$<
 
@@ -1832,7 +1832,7 @@ if [ $COMPILE_VERBOSE -eq 1 ] ; then
 	\$(CC) \$(DIRECTIVES) \$(INCLUDE) \$(CFLAGS) -c -o \$@ \$<
 EOF
 else
-  cat >> config.h <<EOF
+  cat > buildrules.h <<EOF
 .cpp.o:
 	@echo CXX \$<
 	@\$(CXX) \$(DIRECTIVES) \$(INCLUDE) \$(CXXFLAGS) -c -o \$@ \$<

--- a/configure
+++ b/configure
@@ -880,20 +880,22 @@ SetupCompilers() {
   if [ ! -z "$FC"  ] ; then echo "Fortran compiler (FC) set to $FC" ; fi
   # If no compiler type specified try to guess
   if [ -z "$COMPILERS" -o ! -z "$CXX" ] ; then
-    echo "Determining compilers from CXX ($CXX)"
-    SPECIFIED_COMPILER=$COMPILERS
-    case "$CXX" in
-      *g++*     ) COMPILERS='gnu' ;;
-      *clang++* ) COMPILERS='clang' ;;
-      *icpc*    ) COMPILERS='intel' ;;
-      *pgc++*   ) COMPILERS='pgi' ;;
-      *CC*      ) COMPILERS='cray' ;;
-      * ) echo "Warning: Could not detect compiler type ($CXX); assuming GNU" > /dev/stderr;;
-    esac
-    # If compiler was also specified make sure it matches as a sanity check
-    if [ ! -z "$SPECIFIED_COMPILER" -a "$SPECIFIED_COMPILER" != "$COMPILERS" ] ; then
-      echo "Error: $SPECIFIED_COMPILER compilers specified but need $COMPILERS based on CXX = $CXX" > /dev/stderr
-      exit 1
+    if [ ! -z "$CXX" ] ; then
+      SPECIFIED_COMPILER=$COMPILERS
+      echo "Determining compilers from CXX ($CXX)"
+      case "$CXX" in
+        *g++*     ) COMPILERS='gnu' ;;
+        *clang++* ) COMPILERS='clang' ;;
+        *icpc*    ) COMPILERS='intel' ;;
+        *pgc++*   ) COMPILERS='pgi' ;;
+        *CC*      ) COMPILERS='cray' ;;
+        * ) echo "Warning: Could not detect compiler type ($CXX); assuming GNU" > /dev/stderr;;
+      esac
+      # If compiler was also specified make sure it matches as a sanity check
+      if [ ! -z "$SPECIFIED_COMPILER" -a "$SPECIFIED_COMPILER" != "$COMPILERS" ] ; then
+        echo "Error: $SPECIFIED_COMPILER compilers specified but need $COMPILERS based on CXX = $CXX" > /dev/stderr
+        exit 1
+      fi
     fi
   fi
   # If still no compiler default to gnu

--- a/configure
+++ b/configure
@@ -290,6 +290,10 @@ CheckLibraryKeys() {
   for ((i=0; i < $NLIB; i++)) ; do
     LKEY="-"${LIB_CKEY[$i]}
     if [ "$1" = "$LKEY" ] ; then
+      # If previously bundled, clear home
+      if [ "${LIB_STAT[$i]}" = 'bundled' ] ; then
+        LIB_HOME[$i]=''
+      fi
       LIB_STAT[$i]='enabled'
       echo "  ${LIB_CKEY[$i]} enabled."
       return 0
@@ -753,6 +757,7 @@ SetupLibraries() {
     lhome=''
     linc=''
     lflag=''
+    #echo "DEBUG: ${LIB_CKEY[$i]} flag=${LIB_FLAG[$i]} stat=${LIB_STAT[$i]} home=${LIB_HOME[$i]}"
     if [ "${LIB_STAT[$i]}" = 'off' ] ; then
       #echo "${LIB_CKEY[$i]} disabled." # DEBUG
       LIB_TEST[$i]='no'

--- a/configure
+++ b/configure
@@ -93,9 +93,10 @@ UsageFull() {
 }
 
 # ----- Script variables -------------------------------------------------------
-COMPILERS=''      # User-specified compiler suite to use.
-FLINK=''          # Flag for linking in Fortran code
-REQUIRES_FLINK=0  # If 1 FLINK flag required during link phase
+COMPILERS=''       # User-specified compiler suite to use.
+FLINK=''           # Flag for linking in Fortran code
+REQUIRES_FLINK=0   # If 1 FLINK flag required during link phase
+REQUIRES_PTHREAD=0 # If 1 -lpthread required during link phase
 C11FLAG=''        # Flag for compiling C++11 code
 C11_SUPPORT='yes' # Support C++11 code
 SHARED_SUFFIX=''  # Suffix for shared libraries
@@ -415,20 +416,49 @@ EOF
 DetermineFlink() {
   desc="$1"
   flibs="$2"
+  # Do we already need FLINK?
   if [ $REQUIRES_FLINK -eq 0 ] ; then
-    # Try without FLINK
-    TestProgram quiet "$desc" "$CXX" "$CXXFLAGS" testp.cpp "$flibs"
-    if [ $? -eq 1 ] ; then
-      # That failed. Try with FLINK
-      TestProgram "$desc" "$CXX" "$CXXFLAGS" testp.cpp "$flibs $FLINK"
-      REQUIRES_FLINK=1
-    else
-      # That worked. Print OK."
-      echo "$desc: OK"
-    fi
+    flink_opts="no yes"
   else
-    # FLINK already present
-    TestProgram "$desc" "$CXX" "$CXXFLAGS" testp.cpp "$flibs $FLINK"
+    flink_opts="yes"
+  fi
+  # Go through combinations of FLINK/pthread
+  flink_success=0
+  for use_flink in $flink_opts ; do
+    for use_pthread in no yes ; do
+      libs_to_use="$flibs"
+      if [ "$use_flink" = 'yes' ] ; then
+        libs_to_use="$libs_to_use $FLINK"
+      fi
+      if [ "$use_pthread" = 'yes' ] ; then
+        libs_to_use="$libs_to_use -lpthread"
+      fi
+      if [ "$use_flink" = 'yes' -a "$use_pthread" = 'yes' ] ; then
+        # Final try. Report errors here
+        report=''
+      else
+        report='quiet'
+      fi
+      echo "DEBUG: Testing flink $use_flink pthread $use_pthread $report"
+      TestProgram $report "$desc" "$CXX" "$CXXFLAGS" testp.cpp "$libs_to_use"
+      if [ $? -eq 0 ] ; then
+        # Compile/run worked.
+        if [ "$use_flink" = 'yes' ] ; then
+          REQUIRES_FLINK=1
+        fi
+        if [ "$use_pthread" = 'yes' ] ; then
+          REQUIRES_PTHREAD=1
+        fi
+        flink_success=1
+        if [ "$report" = 'quiet' ] ; then
+          echo "$desc: OK"
+        fi
+      fi
+    done
+  done
+  if [ $flink_success -eq 0 ] ; then
+    # Sanity check. Should not make it here.
+    exit 1
   fi
 }
     
@@ -668,6 +698,9 @@ SetupFinalFlags() {
   done
   if [ $REQUIRES_FLINK -eq 1 ] ; then
     CPPTRAJ_LIB="$CPPTRAJ_LIB $FLINK"
+  fi
+  if [ $REQUIRES_PTHREAD -eq 1 ] ; then
+    CPPTRAJ_LIB="$CPPTRAJ_LIB -lpthread"
   fi
   LDFLAGS="$ldf $LDFLAGS"
 }
@@ -1185,6 +1218,8 @@ SetupMKL() {
         mklthread='libmkl_gnu_thread.a'
         mklomp='-lgomp'
       fi
+      # Turn off pthread since we are adding it here.
+      REQUIRES_PTHREAD=0
       mkllib="-L$mkldir $mkllapack $mklblas -Wl,--start-group $mkldir/$mklinterface $mkldir/$mklthread $mkldir/libmkl_core.a -Wl,--end-group $MKLOMP -lpthread -lm -ldl"
     else
       mkllib="-L$mkldir $mkllapack $mklblas -Wl,--start-group $mkldir/$mklinterface $mkldir/libmkl_sequential.a $mkldir/libmkl_core.a -Wl,--end-group -lpthread -lm -ldl"

--- a/configure
+++ b/configure
@@ -738,8 +738,6 @@ SetupLibraries() {
     fi
     LIB_STAT[$LLAPACK]='off'
     LIB_FLAG[$LLAPACK]=''
-    #LIB_STAT[$LARPACK]='enabled' DBG
-    #LIB_HOME[$LARPACK]='' DBG
   elif [ "$BLAS_TYPE" = 'macAccelerate' ] ; then
     LIB_FLAG[$LBLAS]='-framework Accelerate'
     LIB_STAT[$LLAPACK]='off'

--- a/configure
+++ b/configure
@@ -114,6 +114,7 @@ USE_CUDA=0        # 0 = no CUDA, 1 = CUDA
 USE_OPT=1         # 0 = no optimization, 1 = use compiler optimizations, 2 = optimize/tune.
 BLAS_TYPE='other' # other=normal BLAS, mkl, libsci (cray) etc
 MKL_TYPE='mkl'    # mkl = -mkl for Intel compilers, line = link-line advisor style
+MKL_FFTW=''       # If yes, use FFTW from MKL if not otherwise specified.
 USE_DEBUG=0       # 0 = no debug info, 1 = enable compiler debug info
 USE_STATIC=0      # 0 = dynamic linking, 1 = static linking, 2 = static link for specified libraries
 USE_SHARED=0      # 1 = Use flag for position-independent code (required for libcpptraj)
@@ -525,6 +526,9 @@ EOF
       echo "Warning: FFTW3 test failed. CPPTRAJ will be built without FFTW3."
       LIB_STAT[$LFFTW3]='off'
     fi
+  elif [ "$MKL_FFTW" = 'yes' ] ; then
+    # Using FFTW from MKL
+    TestProgram "  Checking FFTW3" "$CXX" "$CXXFLAGS ${LIB_INCL[$LBLAS]}" testp.cpp "${LIB_FLAG[$LBLAS]}"
   else
     TestProgram "  Checking FFTW3" "$CXX" "$CXXFLAGS ${LIB_INCL[$LFFTW3]}" testp.cpp "${LIB_FLAG[$LFFTW3]}"
   fi
@@ -1233,6 +1237,12 @@ SetupMKL() {
   LIB_FLAG[$LBLAS]="$mkllib"
   LIB_STAT[$LLAPACK]='off'
   LIB_FLAG[$LLAPACK]=''
+  # If no FFTW, try using MKL
+  if [ "${LIB_STAT[$LFFTW3]}" = 'off' ] ; then
+    MKL_FFTW='yes'
+    LIB_STAT[$LFFTW3]='enabled'
+    LIB_FLAG[$LFFTW3]=''
+  fi
 }
 
 # ------------------------------------------------------------------------------
@@ -1646,6 +1656,9 @@ if [ $USE_SINGLEENSEMBLE -ne 0 ] ; then
 fi
 echo "  Target platform: $PLATFORM, $NBITS-bit."
 echo "  $COMPILERS compilers in use."
+if [ "$MKL_FFTW" = 'yes' ] ; then
+  echo "  Using FFTW from MKL."
+fi
 if [ "$C11_SUPPORT" = 'yes' ] ; then
   echo "  C++11 support enabled."
   if [ "${LIB_STAT[$LFFTW3]}" = 'off' ] ; then

--- a/configure
+++ b/configure
@@ -733,7 +733,7 @@ SetupLibraries() {
     if [ "${LIB_STAT[$LBLAS]}" != 'direct' ] ; then
       LIB_FLAG[$LBLAS]='-lopenblas'
     fi
-    if [ -z "${LIB_HOME[$LBLAS]}" ] ; then
+    if [ -z "${LIB_HOME[$LBLAS]}" -a "${LIB_STAT[$LBLAS]}" != 'direct' ] ; then
       echo "Warning: '-openblas' may require specifying location with '--with-blas=<DIR>' or '-lblas='"
     fi
     LIB_STAT[$LLAPACK]='off'

--- a/configure
+++ b/configure
@@ -830,17 +830,21 @@ SetupCompilers() {
   if [ ! -z "$CC"  ] ; then echo "C compiler (CC) set to $CC" ; fi
   if [ ! -z "$FC"  ] ; then echo "Fortran compiler (FC) set to $FC" ; fi
   # If no compiler type specified try to guess
-  if [ -z "$COMPILERS" ] ; then
-    if [ ! -z "$CXX" ] ; then
-      echo "Determining compilers from CXX ($CXX)"
-      case "$CXX" in
-        *g++*     ) COMPILERS='gnu' ;;
-        *clang++* ) COMPILERS='clang' ;;
-        *icpc*    ) COMPILERS='intel' ;;
-        *pgc++*   ) COMPILERS='pgi' ;;
-        *CC*      ) COMPILERS='cray' ;;
-        * ) echo "Warning: Could not detect compiler type ($CXX); assuming GNU" > /dev/stderr;;
-      esac
+  if [ -z "$COMPILERS" -o ! -z "$CXX" ] ; then
+    echo "Determining compilers from CXX ($CXX)"
+    SPECIFIED_COMPILER=$COMPILERS
+    case "$CXX" in
+      *g++*     ) COMPILERS='gnu' ;;
+      *clang++* ) COMPILERS='clang' ;;
+      *icpc*    ) COMPILERS='intel' ;;
+      *pgc++*   ) COMPILERS='pgi' ;;
+      *CC*      ) COMPILERS='cray' ;;
+      * ) echo "Warning: Could not detect compiler type ($CXX); assuming GNU" > /dev/stderr;;
+    esac
+    # If compiler was also specified make sure it matches as a sanity check
+    if [ ! -z "$SPECIFIED_COMPILER" -a "$SPECIFIED_COMPILER" != "$COMPILERS" ] ; then
+      echo "Error: $SPECIFIED_COMPILER compilers specified but need $COMPILERS based on CXX = $CXX" > /dev/stderr
+      exit 1
     fi
   fi
   # If still no compiler default to gnu

--- a/src/Action_Energy.cpp
+++ b/src/Action_Energy.cpp
@@ -332,6 +332,14 @@ Action::RetType Action_Energy::Setup(ActionSetup& setup) {
       return Action::ERR;
     EW_->Setup( setup.Top(), Imask_ );
   }
+# ifdef LIBPME
+  else if (elecType_ == PME) {
+    if (((Ewald_ParticleMesh*)EW_)->Init(setup.CoordInfo().TrajBox(), cutoff_, dsumtol_,
+                                         ewcoeff_, skinnb_, erfcDx_, npoints_, debug_, mlimits_))
+      return Action::ERR;
+    EW_->Setup( setup.Top(), Imask_ );
+  }
+# endif
   // For KE, check for velocities/forces
   if (KEtype_ != KE_NONE) {
     if (!setup.CoordInfo().HasVel()) {
@@ -348,14 +356,6 @@ Action::RetType Action_Energy::Setup(ActionSetup& setup) {
               "Warning: 'ketype vv' to estimate kinetic energy.\n");
     }
   }
-# ifdef LIBPME
-  else if (elecType_ == PME) {
-    if (((Ewald_ParticleMesh*)EW_)->Init(setup.CoordInfo().TrajBox(), cutoff_, dsumtol_,
-                                         ewcoeff_, skinnb_, erfcDx_, npoints_, debug_, mlimits_))
-      return Action::ERR;
-    EW_->Setup( setup.Top(), Imask_ );
-  }
-# endif
   currentParm_ = setup.TopAddress();
   return Action::OK;
 }

--- a/src/Action_Pucker.cpp
+++ b/src/Action_Pucker.cpp
@@ -170,6 +170,8 @@ Action::RetType Action_Pucker::DoAction(int frameNum, ActionFrame& frm) {
                         AX_[3].Dptr(), AX_[4].Dptr(), AX_[5].Dptr(), 
                         AX_.size(), aval, tval );
       break;
+    case UNSPECIFIED : // Sanity check
+      return Action::ERR;
   }
   if ( amplitude_ != 0 )
     amplitude_->Add(frameNum, &aval);

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 # Cpptraj standalone Makefile
 include ../config.h
+include ../buildrules.h
 
 include cpptrajfiles
 

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -456,11 +456,6 @@ int Topology::Setup_NoResInfo() {
   return 0;
 }
 
-static inline int NoAtomsErr(const char* msg) {
-  mprinterr("Error: Cannot set up %s, no atoms present.\n");
-  return 1;
-}
-
 // Topology::Resize()
 void Topology::Resize(Pointers const& pIn) {
   atoms_.clear();

--- a/src/TrajoutList.cpp
+++ b/src/TrajoutList.cpp
@@ -74,13 +74,6 @@ int TrajoutList::SetupTrajout(Topology* CurrentParm, CoordinateInfo const& cInfo
   return 0;
 }
 
-static inline void Append(std::string& meta, std::string const& str) {
-  if (meta.empty())
-    meta.assign( str );
-  else
-    meta.append(", " + str);
-}
-
 /** List only active output trajectories. */
 void TrajoutList::ListActive() const {
   if (!trajout_.empty()) {


### PR DESCRIPTION
This PR does 2 things:

1) Fixes a bug where in some cases PME code would not properly be initialized resulting in an error.

2) Improves configure for math libraries and FFTW:
- Libraries are now checked if `-lpthread` is needed.
- CPPTRAJ will now attempt to use FFTW from MKL if the latter is specified and the former is not. Can be disabled with `-nomklfftw`.
- `configure` will now throw an error if CXX is set to one compiler but a different compiler is specified. This could result in errors that were not apparent until the link stage.
- Fix issue where specified BLAS would be overwritten when using `-openblas`.
- ARPACK is no longer automatically pulled in when `-openblas` specified (since it is not always present).