### PR TITLE
Fix potential segfault in 'cphstats' command

### DIFF
--- a/src/Analysis_ConstantPHStats.cpp
+++ b/src/Analysis_ConstantPHStats.cpp
@@ -34,12 +34,14 @@ Analysis::RetType Analysis_ConstantPHStats::Setup(ArgList& analyzeArgs, Analysis
     FRACSTR_ = "deprotonated";
   if (createFracPlot_) {
     fracPlotOut_ = setup.DFL().AddDataFile( analyzeArgs.GetStringKey("fracplotout") );
-    fracPlotOut_->ProcessArgs("xlabel pH ylabel \"Frac. " + std::string(FRACSTR_) + "\" noensextension");
-#   ifdef MPI
-    // Fraction plot should only ever be written by the overall master
-    // since it needs data from every ensemble member.
-    fracPlotOut_->SetThreadCanWrite( Parallel::MasterComm().Master() );
-#   endif
+    if (fracPlotOut_ != 0) {
+      fracPlotOut_->ProcessArgs("xlabel pH ylabel \"Frac. " + std::string(FRACSTR_) + "\" noensextension");
+#     ifdef MPI
+      // Fraction plot should only ever be written by the overall master
+      // since it needs data from every ensemble member.
+      fracPlotOut_->SetThreadCanWrite( Parallel::MasterComm().Master() );
+#     endif
+    }
   }
   // Get DataSets
   DataSetList tempDSL;

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.26.3"
+#define CPPTRAJ_INTERNAL_VERSION "V4.26.4"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Was missing a check for when `fracplot` specified but not `fracplotout`.