### PR TITLE
Protect J-coupling test when coupled with AmberTools.

### DIFF
--- a/test/Test_Jcoupling/RunTest.sh
+++ b/test/Test_Jcoupling/RunTest.sh
@@ -10,7 +10,7 @@ Requires netcdf
 INPUT="-i jcoupling.in"
 # Test 1
 UNITNAME='J-Coupling single frame test'
-CheckFor maxthreads 1
+CheckFor maxthreads 1 file ../../dat/Karplus.txt
 if [ $? -eq 0 ] ; then
   cat > jcoupling.in <<EOF
 noprogress


### PR DESCRIPTION
The AmberTools cmake install does not include the AmberTools/src/cpptraj/dat, so make the the test depend on the directory/file actually being there.