### PR TITLE
Improve detection of C++11 support in configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,16 @@ the following libraries:
 * Parallel NetCDF (-mpi build only, for NetCDF trajectory output in parallel)
 * CUDA (-cuda build only)
 * FFTW (mostly optional; required for PME functionality)
+* [helPME](https://github.com/andysim/helpme) (optional; required for PME functionality)
 
 `./configure gnu` should be adequate to set up compilation for most systems.
 For systems without BLAS/LAPACK/ARPACK and/or NetCDF libraries installed,
 the `-amberlib` flag can be specified to use the ones already compiled in
 an AmberTools installation (`$AMBERHOME` must be set), e.g.
-`./configure -amberlib gnu`. For multicore systems, the `-openmp` flag can
+`./configure -amberlib gnu`. C++11 support is required to enable particle mesh
+Ewald (PME) calculation support.
+
+For multicore systems, the `-openmp` flag can
 be specified to enable OpenMP parallelization, e.g. `./configure -openmp gnu`.
 An MPI-parallelized version of CPPTRAJ can also be built using the `-mpi` flag.
 CPPTRAJ can be built with both MPI and OpenMP; when running this build users

--- a/configure
+++ b/configure
@@ -1420,17 +1420,73 @@ BasicChecks() {
 PlatformTests() {
   # C++11 support
   if [ "$C11_SUPPORT" = 'yes' ] ; then
+    # First try to test a basic C++11 construct
     cat > testp.cpp <<EOF
 #include <initializer_list>
 int main() { constexpr int a = 5; auto b = a; for (auto i : {1, 2, 3}) { b += i; } return 0; }
 EOF
-    TestProgram silent "  Testing C++11 support" "$CXX" "$CXXFLAGS $C11FLAG" testp.cpp
+    TestProgram silent "  Testing basic C++11 support" "$CXX" "$CXXFLAGS $C11FLAG" testp.cpp
     if [ $? -eq 1 ] ; then
       echo "Not present"
       C11_SUPPORT='no'
     else
       C11_SUPPORT='yes'
-      CXXFLAGS="$CXXFLAGS $C11FLAG"
+      # Next, test GNU backend for at least 4.8.1 support.
+      # Clang requires >= 3.3.
+      cat > testp.cpp <<EOF
+#include <cstdio>
+int main() {
+#ifdef __clang_major__
+// Test for Clang >= 3.3
+  printf("Clang %i.%i.%i\n", __clang_major__, __clang_minor__, __clang_patchlevel__);
+  int badClang = 1;
+#if __clang_major__ > 3
+  badClang = 0;
+#elif (__clang_major__ == 3 && __clang_minor__ > 2)
+  badClang = 0;
+#endif
+  if (badClang == 1)
+    printf("Clang < 3.3 detected.\n");
+  else
+    printf("Clang >= 3.3 detected.\n");
+  return badClang;
+#else
+// Test for GCC >= 4.8.1
+  printf("GCC %i.%i.%i\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+  int badGcc = 1;
+#if __GNUC__ > 4
+  badGcc = 0;
+#elif (__GNUC__ == 4 && __GNUC_MINOR__ > 8)
+  badGcc = 0;
+#elif (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ > 0)
+  badGcc = 0;
+#endif
+  if (badGcc == 1)
+    printf("GCC < 4.8.1 detected.\n");
+  else
+    printf("GCC >= 4.8.1 detected.\n");
+  return badGcc;
+#endif /* GCC/Clang */
+}
+EOF
+      echo -n "  Testing GNU backend for C++11 support: "
+      $CXX $CXXFLAGS $C11FLAG -o testp testp.cpp > $COMPOUT 2> $COMPERR
+      if [ $? -ne 0 ] ; then
+        C11_SUPPORT='no'
+      else
+        ./testp > prog.out
+        if [ $? -ne 0 ] ; then
+          C11_SUPPORT='no'
+        fi
+        rm -f testp prog.out
+      fi
+      rm -f $COMPOUT $COMPERR
+      if [ "$C11_SUPPORT" = 'no' ] ; then
+        echo "Not supported"
+      else
+        echo "OK"
+        CXXFLAGS="$CXXFLAGS $C11FLAG"
+      fi
     fi
   fi
   # Some compilers (like older Intel) have a problem with the order of

--- a/configure
+++ b/configure
@@ -1469,7 +1469,7 @@ int main() {
 #endif /* GCC/Clang */
 }
 EOF
-      echo -n "  Testing GNU backend for C++11 support: "
+      echo -n "  Testing system headers for C++11 support: "
       $CXX $CXXFLAGS $C11FLAG -o testp testp.cpp > $COMPOUT 2> $COMPERR
       if [ $? -ne 0 ] ; then
         C11_SUPPORT='no'

--- a/src/Parm_CharmmPsf.cpp
+++ b/src/Parm_CharmmPsf.cpp
@@ -1,5 +1,6 @@
 // Parm_CharmmPsf.cpp
 #include <cstdio> // sscanf
+#include <cstdlib> // atoi
 #include <cstring> // strncmp
 #include <cctype> // isdigit
 #include "Parm_CharmmPsf.h"

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.19.3"
+#define CPPTRAJ_INTERNAL_VERSION "V4.19.4"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Intended to address #743. After the initial C++11 support check, this PR adds a check for the version of the GCC backend and ensures it is >= 4.8.1 (which seems to be the minimal GNU version with full C++11 support). Clang is different, so for clang compilers we check that the version is >= 3.3. Tested on linux with gnu, intel, pgi, and clang, and on OSX with gnu and clang. Seems to work ok. Let's see what happens with the appveyor builds.