### PR TITLE
Enable the test for 'splitcoords'

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -450,6 +450,9 @@ test.xtalsymm:
 test.time:
 	@-cd Test_Time && ./RunTest.sh $(OPT)
 
+test.splitcoords:
+	@-cd Test_SplitCoords && ./RunTest.sh $(OPT)
+
 # Every test target should go here.
 COMPLETETESTS=test.general \
               test.strip \
@@ -594,7 +597,8 @@ COMPLETETESTS=test.general \
               test.hausdorff \
               test.catcrd \
               test.xtalsymm \
-              test.time
+              test.time \
+              test.splitcoords
 
 test.all:
 	$(MAKE) test.complete summary

--- a/test/Test_ReadData/RunTest.sh
+++ b/test/Test_ReadData/RunTest.sh
@@ -4,7 +4,8 @@
 
 CleanFiles vector.in v6and7.dat rex-d.dat MD.ene.dat out.dx out.dat \
            truncoct.dat out?.dx append.dx append.dat temp.dat \
-           truncsparse.dat temp2.dat truncoct.dat.save sparse.dat
+           truncsparse.dat temp2.dat truncoct.dat.save sparse.dat \
+           xyz.dat
 
 TESTNAME='Read data tests'
 


### PR DESCRIPTION
Must have forgotten to add this to the main test Makefile back when it was created. Also fix up a test clean rule.