### PR TITLE
Fix 'molinfo short'

### DIFF
--- a/src/Mol.cpp
+++ b/src/Mol.cpp
@@ -41,12 +41,12 @@ Mol::Marray Mol::UniqueCount(Topology const& top, std::vector<int> const& molNum
                 if (top.Res(curRes0).Name() != top.Res(prevRes0).Name()) {
                   // Residue name mismatch.
                   matchIdx = -1;
-                  iseg = CurMol.MolUnit().nSegments();
                   break;
                 }
                 curRes0++;
                 prevRes0++;
               }
+              if (matchIdx == -1) break;
             } // END loop over segments
           } // END # segments match 
         } // END # residues match

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V4.32.0"
+#define CPPTRAJ_INTERNAL_VERSION "V4.32.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -543,6 +543,7 @@ LIBCPPTRAJ_TRAJ_OBJECTS= \
 LIBCPPTRAJ_PARM_OBJECTS= \
   BondSearch.o \
   CharmmParamFile.o \
+  ExclusionArray.o \
   Mol.o \
   ParameterSet.o \
   ParmFile.o \


### PR DESCRIPTION
Fixes a potential segfault when a residue name mismatch occurs and the residue size is 1.