### PR TITLE
Only run the stdlib RNG test on Linux

### DIFF
--- a/test/Test_Random/RunTest.sh
+++ b/test/Test_Random/RunTest.sh
@@ -30,8 +30,8 @@ EOF
 fi
 
 UNITNAME='Test Stdlib RNG'
-# Stdlib rand implementation is different on windows
-CheckFor notos windows
+# Stdlib rand implementation is different on windows/osx
+CheckFor testos Linux
 if [ $? -eq 0 ] ; then
   cat > rng.in <<EOF
 rng setdefault stdlib    createset Stdlib       settype int count 10 seed 10 out stdlib.dat


### PR DESCRIPTION
The C standard library RNG (`rand()`) specification is not exact, so it cannot be relied upon to be cross-platform. Previously the test was run as long as the OS was not windows. This ensure the random stdlib test only runs on Linux.