### PR TITLE
Fix behavior of ensemble mode in serial

### DIFF
--- a/src/Analysis_VectorMath.h
+++ b/src/Analysis_VectorMath.h
@@ -21,9 +21,11 @@ class Analysis_VectorMath : public Analysis {
     int DoMath(DataSet*, DataSet_Vector&, DataSet_Vector&) const;
 
     ModeType mode_;
-    DataSet_Vector* vinfo1_;
-    DataSet_Vector* vinfo2_;
-    DataSet* DataOut_;       ///< Output data set
+    typedef std::vector<DataSet_Vector*> DVarray;
+    DVarray vinfo1_;
+    DVarray vinfo2_;
+    typedef std::vector<DataSet*> DSarray;
+    DSarray DataOut_;                      ///< Output data set(s)
     bool norm_;
 };
 #endif

--- a/src/Analysis_VectorMath.h
+++ b/src/Analysis_VectorMath.h
@@ -1,7 +1,8 @@
 #ifndef INC_ANALYSIS_VECTORMATH_H
 #define INC_ANALYSIS_VECTORMATH_H
 #include "Analysis.h"
-#include "DataSet_Vector.h"
+// Forward declarations
+class DataSet_Vector;
 class Analysis_VectorMath : public Analysis {
   public:
     Analysis_VectorMath();
@@ -13,8 +14,11 @@ class Analysis_VectorMath : public Analysis {
     enum ModeType {  DOTPRODUCT = 0, DOTANGLE, CROSSPRODUCT };
     static const char* ModeString[];
 
-    int DotProduct(unsigned int, unsigned int, unsigned int);
-    int CrossProduct(unsigned int, unsigned int, unsigned int);
+    int DotProduct(DataSet*, DataSet_Vector&, DataSet_Vector&,
+                   unsigned int, unsigned int, unsigned int) const;
+    int CrossProduct(DataSet*, DataSet_Vector&, DataSet_Vector&,
+                     unsigned int, unsigned int, unsigned int) const;
+    int DoMath(DataSet*, DataSet_Vector&, DataSet_Vector&) const;
 
     ModeType mode_;
     DataSet_Vector* vinfo1_;

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -615,6 +615,10 @@ int CpptrajState::RunEnsemble() {
         // Silence action output for all beyond first member.
         if (member > 0)
           SetWorldSilent( true );
+#       ifndef MPI
+        // All DataSets that will be set up will be part of this ensemble 
+        DSL_.SetEnsembleNum( member );
+#       endif
         if (ActionEnsemble[member]->SetupActions( EnsembleParm[member], exitOnError_ )) {
 #         ifdef MPI
           rprintf("Warning: Ensemble member %i: Could not set up actions for %s: skipping.\n",
@@ -661,6 +665,10 @@ int CpptrajState::RunEnsemble() {
           if ( currentFrame.Frm().CheckCoordsInvalid() )
             rprintf("Warning: Ensemble member %i frame %i may be corrupt.\n",
                     member, (*ens)->Traj().Counter().PreviousFrameNumber()+1);
+#         ifndef MPI
+          // All DataSets that will be set up will be part of this ensemble 
+          DSL_.SetEnsembleNum( member );
+#         endif
 #         ifdef TIMER
           actions_time.Start();
 #         endif
@@ -729,8 +737,13 @@ int CpptrajState::RunEnsemble() {
   post_time_.Start();
   // ========== A C T I O N  O U T P U T  P H A S E ==========
   mprintf("\nENSEMBLE ACTION OUTPUT:\n");
-  for (int member = 0; member < ensembleSize; ++member)
+  for (int member = 0; member < ensembleSize; ++member) {
+#   ifndef MPI
+    // All DataSets that will be set up will be part of this ensemble 
+    DSL_.SetEnsembleNum( member );
+#   endif
     ActionEnsemble[member]->PrintActions();
+  }
   post_time_.Stop();
   // Clean up ensemble action lists
   for (int member = 1; member < ensembleSize; member++)

--- a/src/CpptrajState.cpp
+++ b/src/CpptrajState.cpp
@@ -748,6 +748,10 @@ int CpptrajState::RunEnsemble() {
   // Clean up ensemble action lists
   for (int member = 1; member < ensembleSize; member++)
     delete ActionEnsemble[member];
+# ifndef MPI
+  // Reset ensemble number
+  DSL_.SetEnsembleNum( -1 );
+# endif
 
   return 0;
 }

--- a/src/Exec_DataSetCmd.cpp
+++ b/src/Exec_DataSetCmd.cpp
@@ -238,39 +238,62 @@ Exec::RetType Exec_DataSetCmd::ModifyPoints(CpptrajState& State, ArgList& argIn,
 Exec::RetType Exec_DataSetCmd::VectorCoord(CpptrajState& State, ArgList& argIn) {
   // Keywords
   std::string name = argIn.GetStringKey("name");
-  int idx;
+  int tgtIdx;
   if (argIn.hasKey("X"))
-    idx = 0;
+    tgtIdx = 0;
   else if (argIn.hasKey("Y"))
-    idx = 1;
+    tgtIdx = 1;
   else if (argIn.hasKey("Z"))
-    idx = 2;
+    tgtIdx = 2;
   else {
     mprinterr("Error: 'vectorcoord' requires specifying X, Y, or Z.\n");
     return CpptrajState::ERR;
   }
-  // Data set
-  DataSet* ds1 = State.DSL().GetDataSet( argIn.GetStringNext() );
-  if (ds1 == 0) return CpptrajState::ERR;
-  if (ds1->Type() != DataSet::VECTOR) {
-    mprinterr("Error: 'vectorcoord' only works with vector data sets.\n");
+  // Data set(s)
+  DataSetList dsl1 = State.DSL().GetMultipleSets( argIn.GetStringNext() );
+  if (dsl1.empty()) {
+    mprinterr("Error: 'vectorcoord': No data sets selected.\n");
     return CpptrajState::ERR;
   }
-  if (ds1->Size() < 1) {
-    mprinterr("Error: '%s' is empty.\n", ds1->legend());
-    return CpptrajState::ERR;
-  }
-  // Create output set.
-  static const char* XYZ[3] = { "X", "Y", "Z" };
-  DataSet* out = State.DSL().AddSet( DataSet::DOUBLE, name, "COORD");
-  if (out == 0) return CpptrajState::ERR;
-  // Extract data
-  mprintf("\tExtracting %s coordinate from vector %s to %s\n",
-          XYZ[idx], ds1->legend(), out->Meta().PrintName().c_str());
-  DataSet_Vector const& vec = static_cast<DataSet_Vector const&>( *ds1 );
-  for (unsigned int n = 0; n != vec.Size(); n++) {
-    double d = vec.VXYZ(n)[idx];
-    out->Add( n, &d );
+  DataSet* firstSet = 0;
+  int idx = 0;
+  while (!dsl1.empty()) {
+    for (DataSetList::const_iterator it = dsl1.begin(); it != dsl1.end(); ++it)
+    {
+      if ( (*it)->Type() != DataSet::VECTOR) {
+        mprintf("Warning: '%s' 'vectorcoord' only works with vector data sets.\n", (*it)->legend());
+      } else if ( (*it)->Size() < 1) {
+        mprintf("Warning: '%s' is empty.\n", (*it)->legend());
+      } else {
+        // Create output set.
+        if (name.empty())
+          name = State.DSL().GenerateDefaultName( "COORD" );
+        MetaData md( name );
+        if (idx >= 1) {
+          if (idx == 1) {
+            MetaData fmd = firstSet->Meta();
+            fmd.SetIdx( 0 );
+            firstSet->SetMeta( fmd );
+          }
+          md.SetIdx( idx );
+        }
+        static const char* XYZchar[3] = { "X", "Y", "Z" };
+        DataSet* out = State.DSL().AddSet( DataSet::DOUBLE, md );
+        if (out == 0) return CpptrajState::ERR;
+        if (firstSet == 0)
+          firstSet = out;
+        idx++;
+        // Extract data
+        mprintf("\tExtracting %s coordinate from vector %s to %s\n",
+                XYZchar[tgtIdx], (*it)->legend(), out->Meta().PrintName().c_str());
+        DataSet_Vector const& vec = static_cast<DataSet_Vector const&>( *(*it) );
+        for (unsigned int n = 0; n != vec.Size(); n++) {
+          double d = vec.VXYZ(n)[tgtIdx];
+          out->Add( n, &d );
+        }
+      }
+    }
+    dsl1 = State.DSL().GetMultipleSets( argIn.GetStringNext() );
   }
   return CpptrajState::OK;
 }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.14.9"
+#define CPPTRAJ_INTERNAL_VERSION "V4.14.10"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Control/RunTest.sh
+++ b/test/Test_Control/RunTest.sh
@@ -41,13 +41,6 @@ show
 atoms "@\$last10 - \$Natom" out last10.dat
 run
 
-# Test reading in a comma-separated list of strings
-clear trajin
-for TRAJ in ../tz2.nc,../tz2.crd,../tz2.pdb,../tz2.rst7
-  trajin \$TRAJ lastframe
-done
-distance D1-12 :1 :12 out distance.dat
-run
 EOF
 RunCpptraj "$TESTNAME"
 DoTest TRP.vec.dat.save TRP.vec.dat
@@ -57,7 +50,23 @@ DoTest TRP.tocenter.dat.save TRP.tocenter.dat
 DoTest nh.dat.save nh.dat
 DoTest rms.nofit.dat.save rms.nofit.dat
 DoTest last10.dat.save last10.dat
-DoTest distance.dat.save distance.dat
+
+UNITNAME='Test reading comma-separated list of strings'
+CheckFor maxthreads 4
+if [ $? -eq 0 ] ; then
+  cat > for.in <<EOF
+parm ../tz2.parm7
+# Test reading in a comma-separated list of strings
+clear trajin
+for TRAJ in ../tz2.nc,../tz2.crd,../tz2.pdb,../tz2.rst7
+  trajin \$TRAJ lastframe
+done
+distance D1-12 :1 :12 out distance.dat
+run
+EOF
+  RunCpptraj "$UNITNAME"
+  DoTest distance.dat.save distance.dat
+fi
 
 EndTest
 exit 0

--- a/test/Test_TrajinOffset/RunTest.sh
+++ b/test/Test_TrajinOffset/RunTest.sh
@@ -60,7 +60,9 @@ fi
 
 # Test 4
 UNITNAME='Start argument offset'
-cat > cpptraj.offset.in <<EOF
+CheckFor maxthreads 6
+if [ $? -eq 0 ] ; then
+  cat > cpptraj.offset.in <<EOF
 parm ala2.99sb.mbondi2.parm7
 trajin rem.crd.000 5 10
 dihedral phi0 :1@C :2@N :2@CA :2@C out phi.dat.save noheader
@@ -69,8 +71,9 @@ clear trajin
 trajin rem.crd.000 -5
 dihedral phi1 :1@C :2@N :2@CA :2@C out phi.dat noheader
 EOF
-RunCpptraj "$UNITNAME"
-DoTest phi.dat.save phi.dat
+  RunCpptraj "$UNITNAME"
+  DoTest phi.dat.save phi.dat
+fi
 
 EndTest
 


### PR DESCRIPTION
Any actions that created data sets in Setup, Action, or Print phase would not have ensemble number properly set when running ensemble mode in serial, causing cpptraj to crash. This fixes the behavior.

Also allows the `vectormath` analysis and `dataset vectorcoord` commands to handle multiple data sets.

Protects some tests in parallel.