### PR TITLE
Fix CUDA builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,6 +137,7 @@ pipeline {
                             image 'ambermd/gpu-build:latest'
                             alwaysPull true
                             label "docker && cuda"
+                            args '--gpus all'
                         }
                     }
 


### PR DESCRIPTION
The new CUDA agents on Jenkins use a different nvidia runtime for docker that requires the GPUs made available to the container be declared at the command-line.  This change implements that behavior and will fix CUDA builds from here on.