### PR TITLE
Use condaforge/miniforge3

### DIFF
--- a/devtools/ci/jenkins/Dockerfile.libcpptraj
+++ b/devtools/ci/jenkins/Dockerfile.libcpptraj
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:latest
+FROM condaforge/miniforge3
 
 RUN mkdir /cpptraj && \
     mkdir /.conda /.local && \


### PR DESCRIPTION
The hanging from pytraj test can be caused by either:
- the current image from anaconda
- openmp (default): I am testing this locally with `condaforge/miniforge3` (fine with non-openmp version).  --> Nope, it's fine with openmp for `condaforge/miniforge3` image.