### PR TITLE
Trap PairList errors

### DIFF
--- a/src/Action_Energy.cpp
+++ b/src/Action_Energy.cpp
@@ -416,6 +416,7 @@ double Action_Energy::Dbg_Direct(Frame const& frameIn, int maxpoints) {
 Action::RetType Action_Energy::DoAction(int frameNum, ActionFrame& frm) {
   time_total_.Start();
   double Etot = 0.0, ene, ene2;
+  int err = 0;
   typedef std::vector<CalcType>::const_iterator calc_it;
   for (calc_it calc = Ecalcs_.begin(); calc != Ecalcs_.end(); ++calc)
   {
@@ -484,8 +485,9 @@ Action::RetType Action_Energy::DoAction(int frameNum, ActionFrame& frm) {
       case C_EWALD:
       case C_PME: // Elec must be enabled, vdw may not be
         time_NB_.Start();
-        ene = EW_->CalcEnergy(frm.Frm(), Imask_, ene2);
+        err = EW_->CalcNonbondEnergy(frm.Frm(), Imask_, ene, ene2);
         time_NB_.Stop();
+        if (err != 0) return Action::ERR;
         Energy_[ELEC]->Add(frameNum, &ene);
         if (Energy_[VDW] != 0) Energy_[VDW]->Add(frameNum, &ene2);
         Etot += (ene + ene2);

--- a/src/Action_Image.cpp
+++ b/src/Action_Image.cpp
@@ -112,7 +112,7 @@ Action::RetType Action_Image::Setup(ActionSetup& setup) {
   if (setup.CoordInfo().TrajBox().Type()==Box::ORTHO && triclinic_==OFF)
     ortho_ = true;
   // Setup atom pairs to be unwrapped.
-  imageList_ = Image::CreatePairList(setup.Top(), imageMode_, maskExpression_);
+  imageList_ = Image::CreateAtomPairList(setup.Top(), imageMode_, maskExpression_);
   if (imageList_.empty()) {
     mprintf("Warning: No atoms selected for topology '%s'.\n", setup.Top().c_str());
     return Action::SKIP;

--- a/src/Action_Spam.cpp
+++ b/src/Action_Spam.cpp
@@ -386,7 +386,11 @@ Action::RetType Action_Spam::DoPureWater(int frameNum, Frame const& frameIn)
 {
   t_action_.Start();
   frameIn.BoxCrd().ToRecip(ucell_, recip_);
-  pairList_.CreatePairList(frameIn, ucell_, recip_, mask_);
+  int retVal = pairList_.CreatePairList(frameIn, ucell_, recip_, mask_);
+  if (retVal != 0) {
+    mprinterr("Error: Grid setup failed.\n");
+    return Action::ERR;
+  }
   int wat = 0, wat1 = 0;
   int basenum = frameNum * solvent_residues_.size();
   DataSet_double& evals = static_cast<DataSet_double&>( *myDSL_[0] );

--- a/src/Action_Unwrap.cpp
+++ b/src/Action_Unwrap.cpp
@@ -93,7 +93,7 @@ Action::RetType Action_Unwrap::Setup(ActionSetup& setup) {
     orthogonal_ = true;
 
   // Setup atom pairs to be unwrapped.
-  imageList_ = Image::CreatePairList(setup.Top(), imageMode_, maskExpression_);
+  imageList_ = Image::CreateAtomPairList(setup.Top(), imageMode_, maskExpression_);
   if (imageList_.empty()) {
     mprintf("Warning: Mask selects no atoms for topology '%s'.\n", setup.Top().c_str());
     return Action::SKIP;

--- a/src/BondSearch.cpp
+++ b/src/BondSearch.cpp
@@ -366,7 +366,11 @@ int BondSearch_PL( Topology& top, Frame const& frameIn, double offset, int debug
   PL.SetupPairList( box );
   Matrix_3x3 ucell, recip;
   box.ToRecip( ucell, recip );
-  PL.CreatePairList( frameIn, ucell, recip, AtomMask(0, frameIn.Natom()) );
+  int retVal = PL.CreatePairList( frameIn, ucell, recip, AtomMask(0, frameIn.Natom()) );
+  if (retVal != 0) {
+    mprinterr("Error: Grid setup failed.\n");
+    return 1;
+  }
 
   // Determine bonds
   int cidx;

--- a/src/Ewald.h
+++ b/src/Ewald.h
@@ -5,14 +5,15 @@ class AtomMask;
 class Frame;
 #include "Timer.h"
 #include "PairList.h"
-/// Base class for calculating electrostatics using Ewald methods.
+/// Base class for calculating non-bonded energy using Ewald methods.
 class Ewald {
   public:
     Ewald();
     // ----- Virtual functions -------------------
     virtual ~Ewald() {}
     virtual int Setup(Topology const&, AtomMask const&) = 0;
-    virtual double CalcEnergy(Frame const&, AtomMask const&, double&) = 0; // TODO const?
+    /// Calculate electrostatic and van der Waals energy
+    virtual int CalcNonbondEnergy(Frame const&, AtomMask const&, double&, double&) = 0;
     // -------------------------------------------
     /// Report timings.
     void Timing(double) const;

--- a/src/Ewald_ParticleMesh.h
+++ b/src/Ewald_ParticleMesh.h
@@ -12,7 +12,7 @@ class Ewald_ParticleMesh : public Ewald {
              int, int, const int*);
     // ----- Inherited ---------------------------
     int Setup(Topology const&, AtomMask const&);
-    double CalcEnergy(Frame const&, AtomMask const&, double&); // TODO const?
+    int CalcNonbondEnergy(Frame const&, AtomMask const&, double&, double&);
   private:
     typedef Ewald::Darray Darray;
     /// Based on given length return number of grid points that is power of 2, 3, or 5

--- a/src/Ewald_Regular.h
+++ b/src/Ewald_Regular.h
@@ -10,7 +10,7 @@ class Ewald_Regular : public Ewald {
              double, int, const int*);
     // ----- Inherited ---------------------------
     int Setup(Topology const&, AtomMask const&);
-    double CalcEnergy(Frame const&, AtomMask const&, double&); // TODO const?
+    int CalcNonbondEnergy(Frame const&, AtomMask const&, double&, double&);
   private:
     /// Determine max length for reciprocal calcs based on reciprocal limits
     static double FindMaxexpFromMlim(const int*, Matrix_3x3 const&);

--- a/src/ImageRoutines.cpp
+++ b/src/ImageRoutines.cpp
@@ -21,13 +21,13 @@ static inline void CheckRange(Image::PairType& atomPairs, CharMask const& MaskIn
   }
 }
 
-// Image::CreatePairList() 
+// Image::CreateAtomPairList() 
 /** An atom pair list consists of 2 values for each entry, a beginning
   * index and ending index. For molecules and residues this is the first
   * and just beyond the last atom; for atoms it is just the atom itself
   * twice.
   */
-Image::PairType Image::CreatePairList(Topology const& Parm, Mode modeIn,
+Image::PairType Image::CreateAtomPairList(Topology const& Parm, Mode modeIn,
                                        std::string const& maskExpression)
 {
   PairType atomPairs;

--- a/src/ImageRoutines.h
+++ b/src/ImageRoutines.h
@@ -10,7 +10,7 @@ class Box;
 #include "ImageTypes.h"
 namespace Image {
   /// Create an atom pair list by molecule, residue, or atom.
-  PairType CreatePairList(Topology const&, Mode, std::string const&);
+  PairType CreateAtomPairList(Topology const&, Mode, std::string const&);
   /// \return Coordinates of center if wrapping molecules into truncated oct. shape.
   Vec3 SetupTruncoct( Frame const&, AtomMask*, bool, bool);
   /// Perform non-orthogonal imaging on given pair list, optionally into trunc. oct. shape.

--- a/src/PDBfile.cpp
+++ b/src/PDBfile.cpp
@@ -260,7 +260,7 @@ int PDBfile::pdb_Bonds(int* bnd) {
     unsigned int end = lb + 5;
     char savechar = linebuffer_[end];
     linebuffer_[end] = '\0';
-    bnd[Nscan++] = atof( linebuffer_ + lb );
+    bnd[Nscan++] = atoi( linebuffer_ + lb );
     linebuffer_[end] = savechar;
   }
   if (Nscan < 2)

--- a/src/PairList.cpp
+++ b/src/PairList.cpp
@@ -106,8 +106,8 @@ int PairList::GridAtom(int atomIdx, Vec3 const& frac, Vec3 const& cart) {
 # endif
   if (idx < 0 || idx >= (int)cells_.size()) {
     // This can happen for e.g. NaN coords
-    mprinterr("Internal Error: Grid %i is out of range (>= %zu || < 0)\n",
-              idx, cells_.size());
+    //mprinterr("Internal Error: Grid %i is out of range (>= %zu || < 0)\n",
+    //          idx, cells_.size());
     return 1;
   }
   cells_[idx].AddAtom( AtmType(atomIdx, cart) );

--- a/src/PairList.cpp
+++ b/src/PairList.cpp
@@ -71,6 +71,8 @@ void PairList::FillTranslateVec(Matrix_3x3 const& ucell) {
 }
 
 // PairList::CreatePairList()
+/** \return -1 if error occurs setting up grid, 0 if all OK, otherwise # atoms off-grid
+  */
 int PairList::CreatePairList(Frame const& frmIn, Matrix_3x3 const& ucell,
                              Matrix_3x3 const& recip, AtomMask const& maskIn)
 {
@@ -79,18 +81,21 @@ int PairList::CreatePairList(Frame const& frmIn, Matrix_3x3 const& ucell,
   FillTranslateVec(ucell);
   // If box size has changed a lot this will reallocate grid
   t_gridpointers_.Start();
-  if (SetupGrids(frmIn.BoxCrd().RecipLengths(recip))) return 1;
+  if (SetupGrids(frmIn.BoxCrd().RecipLengths(recip))) return -1;
   t_gridpointers_.Stop();
   // Place atoms in grid cells
   t_map_.Start();
-  GridUnitCell(frmIn, ucell, recip, maskIn);
+  int nOffGrid = GridUnitCell(frmIn, ucell, recip, maskIn);
+  if (nOffGrid > 0)
+    mprintf("Warning: %i atoms are off the grid. This usually indicates corrupted coordinates.\n",
+            nOffGrid);
   t_map_.Stop();
   t_total_.Stop();
-  return 0;
+  return nOffGrid;
 }
 
 // PairList::GridAtom()
-void PairList::GridAtom(int atomIdx, Vec3 const& frac, Vec3 const& cart) {
+int PairList::GridAtom(int atomIdx, Vec3 const& frac, Vec3 const& cart) {
   int i1 = (int)((frac[0]) * (double)nGridX_);
   int i2 = (int)((frac[1]) * (double)nGridY_);
   int i3 = (int)((frac[2]) * (double)nGridZ_);
@@ -99,19 +104,21 @@ void PairList::GridAtom(int atomIdx, Vec3 const& frac, Vec3 const& cart) {
   mprintf("GRID2 atom assigned to cell %6i%6i%10.5f%10.5f%10.5f\n",
           atomIdx+1, idx+1, frac[0], frac[1], frac[2]);
 # endif
-  if (idx < 0 || idx >= (int)cells_.size()) { // Sanity check
+  if (idx < 0 || idx >= (int)cells_.size()) {
+    // This can happen for e.g. NaN coords
     mprinterr("Internal Error: Grid %i is out of range (>= %zu || < 0)\n",
               idx, cells_.size());
-    return;
+    return 1;
   }
   cells_[idx].AddAtom( AtmType(atomIdx, cart) );
   Frac_.push_back( frac );
+  return 0;
 }
 
 /** Place selected atoms into grid cells. Convert to fractional coords, wrap
   * into primary cell, then determine grid cell.
   */
-void PairList::GridUnitCell(Frame const& frmIn, Matrix_3x3 const& ucell,
+int PairList::GridUnitCell(Frame const& frmIn, Matrix_3x3 const& ucell,
                              Matrix_3x3 const& recip, AtomMask const& maskIn)
 {
   // Clear any existing atoms in cells.
@@ -119,6 +126,7 @@ void PairList::GridUnitCell(Frame const& frmIn, Matrix_3x3 const& ucell,
     cell->ClearAtoms();
   Frac_.clear();
   Frac_.reserve( maskIn.Nselected() );
+  int nOffGrid = 0;
   if (frmIn.BoxCrd().Type() == Box::ORTHO) {
     // Orthogonal imaging
     for (AtomMask::const_iterator atom = maskIn.begin(); atom != maskIn.end(); ++atom)
@@ -131,7 +139,7 @@ void PairList::GridUnitCell(Frame const& frmIn, Matrix_3x3 const& ucell,
       mprintf("DBG: o %6i fc=%7.3f%7.3f%7.3f  fcw=%7.3f%7.3f%7.3f  ccw=%7.3f%7.3f%7.3f\n",
               *atom+1, fc[0], fc[1], fc[2], fcw[0], fcw[1], fcw[2], ccw[0], ccw[1], ccw[2]);
 #     endif
-      GridAtom( atom-maskIn.begin(), fcw, ccw );
+      nOffGrid += GridAtom( atom-maskIn.begin(), fcw, ccw );
     }
   } else {
     // Non-orthogonal imaging
@@ -144,9 +152,10 @@ void PairList::GridUnitCell(Frame const& frmIn, Matrix_3x3 const& ucell,
       mprintf("DBG: n %6i fc=%7.3f%7.3f%7.3f  fcw=%7.3f%7.3f%7.3f  ccw=%7.3f%7.3f%7.3f\n",
               *atom+1, fc[0], fc[1], fc[2], fcw[0], fcw[1], fcw[2], ccw[0], ccw[1], ccw[2]);
 #     endif
-      GridAtom( atom-maskIn.begin(), fcw, ccw );
+      nOffGrid += GridAtom( atom-maskIn.begin(), fcw, ccw );
     }
   }
+  return nOffGrid;
 }
 
 // PairList::SetupGrids()

--- a/src/PairList.h
+++ b/src/PairList.h
@@ -55,9 +55,9 @@ class PairList {
     /// Update the translation vectors based on given unit cell matrix.
     void FillTranslateVec(Matrix_3x3 const&);
     /// Add atoms to grid cells.
-    void GridUnitCell(Frame const&, Matrix_3x3 const&, Matrix_3x3 const&, AtomMask const&);
+    int GridUnitCell(Frame const&, Matrix_3x3 const&, Matrix_3x3 const&, AtomMask const&);
     /// Calculate cell index based on given coords and add to cell
-    inline void GridAtom(int, Vec3 const&, Vec3 const&);
+    inline int GridAtom(int, Vec3 const&, Vec3 const&);
 
     Carray cells_;            ///< Hold all cells in grid
     Vec3 translateVec_[18];   ///< Translate vector array

--- a/src/StructureCheck.cpp
+++ b/src/StructureCheck.cpp
@@ -185,7 +185,15 @@ int StructureCheck::PL1_CheckOverlap(Frame const& currentFrame, Matrix_3x3 const
                                      Matrix_3x3 const& recip)
 {
   int Nproblems = 0;
-  pairList_.CreatePairList(currentFrame, ucell, recip, Mask1_);
+  int retVal = pairList_.CreatePairList(currentFrame, ucell, recip, Mask1_);
+  if (retVal < 0) {
+    // Treat grid setup failure as one problem.
+    mprinterr("Error: Grid setup failed.\n");
+    return 1;
+  } else if (retVal > 0) {
+    // Atoms off the grid should count as problems as well.
+    Nproblems = retVal;
+  }
   problemAtoms_.clear();
 
   int cidx;

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.25.1"
+#define CPPTRAJ_INTERNAL_VERSION "V4.25.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Errors that occur when setting up a PairList (due to e.g. corrupt coordinates) are now trapped. The total number of atoms off the grid are now reported instead of a message for every atom off the grid. Atoms that end up off the grid are now counted as problems by the `check` action. Pair list errors in energy calculations are now properly handled. 