### PR TITLE
Fix use of cluster pairwise distance matrix in consecutive cluster calculations

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.29.8"
+#define CPPTRAJ_INTERNAL_VERSION "V4.29.9"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Given the following input:
```
parm nowat.parm7
trajin nowat.nc
createcrd MyTraj
run
set OUT = Cluster.kmeans.CA
for NCLUSTERS in 5,10,15,20
  runanalysis cluster \
    crdset MyTraj \
    kmeans clusters $NCLUSTERS randompoint \
    rms @CA sieve 10 random \
    loadpairdist savepairdist pairdist $OUT/CpptrajPairDist \
    out $OUT/cnumvtime.$NCLUSTERS.dat \
    summary $OUT/summary.$NCLUSTERS.dat \
    info $OUT/info.$NCLUSTERS.dat \
    singlerepout $OUT/reps.$NCLUSTERS.nc singlerepfmt netcdf
done
```
Only the first 2 iterations of the loop (generation of the matrix and loading) would complete; the third would fail because `cluster` would try to add the pairwise set again instead of using the existing one. This PR fixes the behavior so the same pairwise matrix can be used for any number of `cluster` calculations.