### PR TITLE
Add location of CPPTRAJ source directory to cpptraj.sh

### DIFF
--- a/configure
+++ b/configure
@@ -98,6 +98,7 @@ UsageFull() {
 
 # ----- Script variables -------------------------------------------------------
 WORKDIR=`dirname $0`      # Working directory of the configure script
+CURRENTDIR=`pwd`          # Directory configure is being executed in
 COMPILERS=''              # User-specified compiler suite to use.
 FLINK=''                  # Flag for linking in Fortran code
 REQUIRES_FLINK=0          # If 1 FLINK flag required during link phase
@@ -113,6 +114,7 @@ EXE=''                    # Binary executable suffix
 REBUILDOPT=''             # Can be set to --rebuild and passed to get_library.sh
 BUILDTESTOPT='silent'     # Set to blank to avoid asking about building libraries
 INSTALL_DAT='install_dat' # Target for installing data directory
+CPPTRAJSRC=''             # CPPTRAJ source directory
 COMPERR='cpptrajcfg.compile.err'
 COMPOUT='cpptrajcfg.compile.out'
 
@@ -2029,7 +2031,7 @@ SetupCmake() {
     ErrMsg "            $ ../configure -cmake <options>"
     exit 1
   fi
-  # Ensure cmake bnuild system exists
+  # Ensure cmake build system exists
   if [ ! -f "$WORKDIR/cmake/AmberBuildSystemInit.cmake" ] ; then
     ErrMsg "Error: cmake build system is not present."
     ErrMsg "       If this is a GIT repostitory, you may need to initialize the"
@@ -2107,6 +2109,9 @@ fi
 if [ -z "`which grep`" ] ; then
   Err "CPPTRAJ configure requires 'grep'."
 fi
+
+#echo "Path to configure: $WORKDIR"
+#echo "Current dir      : $CURRENTDIR"
 
 CONFIGURECMD="./configure $*"
 
@@ -2250,6 +2255,12 @@ fi
 if [ $USE_CMAKE -eq 1 ] ; then
   SetupCmake
 fi
+
+# Currently need to execute configure in source directory
+if [ "$WORKDIR" != '.' ] ; then
+  Err "CPPTRAJ configure must be executed from the source directory."
+fi
+CPPTRAJSRC=$CURRENTDIR
 
 # Basic checks and directives
 BasicChecks
@@ -2521,6 +2532,7 @@ if [ "$PERFORM_CHECKS" = 'yes' ] ; then
     RFILE=$CPPTRAJHOME/cpptraj.sh
     cat > $RFILE <<EOF
 export CPPTRAJHOME="$CPPTRAJHOME"
+export CPPTRAJSRC="$CPPTRAJSRC"
 export PATH=$CPPTRAJBIN:\${PATH}
 EOF
     if [ "$PLATFORM" != "Darwin" ] ; then
@@ -2531,6 +2543,7 @@ EOF
     RFILE=$CPPTRAJHOME/cpptraj.csh
     cat > $RFILE <<EOF
 setenv CPPTRAJHOME "$CPPTRAJHOME"
+setenv CPPTRAJSRC "$CPPTRAJSRC"
 setenv PATH "$CPPTRAJBIN:\${PATH}"
 EOF
     if [ "$PLATFORM" != "Darwin" ] ; then

--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -320,6 +320,26 @@ Everything else is as printed.
  
 \end_layout
 
+\begin_layout Subsection
+Installation
+\end_layout
+
+\begin_layout Standard
+See instructions in the CPPTRAJ GitHub repository README.md file under 'Installat
+ion & Testing': 
+\begin_inset Flex URL
+status open
+
+\begin_layout Plain Layout
+
+https://github.com/Amber-MD/cpptraj
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
 \begin_layout Section
 Running Cpptraj
 \end_layout
@@ -379,6 +399,10 @@ cpptraj [-p <Top0>] [-i <Input0>] [-y <trajin>] [-x <trajout>]
 \end_inset
 
 
+\end_layout
+
+\begin_layout LyX-Code
+        [--rng {marsaglia|stdlib|mt|pcg32|xo128}]
 \end_layout
 
 \begin_deeper
@@ -553,6 +577,10 @@ cpptraj [-p <Top0>] [-i <Input0>] [-y <trajin>] [-x <trajout>]
 
 \begin_layout Description
 –resmask <mask> : Print detailed residue selection to STDOUT.
+\end_layout
+
+\begin_layout Description
+--rng <type> : Change default random number generator.
 \end_layout
 
 \end_deeper
@@ -41610,6 +41638,7 @@ key "Roe2020"
 literal "true"
 
 \end_inset
+
 
 \end_layout
 

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -837,6 +837,8 @@ SetBinaries() {
   if [ -z "$CPPTRAJ_NDIFF" ] ; then
     if [ $STANDALONE -eq 0 ] ; then
       CPPTRAJ_NDIFF=$DIRPREFIX/test/ndiff.awk
+    elif [ ! -z "$CPPTRAJSRC" ] ; then
+      CPPTRAJ_NDIFF=$CPPTRAJSRC/util/ndiff/ndiff.awk
     else
       CPPTRAJ_NDIFF=$CPPTRAJ_TEST_ROOT/../util/ndiff/ndiff.awk
     fi
@@ -851,6 +853,8 @@ SetBinaries() {
     if [ ! -z "$DO_PARALLEL" ] ; then
       if [ $STANDALONE -eq 0 ] ; then
         CPPTRAJ_NPROC=$DIRPREFIX/AmberTools/test/numprocs
+      elif [ ! -z "$CPPTRAJSRC" ] ; then
+        CPPTRAJ_NPROC=$CPPTRAJSRC/test/nproc
       else
         CPPTRAJ_NPROC=$CPPTRAJ_TEST_ROOT/nproc
       fi


### PR DESCRIPTION
Makes it easier for the separate repository of extra tests to find critical test files.

Also add a check to `configure` to prevent it from being run from somewhere other than the source directory, which is currently unsupported; I should maybe change that at some point.