### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -28999,8 +28999,8 @@ amplitude
 \series bold
 theta
 \series default
- keywords are given, amplitudes/thetas will be calculated in addition to
- pucker.
+ keywords are given, amplitudes/thetas (also in degrees) will be calculated
+ in addition to pucker.
  The results from 
 \series bold
 \shape italic

--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -20385,8 +20385,8 @@ refindex
 \begin_inset space ~
 \end_inset
 
-<#> If specified, calculate distance between <mask1> and <mask2> in specified
- reference.
+<#> If specified, calculate distance between <mask1> in each input frame
+ and <mask2> in the specified reference.
 \end_layout
 
 \begin_layout Description
@@ -20466,8 +20466,8 @@ bound
 \end_deeper
 \begin_layout Standard
 Calculate distance between the center of mass of atoms in <mask1> to atoms
- in <mask2>, between atoms in <mask1> and atoms in <mask2> in specified
- reference, or atoms in <mask1> and the specified point.
+ in <mask2>, between atoms in <mask1> from each input frame and atoms in
+ <mask2> in specified reference, or atoms in <mask1> and the specified point.
  If 
 \series bold
 geom

--- a/src/Action_Pucker.cpp
+++ b/src/Action_Pucker.cpp
@@ -173,8 +173,10 @@ Action::RetType Action_Pucker::DoAction(int frameNum, ActionFrame& frm) {
     case UNSPECIFIED : // Sanity check
       return Action::ERR;
   }
-  if ( amplitude_ != 0 )
+  if ( amplitude_ != 0 ) {
+    aval *= Constants::RADDEG;
     amplitude_->Add(frameNum, &aval);
+  }
   if ( theta_ != 0 ) {
     tval *= Constants::RADDEG;
     theta_->Add(frameNum, &tval);

--- a/src/Action_Pucker.cpp
+++ b/src/Action_Pucker.cpp
@@ -113,11 +113,11 @@ Action::RetType Action_Pucker::Init(ArgList& actionArgs, ActionInit& init, int d
   if (outfile != 0) 
     mprintf("\tData will be written to %s\n", outfile->DataFilename().base());
   if (amplitude_!=0)
-    mprintf("\tAmplitudes will be stored.\n");
+    mprintf("\tAmplitudes (in degrees) will be stored.\n");
   if (theta_!=0)
-    mprintf("\tThetas will be stored.\n");
+    mprintf("\tThetas (in degrees) will be stored.\n");
   if (offset_!=0)
-    mprintf("\tOffset: %f deg. will be added to values.\n", offset_);
+    mprintf("\tOffset: %f degrees will be added to values.\n", offset_);
   if (puckerMin_ > -180.0)
     mprintf("\tOutput range is 0 to 360 degrees.\n");
   else

--- a/src/DataSet_integer_mem.h
+++ b/src/DataSet_integer_mem.h
@@ -14,7 +14,7 @@ class DataSet_integer_mem : public DataSet_integer {
     /// Make set size sizeIn, all values set to 0.0.
     void Resize(size_t sizeIn)        { Data_.resize(sizeIn, 0);   }
     /// Make set size sizeIn, all values set to val.
-    void Assign(size_t sizeIn, int val) { Data_.resize(sizeIn, -1); }
+    void Assign(size_t sizeIn, int val) { Data_.resize(sizeIn, val); }
     inline void AddVal(size_t, int);
     // ----- DataSet_1D functions ----------------
     double Dval(size_t idx)     const { return (double)Data_[idx]; }

--- a/src/Parm_CharmmPsf.h
+++ b/src/Parm_CharmmPsf.h
@@ -11,6 +11,8 @@ class Parm_CharmmPsf : public ParmIO {
     int WriteParm(FileName const&, Topology const&);
     int processWriteArgs(ArgList&) { return 0; }
   private:
-    static inline int FindTag(char*, const char*, int, CpptrajFile&); 
+    static const unsigned int ChmStrMax_;
+    static inline int FindTag(char*, const char*, int, CpptrajFile&);
+    static inline int ParseResID(char&, const char*);
 };
 #endif

--- a/src/Residue.h
+++ b/src/Residue.h
@@ -27,10 +27,10 @@ class Residue {
       originalResNum_(r), segID_(-1), icode_(ic), chainID_(cid),
       isTerminal_(false)
     {}
-    /// CONSTRUCTOR - Res name, original resnum, segment ID
-    Residue(NameType const& n, int r, int s) :
+    /// CONSTRUCTOR - Res name, original resnum, res icode, segment ID
+    Residue(NameType const& n, int r, char i, int s) :
       resname_(n), firstAtom_(-1), lastAtom_(-1), originalResNum_(r), segID_(s),
-       icode_(' '), chainID_(' '), isTerminal_(false)
+       icode_(i), chainID_(' '), isTerminal_(false)
     {}
     inline void SetFirstAtom(int i)        { firstAtom_ = i;      }
     inline void SetLastAtom(int i)         { lastAtom_ = i;       }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.15.1"
+#define CPPTRAJ_INTERNAL_VERSION "V4.16.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Pucker/CremerF.dat.save
+++ b/test/Test_Pucker/CremerF.dat.save
@@ -1,2 +1,2 @@
 #Frame       Furanoid Furanoid[Amp]
-       1     265.1331        0.3530
+       1     265.1331       20.2243

--- a/test/Test_Pucker/CremerP.dat.save
+++ b/test/Test_Pucker/CremerP.dat.save
@@ -1,2 +1,2 @@
 #Frame       Pyranoid Pyranoid[Amp] Pyranoid[Theta]
-       1     183.1090        0.5566          5.1319
+       1     183.1090       31.8880          5.1319


### PR DESCRIPTION
1. Actually use the value passed in to the `DataSet_integer_mem::Assign()` function - doesn't currently cause bugs bug could down the road.
2. Convert calculated pucker amplitude values to degrees to be consistent with pucker and theta. Addresses #735.
3. Update documentation for `pucker` (clarifying all values are in degrees) and `distance` (clarifying how `reference` is used).
4. Fix parsing of PSF files with alpha characters in the residue ID field (which is legal); related to ParmEd/ParmEd#1058. Code will attempt to use alpha character found as residue insertion code.