### PR TITLE
Wrapdata

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -7810,6 +7810,11 @@ dataset { legend <legend> <set> |
 \end_layout
 
 \begin_layout LyX-Code
+          shift [above <value> by <offset>] [below <value> by <offset>]
+ <set arg0> ...
+\end_layout
+
+\begin_layout LyX-Code
     	  [mode <mode>] [type <type>] <set arg1> [<set arg 2> ...]
 \end_layout
 
@@ -8178,6 +8183,61 @@ name> Inverted output set name.
 \end_inset
 
 <set>] String data set containing legends
+\end_layout
+
+\end_deeper
+\begin_layout Description
+shift
+\begin_inset space ~
+\end_inset
+
+
+\end_layout
+
+\begin_deeper
+\begin_layout Description
+[above
+\begin_inset space ~
+\end_inset
+
+<value>
+\begin_inset space ~
+\end_inset
+
+by
+\begin_inset space ~
+\end_inset
+
+<offset>] Values in set(s) above <value> will be shifted by <offset>.
+\end_layout
+
+\begin_layout Description
+[below
+\begin_inset space ~
+\end_inset
+
+<value>
+\begin_inset space ~
+\end_inset
+
+by
+\begin_inset space ~
+\end_inset
+
+<offset>] Values in set(s) below <value> will be shifted by <offset>.
+\end_layout
+
+\begin_layout Description
+<set
+\begin_inset space ~
+\end_inset
+
+arg0>
+\begin_inset space ~
+\end_inset
+
+...
+ Set(s) to shift.
 \end_layout
 
 \end_deeper
@@ -9217,6 +9277,25 @@ dataset dim xdim label Simulation min 1 step 1 Inverted*
 
 \begin_layout LyX-Code
 writedata statecount.agr Inverted* 
+\end_layout
+
+\begin_layout Standard
+The dataset shift command can be used for wrapping circular values, such
+ as torsions.
+ For example, to ensure a pucker has a range from 0 to 360 instead of -180
+ to 180:
+\end_layout
+
+\begin_layout LyX-Code
+pucker Furanoid @C2 @C3 @C4 @C5 @O2 cremer out CremerF.dat amplitude
+\end_layout
+
+\begin_layout LyX-Code
+run
+\end_layout
+
+\begin_layout LyX-Code
+dataset shift Furanoid below 0 by 360
 \end_layout
 
 \begin_layout Subsection

--- a/src/DataFile.cpp
+++ b/src/DataFile.cpp
@@ -364,6 +364,21 @@ int DataFile::RemoveDataSet(DataSet* dataIn) {
   return 0;
 }
 
