### PR TITLE
Improve portability of the curvefit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,17 @@ matrix:
     - { os: linux, compiler: clang, env: COMPILER=clang USE_CMAKE=0 BUILD_TYPE=install TEST_TYPE=test.showerrors }
     - { os: linux, env: COMPILER=gnu USE_CMAKE=0 BUILD_FLAGS="-openmp" OPT=openmp OMP_NUM_THREADS=4 BUILD_TYPE=install TEST_TYPE=test.showerrors }
     - { os: linux, env: COMPILER=gnu USE_CMAKE=0 BUILD_FLAGS="-mpi" DO_PARALLEL="mpiexec -n 2" BUILD_TYPE=install TEST_TYPE=test.showerrors }
-    - { os: osx, compiler: clang, env: COMPILER=clang USE_CMAKE=0 BUILD_FLAGS="-macAccelerate --with-fftw3=/usr/local --with-netcdf=/usr/local -noarpack" BUILD_TYPE=install TEST_TYPE=test.showerrors }
+    - { os: osx, compiler: clang, env: COMPILER=clang USE_CMAKE=0 BUILD_FLAGS="-macAccelerate --with-fftw3=/usr/local --with-netcdf=/usr/local" BUILD_TYPE=install TEST_TYPE=test.showerrors }
     - { os: linux, env: COMPILER=gnu USE_CMAKE=0 BUILD_FLAGS="-openmp -shared -fftw3" OPT=openmp OMP_NUM_THREADS=1 BUILD_TYPE=libcpptraj TEST_TYPE=test.libcpptraj }
     - { os: linux, env: COMPILER=GNU USE_CMAKE=1 BUILD_FLAGS="-DOPENMP=TRUE" OMP_NUM_THREADS=4 OPT=openmp TEST_TYPE=test.showerrors}
