### PR TITLE
Modifications for ambpdb

### DIFF
--- a/src/Trajout_Single.cpp
+++ b/src/Trajout_Single.cpp
@@ -26,18 +26,6 @@ int Trajout_Single::InitTrajWrite(FileName const& tnameIn, ArgList const& argIn,
   return InitTrajout(tnameIn, argIn, DSLin, writeFormatIn);
 }
 
-// Trajout_Single::PrepareStdoutTrajWrite()
-/** Initialize and set up output trajectory for STDOUT write. */
-int Trajout_Single::PrepareStdoutTrajWrite(ArgList const& argIn, DataSetList const& DSLin,
-                                           Topology *tparmIn,
-                                           CoordinateInfo const& cInfoIn, int nFrames,
-                                           TrajectoryFile::TrajFormatType writeFormatIn)
-{
-  if (InitTrajout("", argIn, DSLin, writeFormatIn)) return 1;
-  if (SetupTrajWrite(tparmIn, cInfoIn, nFrames)) return 1;
-  return 0;
-}
-
 /** Initialize trajectory for write. Append ensemble number to filename if given. */
 int Trajout_Single::InitEnsembleTrajWrite(FileName const& tnameIn, ArgList const& argIn,
                                           DataSetList const& DSLin, 

--- a/src/Trajout_Single.h
+++ b/src/Trajout_Single.h
@@ -19,7 +19,7 @@ class DataSetList;
 class Trajout_Single {
   public:
     Trajout_Single() : trajio_(0), debug_(0) {}
-    ~Trajout_Single();
+    virtual ~Trajout_Single(); // NOTE: virtual because it can be inherited
     void SetDebug(int d) { debug_ = d; }
     // ----- Inherited functions -----------------
     /// Prepare trajectory for writing to the given format, but no Topology setup.
@@ -38,9 +38,6 @@ class Trajout_Single {
     /// Init and setup/open traj.
     int PrepareTrajWrite(FileName const&, ArgList const&, DataSetList const&, Topology*,
                          CoordinateInfo const&, int, TrajectoryFile::TrajFormatType);
-    /// Init and setup/open traj for writing to STDOUT (e.g. ambpdb mode)
-    int PrepareStdoutTrajWrite(ArgList const&, DataSetList const&, Topology*,
-                               CoordinateInfo const&, int, TrajectoryFile::TrajFormatType);
     /// Init traj; if given, append ensemble number to name (use in Actions)
     int InitEnsembleTrajWrite(FileName const&, ArgList const&, DataSetList const&,
                               TrajectoryFile::TrajFormatType, int);
@@ -48,8 +45,9 @@ class Trajout_Single {
     // Set the parallel communicator.
     int SetTrajComm(Parallel::Comm const& c) { trajComm_ = c; return 0; }
 #   endif
-  private:
+  protected:
     int InitTrajout(FileName const&, ArgList const&, DataSetList const&, TrajectoryFile::TrajFormatType);
+  private:
 #   ifdef MPI
     /// Peform Topology-related setup for trajectory and open in parallel.
     int ParallelSetupTrajWrite();

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.14.6"
+#define CPPTRAJ_INTERNAL_VERSION "V4.14.7"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
The recent addition of DataSetList to trajectories (see #724) broke AmbPDB in Amber. Since AmbPDB does not need the new DataSetList stuff, it will have a blank placeholder class for that functionality. Also, since the stdout mode of `Trajout_Single` was only for AmbPDB, it will be removed from cpptraj and moved to AmbPDB.