### PR TITLE
Fix errors reading some Amber topology files with CMAP parameters

### DIFF
--- a/src/Parm_Amber.cpp
+++ b/src/Parm_Amber.cpp
@@ -413,7 +413,8 @@ int Parm_Amber::ReadNewParm(Topology& TopIn) {
           ptr = SkipToNextFlag();
         } else {
           int err = 0;
-          switch ((FlagType)flagIdx) {
+          FlagType ftype = (FlagType)flagIdx;
+          switch (ftype) {
             case F_CTITLE: ptype_ = CHAMBER; // Fall through to F_TITLE
                            elec_to_parm_ = ELECTOCHAMBER_;
                            parm_to_elec_ = CHAMBERTOELEC_;
@@ -494,13 +495,13 @@ int Parm_Amber::ReadNewParm(Topology& TopIn) {
             case F_LES_ID:    err = ReadLESid(TopIn, FMT); break;
             // CMAP
             case F_CHM_CMAPC: // fallthrough
-            case F_CMAPC:     err = ReadCmapCounts(FMT); break;
+            case F_CMAPC:     err = ReadCmapCounts(ftype, FMT); break;
             case F_CHM_CMAPR: // fallthrough
-            case F_CMAPR:     err = ReadCmapRes(TopIn, FMT); break;
+            case F_CMAPR:     err = ReadCmapRes(ftype, TopIn, FMT); break;
             case F_CHM_CMAPP: // fallthrough
-            case F_CMAPP:     err = ReadCmapGrid(flagType.c_str(), TopIn, FMT); break;
+            case F_CMAPP:     err = ReadCmapGrid(ftype, flagType.c_str(), TopIn, FMT); break;
             case F_CHM_CMAPI: // fallthrough
-            case F_CMAPI:     err = ReadCmapTerms(TopIn, FMT); break;
+            case F_CMAPI:     err = ReadCmapTerms(ftype, TopIn, FMT); break;
             // Sanity check
             default:
               mprinterr("Internal Error: Unhandled FLAG '%s'.\n", flagType.c_str());
@@ -1339,9 +1340,9 @@ int Parm_Amber::ReadChamberLJ14B(Topology& TopIn, FortranData const& FMT) {
 }
 
 // Parm_Amber::ReadChamberCmapCounts()
-int Parm_Amber::ReadCmapCounts(FortranData const& FMT) {
-  const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPC : F_CMAPC;
-  if (SetupBuffer(f, 2, FMT)) return 1;
+int Parm_Amber::ReadCmapCounts(FlagType ftype, FortranData const& FMT) {
+  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPC : F_CMAPC;
+  if (SetupBuffer(ftype, 2, FMT)) return 1;
   n_cmap_terms_ = atoi( file_.NextElement() );
   n_cmap_grids_ = atoi( file_.NextElement() );
   return 0;
@@ -1349,47 +1350,69 @@ int Parm_Amber::ReadCmapCounts(FortranData const& FMT) {
 
 // Parm_Amber::ReadChamberCmapRes()
 /** Get CMAP resolutions for each grid and allocate grids. */
-int Parm_Amber::ReadCmapRes(Topology& TopIn, FortranData const& FMT) {
-  const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPR : F_CMAPR;
-  if (SetupBuffer(f, n_cmap_grids_, FMT)) return 1;
+int Parm_Amber::ReadCmapRes(FlagType ftype, Topology& TopIn, FortranData const& FMT) {
+  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPR : F_CMAPR;
+  if (SetupBuffer(ftype, n_cmap_grids_, FMT)) return 1;
   for (int i = 0; i != n_cmap_grids_; i++)
     TopIn.AddCmapGrid( CmapGridType( atoi(file_.NextElement()) ) );
   return 0;
 }
 
 // Parm_Amber::ReadChamberCmapGrid()
-/** Read CMAP grid. */
-int Parm_Amber::ReadCmapGrid(const char* CmapFlag, Topology& TopIn, FortranData const& FMT)
+/** Read CMAP grid. It is expected that the grid number is between 1 and CHARMM_CMAP_COUNT */
+int Parm_Amber::ReadCmapGrid(FlagType ftype, const char* CmapFlag, Topology& TopIn, FortranData const& FMT)
 {
+  if (CmapFlag == 0) {
+    mprinterr("Internal Error: ReadCmapGrid: CmapFlag is null.\n");
+    return 1;
+  }
   // Figure out which grid this is.
+  //           11111111112222
   // 012345678901234567890123
-  // CHARMM_CMAP_PARAMETER_XX
-  const size_t cmap_parameter_flag_size = (ptype_ == CHAMBER) ? strlen("CHARMM_CMAP_PARAMETER_") : strlen ("CMAP_PARAMETER_");
-  int gridnum = convertToInteger( std::string( CmapFlag+cmap_parameter_flag_size ) ) - 1;
+  // CHARMM_CMAP_PARAMETER_XX or CMAP_PARAMETER_XX
+  // The former is what is specified by the Amber parm/top file format spec.
+  // The latter appears to be what is output from Charmm GUI
+  // Advance to the final underscore.
+  const char* ptr = CmapFlag;
+  unsigned int underscore_idx = 0;
+  while (*ptr != '\0') {
+    if (*ptr == '_') underscore_idx = (ptr - CmapFlag);
+    ptr++;
+  }
+  // Get string
+  std::string cmap_index_str( CmapFlag+underscore_idx+1 );
+  // Sanity check
+  if (cmap_index_str.size() != 2 || !validInteger(cmap_index_str)) {
+    mprinterr("Error: CMAP index flag %s does not appear to contain an integer: %s\n",
+             CmapFlag, cmap_index_str.c_str());
+    return 1;
+  }
+  //mprintf("DEBUG: cmap index string: %s\n", cmap_index_str.c_str());
+  int gridnum = convertToInteger( cmap_index_str ) - 1;
   if (gridnum < 0 || gridnum >= (int)TopIn.CmapGrid().size()) {
     mprintf("Warning: CMAP grid '%s' out of range.\n", CmapFlag);
-    const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPC : F_CMAPC;
+    //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPC : F_CMAPC;
     if (TopIn.HasCmap())
       mprintf("Warning: Expected grid between 1 and %zu, got %i\n",
               TopIn.CmapGrid().size(), gridnum+1);
     else
-      mprintf("Warning: Missing previous %s section.\n", FLAGS_[f].Flag);
+      mprintf("Warning: Missing previous %s section.\n", FLAGS_[ftype].Flag);
     mprintf("Warning: Skipping read of CMAP grid.\n");
     return 0;
   }
   CmapGridType& GRID = TopIn.SetCmapGrid( gridnum );
-  const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPP : F_CMAPP;
-  if (SetupBuffer(f, GRID.Size(), FMT)) return 1;
+  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPP : F_CMAPP;
+  if (SetupBuffer(ftype, GRID.Size(), FMT)) return 1;
   for (int idx = 0; idx != GRID.Size(); idx++)
     GRID.SetGridPt( idx, atof(file_.NextElement()) );
   return 0;
 }
 
 // Parm_Amber::ReadChamberCmapTerms()
-int Parm_Amber::ReadCmapTerms(Topology& TopIn, FortranData const& FMT) {
+int Parm_Amber::ReadCmapTerms(FlagType ftype, Topology& TopIn, FortranData const& FMT) {
   int nvals = n_cmap_terms_ * 6;
-  const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPI : F_CMAPI;
-  if (SetupBuffer(f, nvals, FMT)) return 1;
+  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPI : F_CMAPI;
+  if (SetupBuffer(ftype, nvals, FMT)) return 1;
   for (int idx = 0; idx != nvals; idx += 6) {
     int a1 = atoi(file_.NextElement()) - 1;
     int a2 = atoi(file_.NextElement()) - 1;

--- a/src/Parm_Amber.cpp
+++ b/src/Parm_Amber.cpp
@@ -1341,7 +1341,6 @@ int Parm_Amber::ReadChamberLJ14B(Topology& TopIn, FortranData const& FMT) {
 
 // Parm_Amber::ReadChamberCmapCounts()
 int Parm_Amber::ReadCmapCounts(FlagType ftype, FortranData const& FMT) {
-  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPC : F_CMAPC;
   if (SetupBuffer(ftype, 2, FMT)) return 1;
   n_cmap_terms_ = atoi( file_.NextElement() );
   n_cmap_grids_ = atoi( file_.NextElement() );
@@ -1351,7 +1350,6 @@ int Parm_Amber::ReadCmapCounts(FlagType ftype, FortranData const& FMT) {
 // Parm_Amber::ReadChamberCmapRes()
 /** Get CMAP resolutions for each grid and allocate grids. */
 int Parm_Amber::ReadCmapRes(FlagType ftype, Topology& TopIn, FortranData const& FMT) {
-  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPR : F_CMAPR;
   if (SetupBuffer(ftype, n_cmap_grids_, FMT)) return 1;
   for (int i = 0; i != n_cmap_grids_; i++)
     TopIn.AddCmapGrid( CmapGridType( atoi(file_.NextElement()) ) );
@@ -1391,7 +1389,6 @@ int Parm_Amber::ReadCmapGrid(FlagType ftype, const char* CmapFlag, Topology& Top
   int gridnum = convertToInteger( cmap_index_str ) - 1;
   if (gridnum < 0 || gridnum >= (int)TopIn.CmapGrid().size()) {
     mprintf("Warning: CMAP grid '%s' out of range.\n", CmapFlag);
-    //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPC : F_CMAPC;
     if (TopIn.HasCmap())
       mprintf("Warning: Expected grid between 1 and %zu, got %i\n",
               TopIn.CmapGrid().size(), gridnum+1);
@@ -1401,7 +1398,6 @@ int Parm_Amber::ReadCmapGrid(FlagType ftype, const char* CmapFlag, Topology& Top
     return 0;
   }
   CmapGridType& GRID = TopIn.SetCmapGrid( gridnum );
-  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPP : F_CMAPP;
   if (SetupBuffer(ftype, GRID.Size(), FMT)) return 1;
   for (int idx = 0; idx != GRID.Size(); idx++)
     GRID.SetGridPt( idx, atof(file_.NextElement()) );
@@ -1411,7 +1407,6 @@ int Parm_Amber::ReadCmapGrid(FlagType ftype, const char* CmapFlag, Topology& Top
 // Parm_Amber::ReadChamberCmapTerms()
 int Parm_Amber::ReadCmapTerms(FlagType ftype, Topology& TopIn, FortranData const& FMT) {
   int nvals = n_cmap_terms_ * 6;
-  //const FlagType f = (ptype_ == CHAMBER) ? F_CHM_CMAPI : F_CMAPI;
   if (SetupBuffer(ftype, nvals, FMT)) return 1;
   for (int idx = 0; idx != nvals; idx += 6) {
     int a1 = atoi(file_.NextElement()) - 1;

--- a/src/Parm_Amber.h
+++ b/src/Parm_Amber.h
@@ -128,10 +128,10 @@ class Parm_Amber : public ParmIO {
     int ReadChamberImpPHASE(Topology&, FortranData const&);
     int ReadChamberLJ14A(Topology&, FortranData const&);
     int ReadChamberLJ14B(Topology&, FortranData const&);
-    int ReadCmapCounts(FortranData const&);
-    int ReadCmapRes(Topology&, FortranData const&);
-    int ReadCmapGrid(const char*, Topology&, FortranData const&);
-    int ReadCmapTerms(Topology&, FortranData const&);
+    int ReadCmapCounts(FlagType,FortranData const&);
+    int ReadCmapRes(FlagType,Topology&, FortranData const&);
+    int ReadCmapGrid(FlagType,const char*, Topology&, FortranData const&);
+    int ReadCmapTerms(FlagType,Topology&, FortranData const&);
     // LES
     int ReadLESntyp(Topology&, FortranData const&);
     int ReadLESfac(Topology&, FortranData const&);

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V5.0.0"
+#define CPPTRAJ_INTERNAL_VERSION "V5.0.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
The CMAP reading code introduced in #843 assumed that if the `CTITLE` flag was present, the CMAP flags would have the style `CHARMM_CMAP_XXX`; however, this is not always the case (e.g. for topologies produced by CHARMM GUI) and cpptraj would fail reading the topology in such a case. This MR rewrites the CMAP parameter reading routines so they are more general and accept either `CHARMM_CMAP_XXX` or `CMAP_XXX` style no matter if `CTITLE` is present or not.