### PR TITLE
Add basic support for Intel OneAPI

### DIFF
--- a/configure
+++ b/configure
@@ -1329,7 +1329,7 @@ SetupCompilers() {
   if [ ! -z "$CC"  ] ; then echo "C compiler (CC) set to $CC" ; fi
   if [ ! -z "$FC"  ] ; then echo "Fortran compiler (FC) set to $FC" ; fi
   # If no compiler type specified try to guess
-  if [ -z "$COMPILERS" -o ! -z "$CXX" ] ; then
+  if [ -z "$COMPILERS" ] ; then
     if [ ! -z "$CXX" ] ; then
       SPECIFIED_COMPILER=$COMPILERS
       echo "Determining compilers from CXX ($CXX)"

--- a/configure
+++ b/configure
@@ -1410,11 +1410,29 @@ SetupCompilers() {
       hostflags=''
       optflags=''
       ompflag='-fopenmp'
-      freefmtflag='-ffree-form'
-      foptflags='-O3'
-      FLINK='-lgfortran'
       picflag='-fpic'
       C11FLAG='-std=c++11'
+      # May be several fortran compiler options
+      if [ -z "$FC" ]; then
+        if [ ! -z "`which ifx`" ] ; then
+          FC=ifx
+        elif [ ! -z "`which ifort`" ] ; then
+          FC=ifort
+        else
+          FC=gfortran
+        fi
+      fi
+      # Determine flags based on what fortran we have
+      if [ "$FC" = 'gfortran' ] ; then
+        freefmtflag='-ffree-form'
+        foptflags='-O3'
+        FLINK='-lgfortran'
+      elif [ "$FC" = 'ifort' ] ; then
+        freefmtflag='-FR'
+        foptflags='-ip -O3'
+        fwarnflag='-warn all'
+        FLINK='-lifport -lifcore'
+      fi
       ;;
     'intel' )
       if [ -z "$CC" ]; then CC=icc; fi

--- a/configure
+++ b/configure
@@ -11,7 +11,7 @@
 #-------------------------------------------------------------------------------
 # Print simple help message
 UsageSimple() {
-  echo "Usage: ./configure <OPTIONS> [gnu | intel | pgi | clang | cray]"
+  echo "Usage: ./configure <OPTIONS> [gnu | intel | pgi | clang | cray | oneapi]"
   echo "  OPTIONS:"
   echo "    --help         : Display this message."
   echo "    --prefix <dir> : Install CPPTRAJ to specified directory (default is this directory)."
@@ -1338,6 +1338,7 @@ SetupCompilers() {
         *clang++* ) COMPILERS='clang' ;;
         *g++*     ) COMPILERS='gnu' ;;
         *icpc*    ) COMPILERS='intel' ;;
+        *icpx*    ) COMPILERS='oneapi' ;;
         *pgc++*   ) COMPILERS='pgi' ;;
         *CC*      ) COMPILERS='cray' ;;
         * ) WrnMsg "Could not detect compiler type ($CXX); assuming GNU" ;;
@@ -1399,6 +1400,20 @@ SetupCompilers() {
       foptflags='-O3'
       FLINK='-lgfortran'
       picflag='-fPIC'
+      C11FLAG='-std=c++11'
+      ;;
+   'oneapi' )
+      if [ -z "$CC" ]; then CC=icx; fi
+      if [ -z "$CXX" ]; then CXX=icpx; fi
+      if [ -z "$FC" ]; then FC=gfortran; fi
+      CXXFLAGS="-fp-model precise $CXXFLAGS"
+      hostflags=''
+      optflags=''
+      ompflag='-fopenmp'
+      freefmtflag='-ffree-form'
+      foptflags='-O3'
+      FLINK='-lgfortran'
+      picflag='-fpic'
       C11FLAG='-std=c++11'
       ;;
     'intel' )
@@ -2287,6 +2302,7 @@ while [ ! -z "$1" ] ; do
     'gnu'        ) COMPILERS=$KEY ;;
     'clang'      ) COMPILERS=$KEY ;;
     'intel'      ) COMPILERS=$KEY ;;
+    'oneapi'     ) COMPILERS=$KEY ;;
     'pgi'        ) COMPILERS=$KEY ;;
     'cray'       ) COMPILERS=$KEY ;;
     'CXX'        ) CXX="$VALUE" ;;

--- a/configure
+++ b/configure
@@ -1405,7 +1405,6 @@ SetupCompilers() {
    'oneapi' )
       if [ -z "$CC" ]; then CC=icx; fi
       if [ -z "$CXX" ]; then CXX=icpx; fi
-      if [ -z "$FC" ]; then FC=gfortran; fi
       CXXFLAGS="-fp-model precise $CXXFLAGS"
       hostflags=''
       optflags=''
@@ -1430,6 +1429,9 @@ SetupCompilers() {
       elif [ "$FC" = 'ifort' ] ; then
         freefmtflag='-FR'
         foptflags='-ip -O3'
+        fwarnflag='-warn all'
+        FLINK='-lifport -lifcore'
+      elif [ "$FC" = 'ifx' ] ; then
         fwarnflag='-warn all'
         FLINK='-lifport -lifcore'
       fi
@@ -1672,6 +1674,22 @@ EOF
       end program testf
 EOF
     TestProgram "  Testing Fortran compiler" "$FC" "$FFLAGS" testp.f
+#    # Test C++/Fortran linking
+#    cat > testp.cpp <<EOF
+#extern "C" { void printmessage(int&); }
+#int main() { int ival = 1; printmessage( ival ); return 0; }
+#EOF
+#    cat > testp.f <<EOF
+#      subroutine printmessage(ival)
+#      integer ival
+#      write(6,'(a,i6)') "Ival is ", ival
+#      end subroutine printmessage
+#EOF
+#    echo "  Testing C++/Fortran linking"
+#    echo "$CXX $CXXFLAGS -c -o testp.cpp.o testp.cpp"
+##    $CXX $CXXFLAGS -c -o testp.cpp.o testp.cpp
+#    echo "$FC $FFLAGS -c -o testp.f.o testp.f"
+#    $FC $FFLAGS -c -o testp.f.o testp.f
   fi
 }
 

--- a/src/readline/tparam.c
+++ b/src/readline/tparam.c
@@ -38,6 +38,10 @@ char *realloc ();
 #define bcopy(s, d, n) memcpy ((d), (s), (n))
 #endif
 
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
 #endif /* not emacs */
 
 #ifndef NULL


### PR DESCRIPTION
Adds a `oneapi` target for `configure` to use the `icx`, `icpx`, and `ifx` compilers. I haven't done any performance testing yet - the purpose of this PR so that such testing can be done. I've tested that cpptraj will compile with all compilers from OneAPI (`icpx`/`icpc`), and that the `icpx`/`gfortran` combo works if the OneAPI HPC add-on is not installed.

Also adds a missing include to the bundled `readline` code that seems to be causing issues with OSX/clang12.

Since no cpptraj code is changed, no version bump.