### PR TITLE
Fix potential buffer overflow when command line is huge

### DIFF
--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -630,7 +630,7 @@ int Cpptraj::Interactive() {
     // Write logfile header entry: date, cmd line opts, topologies
     logfile_.Printf("# %s\n", TimeString().c_str());
     if (!commandLine_.empty())
-      logfile_.Printf("#%s\n", commandLine_.c_str());
+      logfile_.Write(commandLine_.c_str(), commandLine_.size()*sizeof(char));
     DataSetList tops = State_.DSL().GetSetsOfType("*", DataSet::TOPOLOGY);
     if (!tops.empty()) {
       logfile_.Printf("# Loaded topologies:\n");

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.14.0"
+#define CPPTRAJ_INTERNAL_VERSION "V4.14.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Cpptraj tries to write the command line to the log file; before this fix could overflow the internal Printf function. Reported by S. Schott on Amber Gitlab server, issue 53.