### PR TITLE
Fix nastruct time series when no output specified

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.31.0"
+#define CPPTRAJ_INTERNAL_VERSION "V4.31.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Previously, when no output specified, the Print() function was exited before UpdateTimeSeries was called. Addresses #851.