### PR TITLE
Add some new keywords for evalplateau

### DIFF
--- a/src/Analysis_EvalPlateau.cpp
+++ b/src/Analysis_EvalPlateau.cpp
@@ -69,12 +69,12 @@ Analysis::RetType Analysis_EvalPlateau::Setup(ArgList& analyzeArgs, AnalysisSetu
     mprinterr("Error: Tolerance must be greater than or equal to 0.0\n");
     return Analysis::ERR;
   }
-  initpct_ = analyzeArgs.getKeyDouble("initpct", 0.01);
+  initpct_ = analyzeArgs.getKeyDouble("initpct", 1.0) / 100.0;
   if (initpct_ <= 0) {
     mprinterr("Error: Initial percent must be greater than 0.\n");
     return Analysis::ERR;
   }
-  finalpct_ = analyzeArgs.getKeyDouble("finalpct", 0.5);
+  finalpct_ = analyzeArgs.getKeyDouble("finalpct", 50.0) / 100.0;
   if (finalpct_ <= 0) {
     mprinterr("Error: Final percent must be greater than 0.\n");
     return Analysis::ERR;

--- a/src/Analysis_EvalPlateau.h
+++ b/src/Analysis_EvalPlateau.h
@@ -31,6 +31,9 @@ class Analysis_EvalPlateau : public Analysis {
     /// Hold data type for each output data
     static DataSet::DataType OdataType_[NDATA];
 
+    /// Used to add zero data when error occurs evaluating a set
+    void BlankResult(long int, const char*);
+
     Array1D inputSets_;                ///< Will hold data to evaluate
     std::vector<DataSet*> outputSets_; ///< Will hold final fit curves
     std::string dsname_;               ///< Output set(s) base name

--- a/src/Analysis_EvalPlateau.h
+++ b/src/Analysis_EvalPlateau.h
@@ -40,6 +40,7 @@ class Analysis_EvalPlateau : public Analysis {
     CpptrajFile* statsout_;            ///< File to write stats to.
     std::vector<DataSet*> data_;       ///< Will hold output data
     double tolerance_;                 ///< Tolerance for non-linear curve fit
+    double initpct_;                   ///< Percent of initial data to use as guess for A0
     double valaCut_;                   ///< Cutoff for long-term estimate from last half of data
     double chisqCut_;                  ///< Cutoff for non-linear fit chi^2
     double slopeCut_;                  ///< Cutoff for non-linear fit slope

--- a/src/Analysis_EvalPlateau.h
+++ b/src/Analysis_EvalPlateau.h
@@ -41,6 +41,7 @@ class Analysis_EvalPlateau : public Analysis {
     std::vector<DataSet*> data_;       ///< Will hold output data
     double tolerance_;                 ///< Tolerance for non-linear curve fit
     double initpct_;                   ///< Percent of initial data to use as guess for A0
+    double finalpct_;                  ///< Percent of final data to use as guess for A2
     double valaCut_;                   ///< Cutoff for long-term estimate from last half of data
     double chisqCut_;                  ///< Cutoff for non-linear fit chi^2
     double slopeCut_;                  ///< Cutoff for non-linear fit slope

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.26.8"
+#define CPPTRAJ_INTERNAL_VERSION "V4.26.9"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
initpct and finalpct for adjusting the intial and final percent of data used to calculate A0 and A2 respectively.

Also print a blank entry and `err` if an input set cannot be evaluated instead of bailing on everything.