### PR TITLE
Improve configure, more PGI fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,13 @@ before_install:
       brew update;
       brew install netcdf fftw arpack;
       
-      curl -L https://anaconda.org/AmberMD/pysander/16.0/download/osx-64/pysander-16.0-py27_1.tar.bz2 > $HOME/osx_libsander.tar.bz2;
-      tar jxf $HOME/osx_libsander.tar.bz2 lib/libsander.dylib include/sander.h;
-      
+      curl -L https://anaconda.org/AmberMD/amber_phenix/0.9.1/download/osx-64/amber_phenix-0.9.1-0.tar.bz2 > $HOME/osx_amber.tar.bz2;
+      tar jxf $HOME/osx_amber.tar.bz2 lib/libsander.dylib src/sander/sander.h;
+      mkdir -p include && mv src/sander/sander.h include;
     else
-      curl -OL https://anaconda.org/AmberMD/pysander/16.0/download/linux-64/pysander-16.0-py27_1.tar.bz2;
-      tar jxf pysander-16.0-py27_1.tar.bz2 lib/libsander.so include/sander.h;
+      curl -OL https://anaconda.org/AmberMD/amber_phenix/0.9.2/download/linux-64/amber_phenix-0.9.2-0.tar.bz2;
+      tar jxf amber_phenix-0.9.2-0.tar.bz2 lib/libsander.so src/sander/sander.h;
+      mkdir -p include && mv src/sander/sander.h include;
     fi
   - mv lib include $HOME
 

