### PR TITLE
Fix assignment of "original" residue numbering during 'combinecrd'

### DIFF
--- a/devtools/ci/jenkins/Dockerfile.libcpptraj
+++ b/devtools/ci/jenkins/Dockerfile.libcpptraj
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda:latest
+FROM continuumio/miniconda3:latest
 
 RUN mkdir /cpptraj && \
     mkdir /.conda /.local && \

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -1861,7 +1861,7 @@ int Topology::AppendTop(Topology const& NewTop) {
         CurrentAtom.SetTypeIndex( newTypeIdx );
       }
     }
-    AddTopAtom( CurrentAtom, Residue(res.Name(), CurrentAtom.ResNum() + resOffset,
+    AddTopAtom( CurrentAtom, Residue(res.Name(), CurrentAtom.ResNum() + resOffset + 1,
                                      res.Icode(), res.ChainID()) );
   } // END loop over incoming atoms
   // NONBONDS

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.26.4"
+#define CPPTRAJ_INTERNAL_VERSION "V4.26.5"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
 The "original" residue number should start from 1 to be consistent with how cpptraj assigns "original" residue numbers when none are present (i.e. when assigning from topology residue index).

