### PR TITLE
Better handling of COORDS sets with certain commands.

### DIFF
--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -1405,11 +1405,15 @@ int CpptrajState::AddReference( std::string const& fname, ArgList const& args ) 
   Topology* refParm = 0;
   DataSet_Coords* CRD = 0;
   if (argIn.hasKey("crdset")) {
-    CRD = (DataSet_Coords*)DSL_.FindCoordsSet( fname );
-    if (CRD == 0) {
-      mprinterr("COORDS set with name %s not found.\n", fname.c_str());
+    DataSet* dset = DSL_.FindSetOfGroup( fname, DataSet::COORDINATES );
+    if (dset == 0) {
+      mprinterr("Error: COORDS set with name %s not found.\n", fname.c_str());
       return 1;
+    } else if (dset->Type() == DataSet::REF_FRAME) {
+      mprintf("Warning: '%s' is already a reference.\n", fname.c_str());
+      return 0;
     }
+    CRD = static_cast<DataSet_Coords*>( dset );
   } else {
     // Get topology file.
     refParm = DSL_.GetTopology( argIn );

--- a/src/DataSetList.cpp
+++ b/src/DataSetList.cpp
@@ -355,6 +355,17 @@ DataSet* DataSetList::FindSetOfType(std::string const& nameIn, DataSet::DataType
   return dsetOut[0];
 }
 
+/** \return single set belonging to specified group. */
+DataSet* DataSetList::FindSetOfGroup(std::string const& nameIn, DataSet::DataGroup groupIn) const
+{
+  DataSetList dsetOut = SelectGroupSets( nameIn, groupIn );
+  if (dsetOut.empty())
+    return 0;
+  else if (dsetOut.size() > 1)
+    mprintf("Warning: '%s' selects multiple sets. Only using first.\n", nameIn.c_str());
+  return dsetOut[0];
+}
+
 /** Search for a COORDS DataSet. If no name specified, create a default
   * COORDS DataSet named _DEFAULTCRD_.
   */

--- a/src/DataSetList.h
+++ b/src/DataSetList.h
@@ -91,6 +91,8 @@ class DataSetList {
     DataSetList SelectGroupSets( std::string const&, DataSet::DataGroup ) const;
     /// Find next set of specified type with given name.
     DataSet* FindSetOfType(std::string const&, DataSet::DataType) const;
+    /// Find next set of specified group with given name.
+    DataSet* FindSetOfGroup(std::string const&, DataSet::DataGroup) const;
     /// Find COORDS DataSet or create default COORDS DataSet.
     DataSet* FindCoordsSet(std::string const&);
 

--- a/src/Exec_Change.cpp
+++ b/src/Exec_Change.cpp
@@ -36,7 +36,7 @@ Exec::RetType Exec_Change::Execute(CpptrajState& State, ArgList& argIn)
   Topology* parm = 0;
   std::string crdset = argIn.GetStringKey("crdset");
   if (!crdset.empty()) {
-    DataSet_Coords* cset = (DataSet_Coords*)State.DSL().FindCoordsSet( crdset );
+    DataSet_Coords* cset = (DataSet_Coords*)State.DSL().FindSetOfGroup( crdset, DataSet::COORDINATES );
     if (cset == 0) {
       mprinterr("Error: No COORDS set with name '%s' found.\n", crdset.c_str());
       return CpptrajState::ERR;

--- a/src/Exec_CombineCoords.cpp
+++ b/src/Exec_CombineCoords.cpp
@@ -22,18 +22,21 @@ Exec::RetType Exec_CombineCoords::Execute(CpptrajState& State, ArgList& argIn) {
   std::vector<DataSet_Coords*> CRD;
   std::string setname = argIn.GetStringNext();
   while (!setname.empty()) {
-    DataSet_Coords* ds = (DataSet_Coords*)State.DSL().FindCoordsSet( setname );
-    if (ds == 0) {
-      mprinterr("Error: %s: No COORDS set with name %s found.\n", argIn.Command(), setname.c_str());
-      return CpptrajState::ERR;
-    }
-    CRD.push_back( ds );
+    DataSetList crdSets = State.DSL().SelectGroupSets( setname, DataSet::COORDINATES );
+    if (crdSets.empty())
+      mprintf("Warning: '%s' selected no COORDS sets.\n", setname.c_str());
+    for (DataSetList::const_iterator ds = crdSets.begin(); ds != crdSets.end(); ++ds)
+      CRD.push_back( (DataSet_Coords*)*ds );
     setname = argIn.GetStringNext();
   }
   if (CRD.size() < 2) {
     mprinterr("Error: %s: Must specify at least 2 COORDS data sets\n", argIn.Command());
     return CpptrajState::ERR;
   }
+  mprintf("\tCombining %zu sets:", CRD.size());
+  for (std::vector<DataSet_Coords*>::const_iterator it = CRD.begin(); it != CRD.end(); ++it)
+    mprintf(" %s", (*it)->legend());
+  mprintf("\n");
   // Only add the topology to the list if parmname specified
   bool addTop = true;
   Topology CombinedTop;

--- a/src/Exec_CrdAction.cpp
+++ b/src/Exec_CrdAction.cpp
@@ -131,7 +131,7 @@ Exec::RetType Exec_CrdAction::ProcessArgs(CpptrajState& State, ArgList& argIn) {
     mprinterr("Error: %s: Specify COORDS dataset name.\n", argIn.Command());
     return CpptrajState::ERR;
   }
-  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindCoordsSet( setname );
+  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindSetOfGroup( setname, DataSet::COORDINATES );
   if (CRD == 0) {
     mprinterr("Error: %s: No COORDS set with name %s found.\n", argIn.Command(), setname.c_str());
     return CpptrajState::ERR;

--- a/src/Exec_CrdOut.cpp
+++ b/src/Exec_CrdOut.cpp
@@ -40,7 +40,7 @@ Exec::RetType Exec_CrdOut::WriteCrd(CpptrajState& State, ArgList& argIn) {
     mprinterr("Error: crdout: Specify COORDS dataset name.\n");
     return CpptrajState::ERR;
   }
-  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindCoordsSet( setname );
+  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindSetOfGroup( setname, DataSet::COORDINATES );
   if (CRD == 0) {
     mprinterr("Error: crdout: No COORDS set with name %s found.\n", setname.c_str());
     return CpptrajState::ERR;

--- a/src/Exec_ParmWrite.cpp
+++ b/src/Exec_ParmWrite.cpp
@@ -24,7 +24,7 @@ Exec::RetType Exec_ParmWrite::Execute(CpptrajState& State, ArgList& argIn) {
     if (parm == 0) return CpptrajState::ERR;
     err = pfile.WriteTopology( *parm, outfilename, argIn, ParmFile::UNKNOWN_PARM, State.Debug() );
   } else {
-    DataSet_Coords* ds = (DataSet_Coords*)State.DSL().FindCoordsSet(crdset);
+    DataSet_Coords* ds = (DataSet_Coords*)State.DSL().FindSetOfGroup(crdset, DataSet::COORDINATES);
     if (ds == 0) return CpptrajState::ERR;
     mprintf("\tUsing topology from data set '%s'\n", ds->legend());
     err = pfile.WriteTopology(ds->Top(), outfilename, argIn, ParmFile::UNKNOWN_PARM, State.Debug());

--- a/src/Exec_PermuteDihedrals.cpp
+++ b/src/Exec_PermuteDihedrals.cpp
@@ -56,7 +56,7 @@ Exec::RetType Exec_PermuteDihedrals::Execute(CpptrajState& State, ArgList& argIn
     mprinterr("Error: Specify COORDS dataset name with 'crdset'.\n");
     return CpptrajState::ERR;
   }
-  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindCoordsSet( setname );
+  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindSetOfGroup( setname, DataSet::COORDINATES );
   if (CRD == 0) {
     mprinterr("Error: Could not find COORDS set '%s'\n", setname.c_str());
     return CpptrajState::ERR;
@@ -100,12 +100,18 @@ Exec::RetType Exec_PermuteDihedrals::Execute(CpptrajState& State, ArgList& argIn
   }
 
   // Setup output coords
-  outfilename = argIn.GetStringKey("crdout");
-  if (!outfilename.empty()) {
-    mprintf("\tCoordinates saved to set '%s'\n", outfilename.c_str());
-    crdout_ = (DataSet_Coords_CRD*)State.DSL().AddSet(DataSet::COORDS, outfilename);
+  std::string outcrdname = argIn.GetStringKey("crdout");
+  if (!outcrdname.empty()) {
+    mprintf("\tCoordinates saved to set '%s'\n", outcrdname.c_str());
+    crdout_ = (DataSet_Coords_CRD*)State.DSL().AddSet(DataSet::COORDS, outcrdname);
     if (crdout_ == 0) return CpptrajState::ERR;
     crdout_->CoordsSetup( CRD->Top(), CRD->CoordsInfo() );
+  }
+
+  // Require an output option
+  if (outfilename.empty() && outcrdname.empty()) {
+    mprinterr("Error: No output option specified. Use either 'outtraj' and/or 'crdout'\n");
+    return CpptrajState::ERR;
   }
 
   // Get specific mode options.

--- a/src/Exec_RotateDihedral.cpp
+++ b/src/Exec_RotateDihedral.cpp
@@ -30,7 +30,7 @@ Exec::RetType Exec_RotateDihedral::Execute(CpptrajState& State, ArgList& argIn) 
     mprinterr("Error: Specify COORDS dataset name with 'crdset'.\n");
     return CpptrajState::ERR;
   }
-  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindCoordsSet( setname );
+  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindSetOfGroup( setname, DataSet::COORDINATES );
   if (CRD == 0) {
     mprinterr("Error: Could not find COORDS set '%s'\n", setname.c_str());
     return CpptrajState::ERR;

--- a/src/Exec_SplitCoords.cpp
+++ b/src/Exec_SplitCoords.cpp
@@ -19,7 +19,7 @@ Exec::RetType Exec_SplitCoords::Execute(CpptrajState& State, ArgList& argIn)
     mprinterr("Error: %s: Specify COORDS dataset name.\n", argIn.Command());
     return CpptrajState::ERR;
   }
-  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindCoordsSet( setname );
+  DataSet_Coords* CRD = (DataSet_Coords*)State.DSL().FindSetOfGroup( setname, DataSet::COORDINATES );
   if (CRD == 0) {
     mprinterr("Error: %s: No COORDS set with name %s found.\n", argIn.Command(), setname.c_str());
     return CpptrajState::ERR;

--- a/src/ParameterHolders.h
+++ b/src/ParameterHolders.h
@@ -81,7 +81,7 @@ template <class T> class ParmHolder {
   public:
     ParmHolder() {}
     void clear() { bpmap_.clear(); }
-    unsigned int size() const { return bpmap_.size(); }
+    size_t size() const { return bpmap_.size(); }
 /*
     static inline void PrintTypes(AtomTypeHolder const& types) {
       for (AtomTypeHolder::const_iterator it = types.begin(); it != types.end(); ++it)

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.14.8"
+#define CPPTRAJ_INTERNAL_VERSION "V4.14.9"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Change/RunTest.sh
+++ b/test/Test_Change/RunTest.sh
@@ -2,7 +2,7 @@
 
 . ../MasterTest.sh
 
-CleanFiles change.in ala3.mod.pdb ala3.chain.pdb
+CleanFiles change.in ala3.mod.pdb ala3.chain.pdb crdala3.chain.pdb
 
 TESTNAME='Change command test'
 Requires maxthreads 1
@@ -28,6 +28,15 @@ trajout ala3.chain.pdb
 EOF
 RunCpptraj "Change chain ID test"
 DoTest ala3.chain.pdb.save ala3.chain.pdb
+
+cat > change.in <<EOF
+parm ../Test_Charmm/ala3.psf
+loadcrd ../Test_Charmm/ala3.dcd 1 1 name MyCrd
+change crdset MyCrd chainid of * to A
+crdout MyCrd crdala3.chain.pdb
+EOF
+RunCpptraj "Change chain ID of COORDS set test"
+DoTest ala3.chain.pdb.save crdala3.chain.pdb
 
 EndTest
 exit 0


### PR DESCRIPTION
Mostly changes under the hood; only analyses should be using `FindCoordsSet`. Addresses #713 as well. Also return an error if `permutedihedrals` is used without an output option (which effectively does nothing).