### PR TITLE
Add rules for building static libraries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ install: config.h
 libcpptraj: config.h
 	cd src && $(MAKE) libcpptraj
 
+# Create static libraries
+libstatic: config.h
+	cd src && $(MAKE) libstatic
+
 # Run Tests
 check: config.h
 	cd test && $(MAKE) test.complete summary

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,8 +40,8 @@ $(CPPTRAJLIB)/libcpptraj_core.a: $(LIBCPPTRAJ_CORE_OBJECTS)
 $(CPPTRAJLIB)/libcpptraj_file.a: $(LIBCPPTRAJ_FILE_OBJECTS)
 	ar rv $(CPPTRAJLIB)/libcpptraj_file.a $(LIBCPPTRAJ_FILE_OBJECTS)
 
-$(CPPTRAJLIB)/libcpptraj_traj.a: $(LIBCPPTRAJ_TRAJ_OBJECTS)
-	ar rv $(CPPTRAJLIB)/libcpptraj_traj.a $(LIBCPPTRAJ_TRAJ_OBJECTS)
+$(CPPTRAJLIB)/libcpptraj_traj.a: $(LIBCPPTRAJ_TRAJ_OBJECTS) $(XDRFILE_OBJECTS)
+	ar rv $(CPPTRAJLIB)/libcpptraj_traj.a $(LIBCPPTRAJ_TRAJ_OBJECTS) $(XDRFILE_OBJECTS)
 
 $(CPPTRAJLIB)/libcpptraj_parm.a: $(LIBCPPTRAJ_PARM_OBJECTS)
 	ar rv $(CPPTRAJLIB)/libcpptraj_parm.a $(LIBCPPTRAJ_PARM_OBJECTS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,10 +30,24 @@ libcpptraj: $(LIBCPPTRAJ_TARGET)
 $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX): $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET) $(XDRFILE_TARGET) $(ARPACK_TARGET)
 	$(CXX) -shared -o $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX) $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET) $(CPPTRAJ_LIB) $(LDFLAGS)
 
-$(CPPTRAJLIB)/libcpptraj.a: $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)
-	ar rv $(CPPTRAJLIB)/libcpptraj.a $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)
+# Static libraries ---------------------
+#$(CPPTRAJLIB)/libcpptraj.a: $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)
+#	ar rv $(CPPTRAJLIB)/libcpptraj.a $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)
 
-libstatic: $(CPPTRAJLIB)/libcpptraj.a
+$(CPPTRAJLIB)/libcpptraj_core.a: $(LIBCPPTRAJ_CORE_OBJECTS)
+	ar rv $(CPPTRAJLIB)/libcpptraj_core.a $(LIBCPPTRAJ_CORE_OBJECTS)
+
+$(CPPTRAJLIB)/libcpptraj_file.a: $(LIBCPPTRAJ_FILE_OBJECTS)
+	ar rv $(CPPTRAJLIB)/libcpptraj_file.a $(LIBCPPTRAJ_FILE_OBJECTS)
+
+$(CPPTRAJLIB)/libcpptraj_traj.a: $(LIBCPPTRAJ_TRAJ_OBJECTS)
+	ar rv $(CPPTRAJLIB)/libcpptraj_traj.a $(LIBCPPTRAJ_TRAJ_OBJECTS)
+
+$(CPPTRAJLIB)/libcpptraj_parm.a: $(LIBCPPTRAJ_PARM_OBJECTS)
+	ar rv $(CPPTRAJLIB)/libcpptraj_parm.a $(LIBCPPTRAJ_PARM_OBJECTS)
+
+libstatic: $(CPPTRAJLIB)/libcpptraj_core.a $(CPPTRAJLIB)/libcpptraj_traj.a \
+           $(CPPTRAJLIB)/libcpptraj_file.a $(CPPTRAJLIB)/libcpptraj_parm.a
 
 nolibcpptraj:
 	@echo ""

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,11 @@ libcpptraj: $(LIBCPPTRAJ_TARGET)
 $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX): $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET) $(XDRFILE_TARGET) $(ARPACK_TARGET)
 	$(CXX) -shared -o $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX) $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET) $(CPPTRAJ_LIB) $(LDFLAGS)
 
+$(CPPTRAJLIB)/libcpptraj.a: $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)
+	ar rv $(CPPTRAJLIB)/libcpptraj.a $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)
+
+libstatic: $(CPPTRAJLIB)/libcpptraj.a
+
 nolibcpptraj:
 	@echo ""
 	@echo "Error: Cannot build libcpptraj; re-configure with '-shared'"

--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -439,6 +439,12 @@ LIBCPPTRAJ_FILE_OBJECTS= \
   SDFfile.o \
   TinkerFile.o
 