-    - { os: osx, osx_image: xcode9.2, env: COMPILER=CLANG USE_CMAKE=1 BUILD_FLAGS="" TEST_TYPE=test.showerrors}
+    - { os: osx,   env: COMPILER=CLANG USE_CMAKE=1 BUILD_FLAGS="" TEST_TYPE=test.showerrors}
 
 #shell_session_update() { echo "Overriding shell_session_update"; };
 
     
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      rm -rf '/usr/local/include/c++'
-      brew tap homebrew/science;
-      brew update;
-      brew install netcdf fftw arpack;
+      brew install netcdf fftw;
       
       curl -L https://anaconda.org/AmberMD/amber_phenix/0.9.6/download/osx-64/amber_phenix-0.9.6-0.tar.bz2 > $HOME/osx_amber.tar.bz2;
       tar jxf $HOME/osx_amber.tar.bz2 lib/libsander.dylib AmberTools/src/sander/sander.h;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                     steps {
                         sh "./configure --with-netcdf --with-fftw3 gnu"
                         sh "make -j4 install"
-                        sh "make check"
+                        sh "cd test && make test.showerrors"
                     }
                 }
                 stage("Linux Intel Serial Build") {
@@ -51,7 +51,7 @@ pipeline {
                     steps {
                         sh "./configure --with-netcdf -mkl intel"
                         sh "make -j4 install"
-                        sh "make check"
+                        sh "cd test && make test.showerrors"
                     }
                 }
                 stage("Linux PGI serial build") {
@@ -70,7 +70,7 @@ pipeline {
                             try {
                                 sh "./configure --with-netcdf --with-fftw3 pgi"
                                 sh "make -j6 install"
-                                sh "make check"
+                                sh "cd test && make test.showerrors"
                             } catch (error) {
                                 echo "PGI BUILD AND/OR TEST FAILED"
                             }

--- a/src/ClusterList.cpp
+++ b/src/ClusterList.cpp
@@ -109,7 +109,7 @@ void SetBestRepFrame(ClusterNode& node, RepMap const& reps) {
   if (!reps.empty()) {
     node.BestReps().clear();
     for (RepMap::const_iterator it = reps.begin(); it != reps.end(); ++it) {
-      node.BestReps().push_back( ClusterNode::RepPair(it->second, (float)it->first) );
+      node.BestReps().push_back( ClusterNode::RepPair(it->second, it->first) );
     }
   }
 }

--- a/src/ClusterNode.cpp
+++ b/src/ClusterNode.cpp
@@ -1,4 +1,4 @@
-#include <cfloat> // DBL_MAX
+//#incl ude <cfloat> // DBL_MAX
 #include <algorithm> // sort
 #include "ClusterNode.h"
 

--- a/src/ClusterNode.h
+++ b/src/ClusterNode.h
@@ -11,7 +11,7 @@ class ClusterNode {
     ClusterNode(const ClusterNode&);
     ClusterNode& operator=(const ClusterNode&);
     /// Used to pair a representative frame number with a score.
-    typedef std::pair<int,float> RepPair;
+    typedef std::pair<int,double> RepPair;
     /// Used to hold a list of representative frames/scores
     typedef std::vector<RepPair> RepPairArray;
     /// Used to sort clusters by # of frames in cluster

--- a/src/DataSet_string.cpp
+++ b/src/DataSet_string.cpp
@@ -66,6 +66,9 @@ int DataSet_string::Sync(size_t total, std::vector<int> const& rank_frames,
                          Parallel::Comm const& commIn)
 {
   if (commIn.Size() == 1) return 0;
+  // NOTE: Using an integer type for blockSize could potentially overflow, but
+  //       since the MPI standard currently mandates that MPI_Send and MPI_Recv
+  //       take an integer as the count, that is what we use.
   if (commIn.Master()) {
     // MASTER
     char* block = 0;
@@ -76,9 +79,17 @@ int DataSet_string::Sync(size_t total, std::vector<int> const& rank_frames,
     Data_.resize( Data_.size() + additional_frames );
     // Receive data from each rank.
     for (int rank = 1; rank < commIn.Size(); rank++) {
-      // Need the size of the char* block
+      // Need the size of the char* block and max width inside that block
+      int maxWidth = 0;
       int blockSize = 0;
+      commIn.SendMaster( &maxWidth,  1, rank, MPI_INT );
+      // Check string width. Update format width if necessary.
+      if ( maxWidth > format_.Width() )
+        format_.SetWidth( maxWidth );
+      // Receive the block size
       commIn.SendMaster( &blockSize, 1, rank, MPI_INT );
+      // Bail on overflow
+      if (blockSize < 0) return 1;
       if (blockSize > currentBlockSize) {
         if (block != 0) delete[] block;
         block = new char[ blockSize ];
@@ -97,12 +108,20 @@ int DataSet_string::Sync(size_t total, std::vector<int> const& rank_frames,
     if (block != 0) delete[] block;
   } else {
     // RANK
-    // Get sum size of each string on rank (including null char).
-    size_t blockSize = 0;
+    // Get sum size of each string on rank (including null char). Also get
+    // the max size so master can correct the format width if necessary.
+    int maxWidth = 0;
+    int blockSize = 0;
     for (std::vector<std::string>::const_iterator it = Data_.begin(); it != Data_.end(); ++it)
-      blockSize += (it->size() + 1); // +1 for null char.
+    {
+      maxWidth = std::max( maxWidth, (int)it->size() );
+      blockSize += (int)(it->size() + 1); // +1 for null char.
+    }
     char* block = new char[ blockSize ];
+    commIn.SendMaster( &maxWidth,  1, commIn.Rank(), MPI_INT );
     commIn.SendMaster( &blockSize, 1, commIn.Rank(), MPI_INT );
+    // Bail on overflow
+    if (blockSize < 0) return 1;
     // Copy each string (including null char) to array
     char* ptr = block;
     for (std::vector<std::string>::const_iterator it = Data_.begin(); it != Data_.end(); ++it)

--- a/src/FileIO_Bzip2.cpp
+++ b/src/FileIO_Bzip2.cpp
@@ -27,17 +27,17 @@ FileIO_Bzip2::~FileIO_Bzip2() {
 // FileIO_Bzip2::BZerror()
 /** Return a string corresponding to the current value of err.
   */
-const char *FileIO_Bzip2::BZerror() {
-  switch (err_) {
-    case BZ_OK : return "BZ_OK";
-    case BZ_PARAM_ERROR : return "BZ_PARAM_ERROR";
-    case BZ_SEQUENCE_ERROR : return "BZ_SEQUENCE_ERROR";
-    case BZ_IO_ERROR: return "BZ_IO_ERROR";
-    case BZ_UNEXPECTED_EOF : return "BZ_UNEXPECTED_EOF";
-    case BZ_DATA_ERROR : return "BZ_DATA_ERROR";
+const char *FileIO_Bzip2::BZerror(int err) {
+  switch (err) {
+    case BZ_OK               : return "BZ_OK";
+    case BZ_PARAM_ERROR      : return "BZ_PARAM_ERROR";
+    case BZ_SEQUENCE_ERROR   : return "BZ_SEQUENCE_ERROR";
+    case BZ_IO_ERROR         : return "BZ_IO_ERROR";
+    case BZ_UNEXPECTED_EOF   : return "BZ_UNEXPECTED_EOF";
+    case BZ_DATA_ERROR       : return "BZ_DATA_ERROR";
     case BZ_DATA_ERROR_MAGIC : return "BZ_DATA_ERROR_MAGIC";
-    case BZ_MEM_ERROR : return "BZ_MEM_ERROR";
-    case BZ_STREAM_END : return "BZ_MEM_ERROR";
+    case BZ_MEM_ERROR        : return "BZ_MEM_ERROR";
+    case BZ_STREAM_END       : return "BZ_STREAM_END";
   }
   return "Unknown Bzip2 error";
 }
@@ -202,8 +202,8 @@ int FileIO_Bzip2::Read(void *buffer, size_t num_bytes) {
   position_ += ((off_t) numread);
   if (err_!=BZ_OK && err_!=BZ_STREAM_END) {
     mprinterr("Error: FileIO_Bzip2::Read: BZ2_bzRead error: [%s]\n"
-              "Error:                     size=%i expected=%zu\n",
-               this->BZerror(), numread, num_bytes);
+              "Error:                     size=%i expected=%zu position=%lld\n",
+               BZerror(err_), numread, num_bytes, (long long int)position_);
     return -1;
   }
   return numread;

--- a/src/FileIO_Bzip2.cpp
+++ b/src/FileIO_Bzip2.cpp
@@ -90,7 +90,7 @@ int FileIO_Bzip2::Open(const char *filename, const char *mode) {
 
   fp_ = fopen(filename, mode);
   if (fp_==NULL) {
-    mprintf("Error: FileIO_Bzip2::Open: Could not open %s with mode %s\n",filename,mode);
+    mprinterr("Error: FileIO_Bzip2::Open: Could not open %s with mode %s\n",filename,mode);
     return 1;
   }
 
@@ -106,13 +106,14 @@ int FileIO_Bzip2::Open(const char *filename, const char *mode) {
       isBzread_ = false; 
       break;
     case 'a' : 
-      mprintf("Error: FileIO_Bzip2::Open: Append not supported for Bzip2.\n");
+      mprinterr("Error: FileIO_Bzip2::Open: Append not supported for Bzip2.\n");
       return 1; // No append for Bzip2
     default: return 1; 
   }
 
   if (err_ != BZ_OK) {
-    mprintf("Error: FileIO_Bzip2::Open: Could not BZOPEN %s with mode %s\n",filename,mode);
+    mprinterr("Error: FileIO_Bzip2::Open: [%s] Could not BZOPEN %s with mode %s\n",
+            BZerror(err_), filename, mode);
     return 1;
   }
 
@@ -216,7 +217,9 @@ int FileIO_Bzip2::Write(const void *buffer, size_t num_bytes) {
   // Update position
   position_ += ((off_t)num_bytes);
   if (err_ == BZ_IO_ERROR) { 
-    mprintf( "Error: FileIO_Bzip2::Write: BZ2_bzWrite error\n");
+    mprinterr("Error: FileIO_Bzip2::Write: BZ2_bzWrite error: [%s]\n"
+              "Error:                      expected=%zu position=%lld\n",
+              BZerror(err_), num_bytes, (long long int)position_);
     return 1;
   }
   return 0;

--- a/src/FileIO_Bzip2.cpp
+++ b/src/FileIO_Bzip2.cpp
@@ -204,8 +204,8 @@ int FileIO_Bzip2::Read(void *buffer, size_t num_bytes) {
   // If BZ_STREAM_END already encountered, just return.
   if (eofStat_) return 0;
   int numread = BZ2_bzRead(&err_, infile_, buffer, num_bytes);
-  mprintf("DEBUG: bzRead '%s' num_bytes=%zu numread=%i err=%i [%s]\n",
-          bzfilename_, num_bytes, numread, err_, BZerror(err_));
+  //mprintf("DEBUG: bzRead '%s' num_bytes=%zu numread=%i err=%i [%s]\n",
+  //        bzfilename_, num_bytes, numread, err_, BZerror(err_));
   // Update position
   position_ += ((off_t) numread);
   // Check error status

--- a/src/FileIO_Bzip2.h
+++ b/src/FileIO_Bzip2.h
@@ -25,13 +25,14 @@ class FileIO_Bzip2 : public FileIO {
   private:
     static const char *BZerror(int);
 
-    FILE *fp_;
-    BZFILE *infile_;
-    char *bzfilename_;
-    char *bzmode_;
-    off_t position_;
-    int err_;
-    bool isBzread_;
+    FILE *fp_;         ///< The system file handle.
+    BZFILE *infile_;   ///< The bzip file handle.
+    char *bzfilename_; ///< The file name, saved in case we need to rewind.
+    char *bzmode_;     ///< The file mode, saved in case we need to rewind.
+    off_t position_;   ///< The current position in the file, for Tell().
+    int err_;          ///< The current error status.
+    bool eofStat_;     ///< True if BZ_STREAM_END encountered during read.
+    bool isBzread_;    ///< True if reading, false otherwise.
 };
 #endif
 #endif

--- a/src/FileIO_Bzip2.h
+++ b/src/FileIO_Bzip2.h
@@ -23,6 +23,8 @@ class FileIO_Bzip2 : public FileIO {
     int Gets(char *, int );
     int SetSize(long int) { return 0; }
   private:
+    static const char *BZerror(int);
+
     FILE *fp_;
     BZFILE *infile_;
     char *bzfilename_;
@@ -30,8 +32,6 @@ class FileIO_Bzip2 : public FileIO {
     off_t position_;
     int err_;
     bool isBzread_;
-
-    const char *BZerror();
 };
 #endif
 #endif

--- a/src/RPNcalc.cpp
+++ b/src/RPNcalc.cpp
@@ -467,7 +467,7 @@ int RPNcalc::Evaluate(DataSetList& DSL) const {
       else {
         ds = DSL.GetDataSet( T->Name() );
         if (ds == 0) {
-          mprinterr("Error: Data set with name '%s' not found.\n", T->name());
+          rprinterr("Error: Data set with name '%s' not found.\n", T->name());
           return 1;
         }
       }

--- a/src/RPNcalc.h
+++ b/src/RPNcalc.h
@@ -51,6 +51,7 @@ class RPNcalc {
     };
 
     static inline double DoOperation(double, double, TokenType);
+    int TokenLoop(DataSetList& DSL) const;
 
     typedef std::vector<Token> Tarray;
     Tarray tokens_;

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.19.4"
+#define CPPTRAJ_INTERNAL_VERSION "V4.19.5"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_CurveFit/RunTest.sh
+++ b/test/Test_CurveFit/RunTest.sh
@@ -28,16 +28,17 @@ runanalysis curvefit Data.dat nexp 2 name KFitY form mexpk \
   out Kcurve.dat tol 0.0001 maxit 5000
 
 runanalysis curvefit Data.dat nexp 2 name PKFitY form mexpk_penalty \
-  A0=0 A1=1 A2=-1 A3=1 A4=-1 \
+  A0=0 A1=.5 A2=-1 A3=.5 A4=-1 \
   out PKcurve.dat tol 0.0001 maxit 5000 resultsout Results.dat
 EOF
 RunCpptraj "Curve fitting multi-exponential tests."
 DoTest curve.dat.save curve1.dat
 DoTest results1.dat.save results1.dat
-DoTest Kcurve.dat.save Kcurve.dat -r 0.0009
+DoTest Kcurve.dat.save Kcurve.dat -a 0.0002
 # Differences in windows seem like round-off
-DoTest PKcurve.dat.save PKcurve.dat -r 0.0003
-DoTest Results.dat.save Results.dat -a 0.2
+DoTest PKcurve.dat.save PKcurve.dat -a 0.0002
+# Order of exponentials in results can change, so just check curve.
+#DoTest Results.dat.save Results.dat -a 0.2
 
 # Custom X output range.
 cat > cf.in <<EOF

--- a/test/Test_CurveFit/RunTest.sh
+++ b/test/Test_CurveFit/RunTest.sh
@@ -2,7 +2,8 @@
 
 . ../MasterTest.sh
 
-CleanFiles cf.in curve.dat curve1.dat Kcurve.dat PKcurve.dat curve2.dat Results.dat
+CleanFiles cf.in curve.dat curve1.dat Kcurve.dat PKcurve.dat curve2.dat \
+           Results.dat results1.dat
 
 INPUT="-i cf.in"
 # General test
@@ -20,7 +21,7 @@ cat > cf.in <<EOF
 readdata Data.dat index 1
 runanalysis curvefit Data.dat nexp 2 name FitY \
   A0=1 A1=-1 A2=1 A3=-1 \
-  out curve1.dat tol 0.0001 maxit 5000
+  out curve1.dat resultsout results1.dat tol 0.0001 maxit 5000
 
 runanalysis curvefit Data.dat nexp 2 name KFitY form mexpk \
   A0=0 A1=1 A2=-1 A3=1 A4=-1 \
@@ -32,6 +33,7 @@ runanalysis curvefit Data.dat nexp 2 name PKFitY form mexpk_penalty \
 EOF
 RunCpptraj "Curve fitting multi-exponential tests."
 DoTest curve.dat.save curve1.dat
+DoTest results1.dat.save results1.dat
 DoTest Kcurve.dat.save Kcurve.dat -r 0.0009
 # Differences in windows seem like round-off
 DoTest PKcurve.dat.save PKcurve.dat -r 0.0003

--- a/test/Test_CurveFit/results1.dat.save
+++ b/test/Test_CurveFit/results1.dat.save
@@ -1,0 +1,11 @@
+#Fit equation 'FitY = (A0 * exp(X * A1)) + (A2 * exp(X * A3))' to set 'Y=(0.6*exp(-0.004*X))+(0.4*exp(-0.02*X))'
+#Final Param A0 = 0.6
+#Final Param A1 = -0.004
+#Final Param A2 = 0.4
+#Final Param A3 = -0.02
+#Correlation coefficient: 1
+#Chi squared: 7.70001e-16
+#Uncertainty coefficient: 4.03516e-09
+#RMS percent error: 4.50419e-09
+#Sum of prefactors = 1
+#Time constants (-1.0/A<n>):          250           50


### PR DESCRIPTION
The multi-exponential curve fit with a penalty function tends to not be very stable since the ordering of the exponential functions doesn't really matter. This PR changes the test slightly to just check the resulting curves, and check the specific parameters for the simpler multi-exponential fit instead. Also gives the multi-exponential + penalty test a better starting guess for some parameters to improve the stability. Hopefully this will go a ways towards improving test behavior with certain compilers.