--- a/configure
+++ b/configure
@@ -847,7 +847,7 @@ SetupLibraries() {
           else
             lflag="-L$lhdir ${LIB_FLAG[$i]}"
           fi
-          # Library-specific INCLUDE fixes
+          # Library-specific INCLUDE fixes when home specified.
           if [ $i -eq $LREADLINE ] ; then
             linc="$linc/readline"
           fi
@@ -870,7 +870,11 @@ SetupLibraries() {
           lflag="${LIB_HOME[$LSANDER]}/lib/libsander$SHARED_SUFFIX"
         fi
       fi
-      #echo "${LIB_CKEY[$i]} ${LIB_STAT[$i]} linc $linc lflag $lflag" # DEBUG
+      # Special case. If library had include path set already, do not override it.
+      if [ ! -z "${LIB_INCL[$i]}" ] ; then
+        linc=${LIB_INCL[$i]}
+      fi
+      #echo "DEBUG lib ${LIB_CKEY[$i]} stat=\"${LIB_STAT[$i]}\" linc=\"$linc\" lflag=\"$lflag\"" # DEBUG
       LIB_FLAG[$i]="$lflag"
       LIB_INCL[$i]="$linc"
     fi
@@ -1194,21 +1198,27 @@ SetupMKL() {
   if [ "$MKL_TYPE" = 'mkl' -a "$COMPILERS" != 'intel' ] ; then
      MKL_TYPE='line'
   fi
+  # Determine mkl home directory
+  mklroot=''
+  if [ ! -z "$MKLROOT" ] ; then
+    mklroot=$MKLROOT
+  elif [ ! -z "$MKL_HOME" ] ; then
+    mklroot=$MKL_HOME
+  fi
+  if [ ! -z "$mklroot" ] ; then
+    echo "  Using MKL for BLAS/LAPACK in $mklroot"
+  fi
+  # Determine link style
   if [ "$MKL_TYPE" = 'mkl' ] ; then
     # Simple flag for Intel compilers
     mkllib='-mkl'
   else
     # Link-line advisor style
-    if [ -z "$MKLROOT" ] ; then
-      if [ -z "$MKL_HOME" ] ; then
-        echo "MKLROOT/MKL_HOME not set."
-        exit 1
-      fi
-      mkldir=$MKL_HOME
-    else
-      mkldir=$MKLROOT
+    if [ -z "$mklroot" ] ; then
+      echo "MKLROOT/MKL_HOME not set."
+      exit 1
     fi
-    echo "  Using MKL for BLAS/LAPACK in $mkldir"
+    mkldir=$mklroot
     # Determine architecture
     if [ "$NBITS" -eq 64 ] ; then
       mkldir="$mkldir/lib/intel64"
@@ -1251,6 +1261,9 @@ SetupMKL() {
     MKL_FFTW='yes'
     LIB_STAT[$LFFTW3]='enabled'
     LIB_FLAG[$LFFTW3]=''
+    if [ ! -z "$mklroot" ] ; then
+      LIB_INCL[$LBLAS]="-I$mklroot/include/fftw"
+    fi
   fi
 }
 

--- a/configure
+++ b/configure
@@ -987,8 +987,8 @@ SetupCompilers() {
       if [ -z "$CC" ]; then CC=pgcc; fi
       if [ -z "$CXX" ]; then CXX=pgc++; fi
       if [ -z "$FC" ]; then FC=pgf90; fi
-      CXXFLAGS="-Kieee $CXXFLAGS"
-      CFLAGS="-Kieee $CFLAGS"
+      CXXFLAGS="-Kieee -Mnoflushz $CXXFLAGS"
+      CFLAGS="-Kieee -Mnoflushz $CFLAGS"
       hostflags='-fastsse'
       optflags='-fast'
       foptflags='-fast'

--- a/configure
+++ b/configure
@@ -1215,7 +1215,7 @@ SetupMKL() {
   else
     # Link-line advisor style
     if [ -z "$mklroot" ] ; then
-      echo "MKLROOT/MKL_HOME not set."
+      echo "Error: MKLROOT/MKL_HOME not set." > /dev/stderr
       exit 1
     fi
     mkldir=$mklroot
@@ -1329,7 +1329,7 @@ BasicChecks() {
     CPPTRAJBIN=$CPPTRAJHOME/bin
     CPPTRAJLIB=$CPPTRAJHOME/lib
   elif [ ! -d "$CPPTRAJHOME" ] ; then
-    echo "Error: Install directory '$CPPTRAJHOME' does not exist."
+    echo "Error: Install directory '$CPPTRAJHOME' does not exist." > /dev/stderr
     exit 1
   fi
   # Test incompatible options
@@ -1421,7 +1421,7 @@ extern "C" { void mytest_(int&); } int main() { int ival=14; printf("Testing"); 
 EOF
         $CXX $CXXFLAGS -c -o testc.o testc.cpp > /dev/null 2> compile.err
         if [ $? -ne 0 ] ; then
-          cat compile.err
+          cat compile.err > /dev/stderr
           exit 1
         fi
         cat > testf.f <<EOF
@@ -1433,7 +1433,7 @@ end subroutine mytest
 EOF
         $FC $FFLAGS -c -o testf.o testf.f > /dev/null 2> compile.err
         if [ $? -ne 0 ] ; then
-          cat compile.err
+          cat compile.err > /dev/stderr
           exit 1
         fi
         TestProgram quiet "clang++/gfortran link" "$CXX" " " "testc.o testf.o" "$FLINK"

--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -8685,7 +8685,7 @@ cpptraj
 .
  If given with a command, print help for that command.
  Otherwise, list all commands of a certain category (General, System, Coords,
- Trajecotyr, Topology, Action, Analysis, or Control), help for various file
+ Trajectory, Topology, Action, Analysis, or Control), help for various file
  formats, or help with atom mask syntax.
 \end_layout
 

--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -8625,7 +8625,56 @@ help
 
 \end_inset
 
- {[<command>] | General | Action | Analysis | Topology | Trajectory}
+ [ { All |
+\end_layout
+
+\begin_layout LyX-Code
+	     <cmd> |
+\end_layout
+
+\begin_layout LyX-Code
+ 	    <command category> |
+\end_layout
+
+\begin_layout LyX-Code
+ 	    Form[ats] [{read|write}] |
+\end_layout
+
+\begin_layout LyX-Code
+ 	    Form[ats] [{trajin|trajout|readdata|writedata|parm|parmwrite} [<fmt
+ key>]] |
+\end_layout
+
+\begin_layout LyX-Code
+ 	    Mask 	   } ]
+\end_layout
+
+\begin_layout LyX-Code
+	Command Categories: Gen[eral] Sys[tem] Coor[ds] Traj[ectory] Top[ology]
+\end_layout
+
+\begin_layout LyX-Code
+	                    Act[ion] Ana[lysis] Con[trol]
+\end_layout
+
+\begin_layout LyX-Code
+  All                : Print all known commands.
+\end_layout
+
+\begin_layout LyX-Code
+  <cmd>              : Print help for command <cmd>.
+\end_layout
+
+\begin_layout LyX-Code
+  <command category> : Print all commands in specified category.
+\end_layout
+
+\begin_layout LyX-Code
+  Form[ats]          : Help for file formats.
+\end_layout
+
+\begin_layout LyX-Code
+  Mask               : Help for mask syntax.
 \end_layout
 
 \begin_layout Standard
@@ -8635,8 +8684,9 @@ cpptraj
 \shape default
 .
  If given with a command, print help for that command.
- Otherwise, list all commands of a certain category (General, Action, Analysis,
- Topology, or Trajectory).
+ Otherwise, list all commands of a certain category (General, System, Coords,
+ Trajecotyr, Topology, Action, Analysis, or Control), help for various file
+ formats, or help with atom mask syntax.
 \end_layout
 
 \begin_layout Subsection
@@ -8653,6 +8703,7 @@ list <type>
 
 \begin_layout Standard
 List the currently loaded objects of <type>.
+ If no type is given then list all loaded objects.
 \end_layout
 
 \begin_layout Subsection
@@ -25166,6 +25217,8 @@ Calculate the shortest distance to an image, i.e.
 maskcenter
 \series default
  is specified the center of the masks is used.
+ By convention, the lower atom number is saved as A1 and the higher is saved
+ as A2.
 \end_layout
 
 \begin_layout Subsection

--- a/src/Action_MinImage.cpp
+++ b/src/Action_MinImage.cpp
@@ -211,8 +211,8 @@ Action::RetType Action_MinImage::DoAction(int frameNum, ActionFrame& frm) {
           minDist_[mythread] = Dist2;
           minAtom1_[mythread] = Mask1_[m1];
           minAtom2_[mythread] = Mask2_[m2];
-//          rprintf("DEBUG: New Min Dist: Atom %i to %i (%g)\n",
-//                  Mask1_[m1]+1,Mask2_[m2]+1,sqrt(Dist2));
+          //rprintf("DEBUG: New Min Dist: Atom %i to %i (%g)\n",
+          //        Mask1_[m1]+1,Mask2_[m2]+1,sqrt(Dist2));
           //pdbout_.WriteHET(1, minxyz_[0], minxyz_[1], minxyz_[2]);
         }
       }
@@ -232,8 +232,11 @@ Action::RetType Action_MinImage::DoAction(int frameNum, ActionFrame& frm) {
       }
     ++min1;
     ++min2;
-    atom1_->Add(frameNum, &min1);
-    atom2_->Add(frameNum, &min2);
+    // By convention make atom 1 the lowest number
+    int lowest_num = std::min(min1, min2);
+    int highest_num = std::max(min1, min2);
+    atom1_->Add(frameNum, &lowest_num);
+    atom2_->Add(frameNum, &highest_num);
     Dist2 = sqrt( globalMin );
   }
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -20,5 +20,5 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.11.9"
+#define CPPTRAJ_INTERNAL_VERSION "V4.12.0"
 #endif

--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -1,6 +1,7 @@
 # These files are common to cpptraj/libcpptraj. Files that need to be built
 # differently for each will go into SOURCES/LIBCPPTRAJ_OBJECTS respectively.
 COMMON_SOURCES= \
+        SpaceGroup.cpp \
         Action.cpp \
         ActionFrameCounter.cpp \
         ActionList.cpp \
@@ -325,7 +326,6 @@ COMMON_SOURCES= \
         Residue.cpp \
         SDFfile.cpp \
         SimplexMin.cpp \
-        SpaceGroup.cpp \
         Spline.cpp \
         StringRoutines.cpp \
         StructureCheck.cpp \


### PR DESCRIPTION
The following should hopefully address issues in #684.
- Implement convention in `minimage` that the first atom reported is always the one with the lowest index.
- Add the `-Mnoflushz` flag for PGI compiles to bring behavior more in line to GNU/Intel (fixes the binary comparison in the CCP4 test).

Also:
- Fixes configure so that FFTW header from MKL is correctly found (#682).
- Move SpaceGroup.cpp to front of compile; since it takes so long compiling it first saves some time during parallel makes.
- Fix the manual text for `help`.