### PR TITLE
Fix 'trajout' behavior when 'start' is > 1 and 'offset' specified.

### DIFF
--- a/src/ActionFrameCounter.cpp
+++ b/src/ActionFrameCounter.cpp
@@ -1,4 +1,5 @@
 #include "ActionFrameCounter.h"
+#include "ArgList.h"
 #include "CpptrajStdio.h"
 
 // CONSTRUCTOR

--- a/src/ActionFrameCounter.h
+++ b/src/ActionFrameCounter.h
@@ -8,7 +8,7 @@ class ActionFrameCounter {
     static const char* HelpText;
     int InitFrameCounter(ArgList&);
     /// \return true if frame should not be processed.
-    bool CheckFrameCounter(int frameNum) const {
+    int CheckFrameCounter(int frameNum) const {
 /*      if (start_ == -1) return true;
       // Need this in case frames were skipped
       while (start_ < frameNum)
@@ -17,11 +17,11 @@ class ActionFrameCounter {
       start_ += offset_;
       // Since frameNum will never be -1, this disables all future checks.
       if (start_ > stop_ && stop_ != -1) start_ = -1;*/
-      if (stop_ != -1 && frameNum > stop_) return true;
-      if (frameNum < start_) return true;
-      if (offset_ == 1) return false;
-      if ( ((frameNum + start_) % offset_) != 0 ) return true;
-      return false;
+      if (stop_ != -1 && frameNum > stop_) return 1;
+      if (frameNum < start_) return 2;
+      if (offset_ == 1) return 0;
+      if ( ((frameNum - start_) % offset_) != 0 ) return 3;
+      return 0;
     }
     void FrameCounterInfo() const;
     void FrameCounterBrief() const;

--- a/src/ActionFrameCounter.h
+++ b/src/ActionFrameCounter.h
@@ -1,6 +1,7 @@
 #ifndef INC_ACTIONFRAMECOUNTER_H
 #define INC_ACTIONFRAMECOUNTER_H
-#include "ArgList.h"
+// Forward declarations
+class ArgList;
 /// Internal frame counter, for processing a subset of frames.
 class ActionFrameCounter {
   public:

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -756,6 +756,8 @@ CpptrajState::RetType Command::ProcessInput(CpptrajState& State, std::string con
 # ifdef MPI
   } // END if master
   if (Parallel::World().CheckError( cmode )) return CpptrajState::ERR;
+# else
+  if (cmode != CpptrajState::OK) return CpptrajState::ERR;
 # endif
   int readMoreInput = 1;
   while (readMoreInput == 1) {

--- a/src/OutputTrajCommon.cpp
+++ b/src/OutputTrajCommon.cpp
@@ -136,6 +136,8 @@ void OutputTrajCommon::CommonInfo() const {
   if (noReps_) mprintf(" no replica dimensions,");
   if (hasRange_)
     FrameRange_.PrintRange(": Writing frames", 1);
+  else if (!frameCount_.DefaultSettings())
+    frameCount_.FrameCounterBrief();
   else if (NframesToWrite_ > 0) {
     mprintf(": Writing %i frames", NframesToWrite_);
     frameCount_.FrameCounterBrief();

--- a/src/OutputTrajCommon.h
+++ b/src/OutputTrajCommon.h
@@ -75,6 +75,7 @@ int OutputTrajCommon::CheckFrameRange(int set) {
     // This frame is next in the range. Advance FrameRange iterator.
     ++rangeframe_;
   } else {
+    //printf("DEBUG: CheckFrameRange(%i)= %i\n", set, frameCount_.CheckFrameCounter(set));
     if (frameCount_.CheckFrameCounter( set )) return 1;
   }
   // Frame will be processed. Increment frame count.

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.14.12"
+#define CPPTRAJ_INTERNAL_VERSION "V4.15.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Matrix/RunTest.sh
+++ b/test/Test_Matrix/RunTest.sh
@@ -2,7 +2,8 @@
 
 . ../MasterTest.sh
 
-CleanFiles matrix.in mtest.dat.save mtest.*.dat evecs.10.dat
+CleanFiles matrix.in mtest.dat.save mtest.*.dat evecs.10.dat \
+           tz2.dist.ca.matrix.dat.save tz2.dist.ca.matrix.dat
 
 TESTNAME='Matrix Tests'
 Requires maxthreads 10
@@ -43,7 +44,6 @@ DoTest mtest.dat.12.save mtest.12.dat
 DoTest mtest.dat.13.save mtest.13.dat
 
 # Test reading symmetric matrix
-# Test reading symmetric matrix
 # NOTE: Currently disabled due to eigenvector sign flips causing false test errors.
 ReadSymmMatrix() {
 cat > matrix.in <<EOF
@@ -53,6 +53,22 @@ EOF
 RunCpptraj "Read symmetric matrix data test."
 DoTest evecs.10.dat.save evecs.10.dat
 }
+
+# Test start/stop/offset args
+cat > matrix.in <<EOF
+parm ../tz2.parm7
+trajin ../tz2.nc 5 100 10
+matrix dist @CA out tz2.dist.ca.matrix.dat.save
+EOF
+RunCpptraj "Generate matrix with trajectory start/stop/offset"
+cat > matrix.in <<EOF
+parm ../tz2.parm7
+trajin ../tz2.nc
+matrix dist @CA out tz2.dist.ca.matrix.dat start 5 stop 100 offset 10
+EOF
+RunCpptraj "Generate matrix with action stop/start/offset"
+DoTest tz2.dist.ca.matrix.dat.save tz2.dist.ca.matrix.dat
+
 EndTest
   
 exit 0


### PR DESCRIPTION
There was a `+` that should have been a `-`. Adds a test that should catch this behavior in the future. Thanks to Tyler Luchko for reporting this.