### PR TITLE
Add option to prevent spaces between frames in 'nastruct' output.

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -28082,7 +28082,7 @@ nastruct
 \end_layout
 
 \begin_layout LyX-Code
-         [baseref <file>] ...
+         [noframespaces] [baseref <file>] ...
 \end_layout
 
 \begin_layout LyX-Code
@@ -28154,6 +28154,15 @@ naout
 \begin_layout Description
 [calcnohb] Calculate parameters between bases in base pairs even if no hydrogen
  bonds present between them.
+\end_layout
+
+\begin_layout Description
+[noframespaces] If specified there will be no spaces between frames in the
+ 
+\series bold
+naout
+\series default
+ files.
 \end_layout
 
 \begin_layout Description

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -28,6 +28,7 @@ Action_NAstruct::Action_NAstruct() :
   printheader_(true),
   seriesUpdated_(false),
   skipIfNoHB_(true),
+  spaceBetweenFrames_(true),
   bpout_(0), stepout_(0), helixout_(0),
   masterDSL_(0)
 # ifdef NASTRUCTDEBUG
@@ -38,7 +39,7 @@ Action_NAstruct::Action_NAstruct() :
 void Action_NAstruct::Help() const {
   mprintf("\t[<dataset name>] [resrange <range>] [naout <suffix>]\n"
           "\t[noheader] [resmap <ResName>:{A,C,G,T,U} ...] [calcnohb]\n"
-          "\t[baseref <file>] ...\n"
+          "\t[noframespaces] [baseref <file>] ...\n"
           "\t[hbcut <hbcut>] [origincut <origincut>] [altona | cremer]\n"
           "\t[zcut <zcut>] [zanglecut <zanglecut>] [groovecalc {simple | 3dna}]\n"
           "\t[{ %s | allframes | guessbp}]\n", DataSetList::RefArgs);
@@ -58,7 +59,9 @@ void Action_NAstruct::Help() const {
           "  hydrogen bonds present between base pairs.\n"
           "  Base pair parameters are written to 'BP.<suffix>', base pair step parameters\n"
           "  are written to 'BPstep.<suffix>', and helix parameters are written to\n"
-          "  Helix.<suffix>'\n");
+          "  Helix.<suffix>'.\n"
+          "  If 'noframespaces' is specified there will be no spaces between frames\n"
+          "  in the 'naout' files.\n");
 }
 
 // Action_NAstruct::Init()
@@ -110,6 +113,7 @@ Action::RetType Action_NAstruct::Init(ArgList& actionArgs, ActionInit& init, int
     resRange_.ShiftBy(-1); // User res args start from 1
   printheader_ = !actionArgs.hasKey("noheader");
   skipIfNoHB_ = !actionArgs.hasKey("calcnohb");
+  spaceBetweenFrames_ = !actionArgs.hasKey("noframespaces");
   // Determine how base pairs will be found.
   ReferenceFrame REF = init.DSL().GetReferenceFrame( actionArgs );
   if (REF.error()) return Action::ERR;
@@ -197,6 +201,7 @@ Action::RetType Action_NAstruct::Init(ArgList& actionArgs, ActionInit& init, int
     mprintf("\tBase pair step parameters written to %s\n", stepout_->Filename().full());
     mprintf("\tHelical parameters written to %s\n", helixout_->Filename().full());
     if (!printheader_) mprintf("\tHeader line will not be written.\n");
+    if (!spaceBetweenFrames_) mprintf("\tNo spaces will be written between frames.\n");
   }
   mprintf("\tHydrogen bond cutoff for determining base pairs is %.2f Angstroms.\n",
           sqrt( HBdistCut2_ ) );
@@ -1776,7 +1781,7 @@ void Action_NAstruct::Print() {
           bpout_->Printf(GROOVE_FMT, BP.major_->Dval(frame), BP.minor_->Dval(frame));
         bpout_->Printf("\n");
       }
-      bpout_->Printf("\n");
+      if (spaceBetweenFrames_) bpout_->Printf("\n");
     }
   }
 
@@ -1821,7 +1826,7 @@ void Action_NAstruct::Print() {
         }
         stepout_->Printf("\n");
       }
-      stepout_->Printf("\n");
+      if (spaceBetweenFrames_) stepout_->Printf("\n");
     }
     // Helix frames
     if (printheader_)
@@ -1840,7 +1845,7 @@ void Action_NAstruct::Print() {
                           BS.tip_->Dval(frame),   BS.htwist_->Dval(frame));
         helixout_->Printf("\n");
       }
-      helixout_->Printf("\n");
+      if (spaceBetweenFrames_) helixout_->Printf("\n");
     }
   }
 }

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -153,6 +153,7 @@ class Action_NAstruct: public Action {
     bool printheader_;                  ///< If true, print header to naout files.
     bool seriesUpdated_;                ///< If false, check that time series data is nframes long
     bool skipIfNoHB_;                   ///< When true, do not calc parameters when BP not present
+    bool spaceBetweenFrames_;           ///< If false do not print spaces between frames in naout
     CpptrajFile* bpout_;                ///< Base pair out (BP.<suffix>).
     CpptrajFile* stepout_;              ///< Base pair step out (BPstep.<suffix>).
     CpptrajFile* helixout_;             ///< Helical parameters out (Helix.<suffix>).

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.25.7"
+#define CPPTRAJ_INTERNAL_VERSION "V4.25.8"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Intended to address #803. If `noframespaces` is specified to `nastruct`, spaces will not be printed between frames.