### PR TITLE
Fix Tinker ARC file detection when title line only has # atoms.

### DIFF
--- a/src/TinkerFile.cpp
+++ b/src/TinkerFile.cpp
@@ -26,7 +26,7 @@ static inline int SetNatomAndTitle(ArgList& lineIn, int& natom, std::string& tit
     nextWord = lineIn.GetStringNext();
   }
   // If all arguments were numbers this is probably not a title line after all.
-  if (nNumbers == lineIn.Nargs()) return 1;
+  if (lineIn.Nargs() > 1 && nNumbers == lineIn.Nargs()) return 1;
   return 0;
 }
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.25.6"
+#define CPPTRAJ_INTERNAL_VERSION "V4.25.7"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
The previous format check looked to see if the number of valid numbers on the tinker title line was the same as the number of tokens on the line; if so, detection would fail (because this may be another file format). This doesn't account for the case where there is only one number (a valid integer, the number of atoms), which is OK.

