### PR TITLE
Improve configure compile fail detection

### DIFF
--- a/configure
+++ b/configure
@@ -367,7 +367,7 @@ TestProgram() {
   COMPILELINE="$comp $args -o testp $file $link"
   #echo "COMPILE: $COMPILELINE" #DEBUG
   $COMPILELINE > $COMPOUT 2> $COMPERR
-  if [ $? -ne 0 ] ; then
+  if [ $? -ne 0 -o ! -f 'testp' ] ; then
     if [ $silent -eq 0 ] ; then
       echo ""
       ErrMsg "Test compile failed: $COMPILELINE"


### PR DESCRIPTION
Sometimes compile can fail but return 0 (esp. if its a wrapper). Fail also if binary not produced.