+/** \return True if this DataFile contains any of the sets in the given set list.
+  * Matches are determined via memory address.
+  */
+bool DataFile::ContainsAnyOfSets(std::vector<DataSet*> const& setsIn) const {
+  for (std::vector<DataSet*>::const_iterator ds0 = setsIn.begin();
+                                             ds0 != setsIn.end(); ++ds0)
+  {
+    DataSet* tgt = *ds0;
+    for (DataSetList::const_iterator ds1 = SetList_.begin();
+                                     ds1 != SetList_.end(); ++ds1)
+      if (tgt == *ds1) return true;
+  }
+  return false;
+}
+
 // GetPrecisionArg()
 static inline int GetPrecisionArg(std::string const& prec_str, int& width, int& prec)
 {

--- a/src/DataFile.h
+++ b/src/DataFile.h
@@ -62,6 +62,8 @@ class DataFile {
     int AddDataSet(DataSet*);
     /// Remove a set from the DataFile.
     int RemoveDataSet(DataSet*);
+    /// \return True if this DataFile contains any of the sets in given DataSetList
+    bool ContainsAnyOfSets(std::vector<DataSet*> const&) const;
     /// Process DataFile-related arguments
     int ProcessArgs(ArgList&);
     int ProcessArgs(std::string const&); // TODO: Determine where this is used

--- a/src/DataFileList.cpp
+++ b/src/DataFileList.cpp
@@ -382,6 +382,15 @@ void DataFileList::ResetWriteStatus() {
     (*df)->SetDFLwrite( true );
 }
 
+/** Check all DataFiles for sets in the given DataSetList. For DataFiles
+  * that contain any of these sets, reset their write status.
+  */
+void DataFileList::ResetWriteStatIfContain(std::vector<DataSet*> const& setsIn) {
+  for (DFarray::iterator df = fileList_.begin(); df != fileList_.end(); ++df)
+    if ( (*df)->ContainsAnyOfSets( setsIn ) )
+      (*df)->SetDFLwrite( true );
+}
+
 // DataFileList::ProcessDataFileArgs()
 /** Process command relating to data files. */
 int DataFileList::ProcessDataFileArgs(ArgList& dataArg) {

--- a/src/DataFileList.h
+++ b/src/DataFileList.h
@@ -54,7 +54,11 @@ class DataFileList {
     void WriteAllDF();
     /// \return true if DataFiles have not yet been written.
     bool UnwrittenData() const;
+    /// Reset the write status of all DataFiles so they will be written
     void ResetWriteStatus();
+    /// Reset the write status of DataFiles containing any of the input sets.
+    void ResetWriteStatIfContain(std::vector<DataSet*> const& dslIn);
+    /// Process any data file args
     int ProcessDataFileArgs(ArgList&);
     int Debug() const { return debug_; }
     int EnsembleNum() const { return ensembleNum_; }

--- a/src/DataSet_1D.h
+++ b/src/DataSet_1D.h
@@ -20,6 +20,8 @@ class DataSet_1D : public DataSet {
     virtual double Xcrd(size_t) const = 0;
     /// \return Memory address at position cast to void *. TODO may not need this anymore.
     virtual const void* VoidPtr(size_t) const = 0;
+    /// Set Y value at given index
+    virtual void SetY(size_t, double) = 0;
     // -------------------------------------------
     /// \return Average over set Y values
     double Avg()           const { return Avg( 0 ); }

--- a/src/DataSet_Mesh.h
+++ b/src/DataSet_Mesh.h
@@ -28,9 +28,10 @@ class DataSet_Mesh : public DataSet_1D {
     int MemAlloc(SizeArray const&);
     void CopyBlock(size_t, const DataSet*, size_t, size_t);
     // ----- DataSet_1D functions ----------------
-    double Dval(size_t idx)  const { return mesh_y_[idx];       }
-    double Xcrd(size_t idx)  const { return mesh_x_[idx];       }
+    double Dval(size_t idx)   const { return mesh_y_[idx];       }
+    double Xcrd(size_t idx)   const { return mesh_x_[idx];       }
     const void* VoidPtr(size_t) const;
+    void SetY(size_t idx, double y) { mesh_y_[idx] = y; }
     // -------------------------------------------
     inline void AddXY(double,double);
     double X(int i) const { return mesh_x_[i]; }

--- a/src/DataSet_double.h
+++ b/src/DataSet_double.h
@@ -34,9 +34,10 @@ class DataSet_double : public DataSet_1D {
     int MemAlloc(SizeArray const&);
     void CopyBlock(size_t, const DataSet*, size_t, size_t);
     // ----- DataSet_1D functions ----------------
-    double Dval(size_t idx)        const { return Data_[idx];         }
-    double Xcrd(size_t idx)        const { return Dim(0).Coord(idx);  }
+    double Dval(size_t idx)         const { return Data_[idx];         }
+    double Xcrd(size_t idx)         const { return Dim(0).Coord(idx);  }
     const void* VoidPtr(size_t idx) const { return (void*)(&(Data_[0])+idx); }
+    void SetY(size_t idx, double y)       { Data_[idx] = y; }
   private:
     std::vector<double> Data_;
 };

--- a/src/DataSet_float.h
+++ b/src/DataSet_float.h
@@ -28,9 +28,10 @@ class DataSet_float : public DataSet_1D {
     int MemAlloc(SizeArray const&);
     void CopyBlock(size_t, const DataSet*, size_t, size_t);
     // ----- DataSet_1D functions ----------------
-    double Dval(size_t idx)        const { return (double)Data_[idx]; }
-    double Xcrd(size_t idx)        const { return Dim(0).Coord(idx);  }
+    double Dval(size_t idx)         const { return (double)Data_[idx]; }
+    double Xcrd(size_t idx)         const { return Dim(0).Coord(idx);  }
     const void* VoidPtr(size_t idx) const { return (void*)(&(Data_[0])+idx); }
+    void SetY(size_t idx, double y)       { Data_[idx] = (float)y; }
     // -------------------------------------------
     float* Ptr()                         { return &(Data_[0]);        }
   private:

--- a/src/DataSet_integer.h
+++ b/src/DataSet_integer.h
@@ -22,6 +22,7 @@ class DataSet_integer : public DataSet_1D {
 #   endif
     // ----- DataSet_1D functions ----------------
     double Xcrd(size_t idx)     const { return Dim(0).Coord(idx);  }
+    void SetY(size_t idx, double y) { SetElement(idx, (int)y); }
     // -------------------------------------------
     //typedef std::vector<int>::iterator iterator;
     //iterator begin()                  { return Data_.begin();      }

--- a/src/DataSet_pH.h
+++ b/src/DataSet_pH.h
@@ -27,6 +27,7 @@ class DataSet_pH : public DataSet_1D {
     double Dval(size_t i)           const { return (double)states_[i];         }
     double Xcrd(size_t idx)         const { return Dim(0).Coord(idx);          }
     const void* VoidPtr(size_t idx) const { return (void*)(&(states_[0])+idx); }
+    void SetY(size_t i, double y)         { states_[i] = (int)y; }
     // -------------------------------------------
     void Resize(size_t, int);
     void SetResidueInfo(Cph::CpRes const& r) { res_ = r; }

--- a/src/Exec_DataSetCmd.cpp
+++ b/src/Exec_DataSetCmd.cpp
@@ -1022,12 +1022,12 @@ Exec::RetType Exec_DataSetCmd::ShiftData(CpptrajState& State, ArgList& argIn) {
         mprintf("Warning: Set '%s' is not scalar 1D, skipping.\n", (*ds)->legend());
       } else {
         DataSet_1D& set = static_cast<DataSet_1D&>( *(*ds) );
-        mprintf("\t%s\n", set.legend());
+        mprintf("\tModifying set: %s\n", set.legend());
         // Check value against all criteria, modify by offset if necessary
         for (unsigned int idx = 0; idx < set.Size(); idx++)
         {
           double dval = set.Dval(idx);
-          mprintf("DBG: %u %g", idx, dval);
+          //mprintf("DBG: %u %g", idx, dval);
           for (unsigned int ii = 0; ii < criteria.size(); ii++)
           {
             if (criteria[ii] == LESS_THAN && dval < vals[ii])
@@ -1035,7 +1035,7 @@ Exec::RetType Exec_DataSetCmd::ShiftData(CpptrajState& State, ArgList& argIn) {
             else if (criteria[ii] == GREATER_THAN && dval > vals[ii])
               dval += offsets[ii];
           }
-          mprintf(" %g\n", dval);
+          //mprintf(" %g\n", dval);
           set.SetY( idx, dval );
         } // END loop over set values
         modifiedSets_.push_back( *ds );

--- a/src/Exec_DataSetCmd.cpp
+++ b/src/Exec_DataSetCmd.cpp
@@ -74,6 +74,7 @@ void Exec_DataSetCmd::Help(ArgList& argIn) const {
 
 // Exec_DataSetCmd::Execute()
 Exec::RetType Exec_DataSetCmd::Execute(CpptrajState& State, ArgList& argIn) {
+  modifiedSets_.clear();
   RetType err = CpptrajState::OK;
   if (argIn.Contains("legend")) {         // Set legend for one data set
     std::string legend = argIn.GetStringKey("legend");
@@ -120,6 +121,11 @@ Exec::RetType Exec_DataSetCmd::Execute(CpptrajState& State, ArgList& argIn) {
   // ---------------------------------------------
   } else {                                  // Default: change mode/type for one or more sets.
     err = ChangeModeType(State, argIn);
+  }
+  // If any sets were modified, write out data again.
+  if (err == CpptrajState::OK && !modifiedSets_.empty()) {
+    State.DFL().ResetWriteStatIfContain( modifiedSets_ );
+    State.DFL().WriteAllDF();
   }
   return err;
 }
@@ -1032,6 +1038,7 @@ Exec::RetType Exec_DataSetCmd::ShiftData(CpptrajState& State, ArgList& argIn) {
           mprintf(" %g\n", dval);
           set.SetY( idx, dval );
         } // END loop over set values
+        modifiedSets_.push_back( *ds );
       }
     } // END loop over sets
     ds_arg = argIn.GetStringNext();

--- a/src/Exec_DataSetCmd.cpp
+++ b/src/Exec_DataSetCmd.cpp
@@ -958,7 +958,7 @@ Exec::RetType Exec_DataSetCmd::InvertSets(CpptrajState& State, ArgList& argIn) {
 
 // Exec_DataSetCmd::Help_Shift()
 void Exec_DataSetCmd::Help_Shift() {
-  mprintf("  shift [above <value> by <offset>] [below <value> by <offset>] ... <set arg0> ...\n"
+  mprintf("  shift [above <value> by <offset>] [below <value> by <offset>] <set arg0> ...\n"
           "    Shift the values in given set(s) by an offset if the points meet\n"
           "    certain criteria.\n");
 }

--- a/src/Exec_DataSetCmd.h
+++ b/src/Exec_DataSetCmd.h
@@ -35,5 +35,7 @@ class Exec_DataSetCmd : public Exec {
     RetType InvertSets(CpptrajState&, ArgList&);
     static void Help_Shift();
     RetType ShiftData(CpptrajState&, ArgList&);
+
+    std::vector<DataSet*> modifiedSets_;
 };
 #endif

--- a/src/Exec_DataSetCmd.h
+++ b/src/Exec_DataSetCmd.h
@@ -33,5 +33,7 @@ class Exec_DataSetCmd : public Exec {
     RetType ChangeModeType(CpptrajState const&, ArgList&);
     static void Help_InvertSets();
     RetType InvertSets(CpptrajState&, ArgList&);
+    static void Help_Shift();
+    RetType ShiftData(CpptrajState&, ArgList&);
 };
 #endif

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.25.12"
+#define CPPTRAJ_INTERNAL_VERSION "V4.25.13"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Add new subcommand to `dataset` command, `shift`; can be used to apply offsets to data that match certain criteria:
```
shift [above <value> by <offset>] [below <value> by <offset>] <set arg0> ...
```
For example, to shift torsion data that is -180 to 180 to 0 to 360:
```
dataset shift TorsionSet below 0 by 360
```