### PR TITLE
Fix reading XVG files when no legends present.

### DIFF
--- a/src/DataIO_XVG.cpp
+++ b/src/DataIO_XVG.cpp
@@ -54,8 +54,7 @@ int DataIO_XVG::ReadData(FileName const& fname,
     ptr = infile.Line();
   }
   if (Legends.empty()) {
-    mprinterr("Error: No set legends found in XVG file.\n");
-    return 1;
+    mprintf("Warning: No set legends found in XVG file, assuming only one data set.\n");
   }
   if (ptr == 0) {
     mprinterr("Error: No data in XVG file.\n");
@@ -63,9 +62,17 @@ int DataIO_XVG::ReadData(FileName const& fname,
   }
   // Create 1 data set for each legend
   DataSetList::DataListType inputSets;
-  for (unsigned int i = 0; i != Legends.size(); i++) {
-    MetaData md( dsname, i );
-    md.SetLegend( Legends[i] );
+  if (!Legends.empty()) {
+    for (unsigned int i = 0; i != Legends.size(); i++) {
+      MetaData md( dsname, i );
+      md.SetLegend( Legends[i] );
+      DataSet_double* ds = new DataSet_double();
+      if (ds == 0) return 1;
+      ds->SetMeta( md );
+      inputSets.push_back( ds );
+    }
+  } else {
+    MetaData md(dsname);
     DataSet_double* ds = new DataSet_double();
     if (ds == 0) return 1;
     ds->SetMeta( md );

--- a/src/Parm_Gromacs.cpp
+++ b/src/Parm_Gromacs.cpp
@@ -405,6 +405,7 @@ int Parm_Gromacs::ReadParm(FileName const& fname, Topology &TopIn) {
       }
     if (tgtmol == -1) {
       mprinterr("Error: Molecule %s is not defined in gromacs topology.\n", mols_[m].c_str());
+      mprinterr("Error:   Ensure the GMXDATA environment variable is correctly set.\n");
       return 1;
     }
     AtomArray const& Mol = gmx_molecules_[tgtmol].atoms_;

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V5.3.3"
+#define CPPTRAJ_INTERNAL_VERSION "V5.3.4"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 5.3.4.

Will assume only 1 data set present and proceed accordingly instead of failing to read anything.

Also add a message about checking `GMXDATA` env. variable when molecule not found in gromacs topology (#901).