### PR TITLE
Detect and report non-ASCII characters in input

### DIFF
--- a/src/ArgList.cpp
+++ b/src/ArgList.cpp
@@ -102,17 +102,10 @@ int ArgList::SetList(std::string const& inputString, const char *separator) {
   marked_.clear();
   // Store inputString
   argline_.assign(inputString);
-  // Store positions of bad characters
-  std::vector<unsigned int> badChars;
   // Begin tokenization
   char* pch = strtok(tempString, separator);
   if (pch != 0) {
     while (pch != 0) {
-      // Extended ASCII check
-      if (*pch < 0 || *pch > 127) {
-        //mprintf("Warning: Non-ASCII character '%x' detected in input at position %li: '%s'.\n", (unsigned int)*pch, pch - tempString, argline_.c_str());
-        badChars.push_back( (unsigned int)(pch - tempString) );
-      }
       // If the argument is not quoted add it to the list
       if (pch[0] != '\"' && pch[0] != '\'') 
         arglist_.push_back( std::string(pch) );
@@ -149,6 +142,26 @@ int ArgList::SetList(std::string const& inputString, const char *separator) {
     // Set up marked array
     marked_.resize( arglist_.size(), false );
   }
+  delete[] tempString;
+  return 0;
+}
+
+/** Check the current argline_ for non-ASCII characters; report
+  * if found.
+  */
+void ArgList::CheckArgLineForNonASCII() const {
+  // Store positions of bad characters
+  std::vector<unsigned int> badChars;
+  for (std::string::const_iterator pch = argline_.begin(); pch != argline_.end(); ++pch)
+  {
+    int charCode = (int)*pch;
+    // Extended ASCII check
+    if (charCode < 0 || charCode > 127) {
+      mprintf("Warning: Non-ASCII character '%c' (%x) detected in input.\n", *pch, (unsigned int)*pch);
+      //mprintf("Warning: Non-ASCII character '%x' detected in input at position %li.\n", (unsigned int)*pch, pch - argline_.begin() + 1);
+      badChars.push_back( (unsigned int)(pch - argline_.begin()) );
+    }
+  }
   if (!badChars.empty()) {
     std::string caratStr(argline_.size(), ' ');
     for (std::vector<unsigned int>::const_iterator it = badChars.begin(); it != badChars.end(); ++it)
@@ -158,8 +171,6 @@ int ArgList::SetList(std::string const& inputString, const char *separator) {
     mprintf("Warning:  %s \n", caratStr.c_str());
     mprintf("Warning: These characters may need to be removed.\n");
   }
-  delete[] tempString;
-  return 0;
 }
 
 // ArgList::RemainingArgs()

--- a/src/ArgList.cpp
+++ b/src/ArgList.cpp
@@ -102,10 +102,17 @@ int ArgList::SetList(std::string const& inputString, const char *separator) {
   marked_.clear();
   // Store inputString
   argline_.assign(inputString);
+  // Store positions of bad characters
+  std::vector<unsigned int> badChars;
   // Begin tokenization
   char* pch = strtok(tempString, separator);
   if (pch != 0) {
     while (pch != 0) {
+      // Extended ASCII check
+      if (*pch < 0 || *pch > 127) {
+        //mprintf("Warning: Non-ASCII character '%x' detected in input at position %li: '%s'.\n", (unsigned int)*pch, pch - tempString, argline_.c_str());
+        badChars.push_back( (unsigned int)(pch - tempString) );
+      }
       // If the argument is not quoted add it to the list
       if (pch[0] != '\"' && pch[0] != '\'') 
         arglist_.push_back( std::string(pch) );
@@ -141,6 +148,15 @@ int ArgList::SetList(std::string const& inputString, const char *separator) {
     } // END while loop
     // Set up marked array
     marked_.resize( arglist_.size(), false );
+  }
+  if (!badChars.empty()) {
+    std::string caratStr(argline_.size(), ' ');
+    for (std::vector<unsigned int>::const_iterator it = badChars.begin(); it != badChars.end(); ++it)
+      caratStr[*it] = '^';
+    mprintf("Warning: Non-ASCII character(s) detected in input (at '^'):\n");
+    mprintf("Warning: [%s]\n", argline_.c_str());
+    mprintf("Warning:  %s \n", caratStr.c_str());
+    mprintf("Warning: These characters may need to be removed.\n");
   }
   delete[] tempString;
   return 0;

--- a/src/ArgList.h
+++ b/src/ArgList.h
@@ -49,6 +49,8 @@ class ArgList {
     void ClearList();
     /// Set up argument list from string and given separators
     int SetList(std::string const&, const char *);
+    /// Check for and report non-ASCII characters in argline_
+    void CheckArgLineForNonASCII() const;
     /// \return an argument list of remaining unmarked args (and mark them here).
     ArgList RemainingArgs();
     /// \return number of unmarked arguments

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -647,6 +647,7 @@ int Command::ExecuteControlBlock(int block, CpptrajState& State)
 CpptrajState::RetType Command::Dispatch(CpptrajState& State, std::string const& commandIn)
 {
   ArgList cmdArg( commandIn );
+  cmdArg.CheckArgLineForNonASCII();
   cmdArg.MarkArg(0); // Always mark the first arg as the command
   if (State.Debug() > 0)
     cmdArg.PrintDebug();

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -648,6 +648,8 @@ CpptrajState::RetType Command::Dispatch(CpptrajState& State, std::string const& 
 {
   ArgList cmdArg( commandIn );
   cmdArg.MarkArg(0); // Always mark the first arg as the command
+  if (State.Debug() > 0)
+    cmdArg.PrintDebug();
   // Check for control block
   if (!control_.empty()) {
     mprintf("  [%s]\n", cmdArg.ArgLine());

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V5.2.0"
+#define CPPTRAJ_INTERNAL_VERSION "V5.2.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Non-ASCII (like unicode) characters can appear like unhandled input to CPPTRAJ. This PR adds support for detecting and reporting where these characters are in input, and informs users they may need to remove these characters. Version 5.2.1.