+# These objects are required for Gromacs XTC support in libcpptraj_traj.a
+XDRFILE_OBJECTS= \
+  xdrfile/xdrfile.o \
+  xdrfile/xdr_seek.o \
+  xdrfile/xdrfile_xtc.o
+
 # These objects contain trajectory file functionality. Requires core and file libraries.
 LIBCPPTRAJ_TRAJ_OBJECTS= \
   TrajectoryFile.o \
@@ -446,6 +452,9 @@ LIBCPPTRAJ_TRAJ_OBJECTS= \
   Trajout_Single.o \
   InputTrajCommon.o \
   OutputTrajCommon.o \
+  ActionFrameCounter.o \
+  NC_Routines.o \
+  NetcdfFile.o \
   TrajFrameCounter.o \
   Traj_AmberCoord.o \
   Traj_AmberNetcdf.o \

--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -392,3 +392,93 @@ LIBCPPTRAJ_OBJECTS=$(COMMON_SOURCES:.cpp=.o) $(CSOURCES:.c=.o) \
         Energy_Sander.LIBCPPTRAJ.o \
         ReadLine.LIBCPPTRAJ.o
 
+# These objects contain "core" functionality.
+# NOTE: From Topology down could be separate.
+# NOTE: Topology does not depend on ArgList but makes sense to have it in Core
+# NOTE: Ditto for DistRoutines.o, TextFormat.o, PairList.o, Timer.o, ByteRoutines.o
+LIBCPPTRAJ_CORE_OBJECTS= \
+  CpptrajStdio.o \
+  StringRoutines.o \
+  DistRoutines.o \
+  ArgList.o \
+  TextFormat.o \
+  PairList.o \
+  Timer.o \
+  ByteRoutines.o \
+  Topology.o \
+  Atom.o \
+  AtomMask.o \
+  AtomType.o \
+  Box.o \
+  CharMask.o \
+  CoordinateInfo.o \
+  FileName.o \
+  Frame.o \
+  MaskToken.o \
+  Matrix_3x3.o \
+  NameType.o \
+  Parallel.o \
+  Range.o \
+  Residue.o \
+  Vec3.o
+
+# These objects contain basic file-related functionality. Requires core library
+LIBCPPTRAJ_FILE_OBJECTS= \
+  CpptrajFile.o \
+  BufferedFrame.o \
+  BufferedLine.o \
+  FileIO_Bzip2.o \
+  FileIO_Gzip.o \
+  FileIO_Mpi.o \
+  FileIO_MpiShared.o \
+  FileIO_Std.o \
+  FileTypes.o \
+  CIFfile.o \
+  Mol2File.o \
+  PDBfile.o \
+  SDFfile.o \
+  TinkerFile.o
+
+# These objects contain trajectory file functionality. Requires core and file libraries.
+LIBCPPTRAJ_TRAJ_OBJECTS= \
+  TrajectoryFile.o \
+  Trajin_Single.o \
+  Trajout_Single.o \
+  InputTrajCommon.o \
+  OutputTrajCommon.o \
+  TrajFrameCounter.o \
+  Traj_AmberCoord.o \
+  Traj_AmberNetcdf.o \
+  Traj_AmberRestart.o \
+  Traj_AmberRestartNC.o \
+  Traj_Binpos.o \
+  Traj_CharmmCor.o \
+  Traj_CharmmDcd.o \
+  Traj_CharmmRestart.o \
+  Traj_CIF.o \
+  Traj_Conflib.o \
+  Traj_GmxTrX.o \
+  Traj_GmxXtc.o \
+  Traj_Gro.o \
+  Traj_Mol2File.o \
+  Traj_NcEnsemble.o \
+  Traj_PDBfile.o \
+  Traj_SDF.o \
+  Traj_SQM.o \
+  Traj_Tinker.o \
+  Traj_XYZ.o
+
+# These objects contain parameter file functionality. Requires core and file libraries.
+LIBCPPTRAJ_PARM_OBJECTS= \
+  BondSearch.o \
+  Mol.o \
+  ParmFile.o \
+  Parm_Amber.o \
+  Parm_CharmmPsf.o \
+  Parm_CIF.o \
+  Parm_Gromacs.o \
+  Parm_Mol2.o \
+  Parm_PDB.o \
+  Parm_SDF.o \
+  Parm_Tinker.o
+


### PR DESCRIPTION
Adds 4 static libraries:

* **libcpptraj_core.a** : Contains core functionality; basic IO for STDOUT/STDERR, argument lists, topology, etc.
* **libcpptraj_file.a** : Basic File IO.
* **libcpptraj_traj.a** : Single trajectory file IO.
* **libcpptraj_parm.a** : Topology file IO.

This is currently so that `ambpdb` in AmberTools can avoid using the shared library, but may be useful for other programs down the road.