### PR TITLE
Remove reference to AtomType.o, no longer used.

### DIFF
--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -425,7 +425,6 @@ LIBCPPTRAJ_CORE_OBJECTS= \
   Topology.o \
   Atom.o \
   AtomMask.o \
-  AtomType.o \
   Box.o \
   CharMask.o \
   CoordinateInfo.o \


### PR DESCRIPTION
I had a leftover object that caused it to erroneously pass last time. This time all should be well...