### PR TITLE
Remove the Intel compiler build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
                     post { cleanup { deleteDir() } }
                 }
                 stage("Linux Intel Serial Build") {
+                    when { expression { return false } }
                     agent {
                         docker {
                             image 'ambermd/cpu-build:latest'


### PR DESCRIPTION
I don't want to do this, but Intel makes it harder and harder each year to renew the license (which has currently expired).  I'll leave the block in there in case Intel makes it easier or possible to do this in the future, but let's not block pytraj testing because my Intel compiler license has expired and I can't bother spending the hour(s) I need to try and fix it.