### PR TITLE
Parallelize time correlation function calculation with OpenMP

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -1142,6 +1142,10 @@ replicatecell
 \end_layout
 
 \begin_layout LyX-Code
+rotdif
+\end_layout
+
+\begin_layout LyX-Code
 rmsavgcorr
 \end_layout
 
@@ -46339,6 +46343,8 @@ reference "subsec:cpptraj-average"
  random vector.
  The time correlation functions are calculated for each random vector time
  series using Legendre polynomials of the specified order (default 2).
+ Calculation of time correlation functions can be sped up by using the OpenMP
+ version of CPPTRAJ.
  The maximum length of the correlation function (or lag) can be specified
  by 
 \series bold

--- a/src/Analysis_Rotdif.cpp
+++ b/src/Analysis_Rotdif.cpp
@@ -135,7 +135,7 @@ Analysis::RetType Analysis_Rotdif::Setup(ArgList& analyzeArgs, AnalysisSetup& se
     amoeba_ftol_ = analyzeArgs.getKeyDouble("fit_tol", amoeba_ftol_);
     amoeba_itmax_ = analyzeArgs.getKeyInt("fit_itmax", amoeba_itmax_);
   }
-  // Rotation matrices data set. TODO: Make optional
+  // Rotation matrices data set.
   std::string rm_name = analyzeArgs.GetStringKey("rmatrix");
   Rmatrices_ = (DataSet_Mat3x3*)setup.DSL().FindSetOfType( rm_name, DataSet::MAT3X3 );
   if (Rmatrices_ == 0) {
@@ -1267,7 +1267,7 @@ int Analysis_Rotdif::DetermineDeffsAlt() {
     // Reset rotated_vectors to the beginning and clear spherical harmonics 
     rotated_vectors.reset();
     // Normalize vector
-    //rndvec->Normalize(); // FIXME: Should already be normalized
+    //rndvec->Normalize(); // NOTE: Should already be normalized
     // Assign normalized vector to rotated_vectors position 0
     rotated_vectors.AddVxyz( *rndvec );
     // Loop over rotation matrices
@@ -1429,7 +1429,6 @@ int Analysis_Rotdif::DetermineDeffsAlt() {
   * \param maxdat Maximum length to compute time correlation functions (units of 'frames')
   * \param pY Will be set with values for correlation function, l=olegendre_
   */
-// TODO: Make rotated_vectors const&
 int Analysis_Rotdif::direct_compute_corr(DataSet_Vector const& rotated_vectors, int maxdat,
                                        std::vector<double>& pY)
 {
@@ -1532,7 +1531,7 @@ double Analysis_Rotdif::calcEffectiveDiffusionConst(double f ) {
   * time correlation function curve and estimate the diffusion constant.
   * Sets D_Eff, normalizes random_vectors.
   */
-// TODO: OpenMP Parallelize
+/*
 int Analysis_Rotdif::DetermineDeffs() {
   int itotframes;                 // Total number of frames (rotation matrices) 
   DataSet_Vector rotated_vectors; // Hold vectors after rotation with Rmatrices
@@ -1576,7 +1575,7 @@ int Analysis_Rotdif::DetermineDeffs() {
     // Reset rotated_vectors to the beginning 
     rotated_vectors.reset();
     // Normalize vector
-    //rndvec->Normalize(); // FIXME: Should already be normalized
+    //rndvec->Normalize(); // NOTE: Should already be normalized
     // Assign normalized vector to rotated_vectors position 0
     rotated_vectors.AddVxyz( *rndvec );
     // Loop over rotation matrices
@@ -1655,6 +1654,7 @@ int Analysis_Rotdif::DetermineDeffs() {
   }
   return 0;
 }
+*/
 
 /** Threaded version of DetermineDeffs */
 int Analysis_Rotdif::DetermineDeffs_Threaded() {

--- a/src/Analysis_Rotdif.cpp
+++ b/src/Analysis_Rotdif.cpp
@@ -194,6 +194,18 @@ Analysis::RetType Analysis_Rotdif::Setup(ArgList& analyzeArgs, AnalysisSetup& se
       mprintf("\tDiffusion constants output to STDOUT\n");
   } else {
     mprintf("\tVector time correlation functions will be calculated directly.\n");
+#   ifdef _OPENMP
+    int nthreads = 1;
+#   pragma omp parallel
+    {
+#     pragma omp master
+      {
+        nthreads = omp_get_num_threads();
+      }
+    }
+    if (nthreads > 1)
+      mprintf("\tCalculation of time correlation functions will be parallelized using %i threads.\n", nthreads);
+#   endif
     if (!corrOut_.empty())
       mprintf("\tVector time correlation functions will be written to '%s.X'\n",
               corrOut_.c_str());

--- a/src/Analysis_Rotdif.h
+++ b/src/Analysis_Rotdif.h
@@ -39,7 +39,7 @@ class Analysis_Rotdif: public Analysis {
     static void PrintVec6(CpptrajFile&, const char*, std::vector<double> const&);
     void PrintTau( std::vector<double> const& );
     int Tensor_Fit(std::vector<double>&);
-    int DetermineDeffs();
+    //int DetermineDeffs();
     int DetermineDeffs_Threaded();
     void PrintDeffs(std::string const&) const;
 

--- a/src/Analysis_Rotdif.h
+++ b/src/Analysis_Rotdif.h
@@ -3,6 +3,7 @@
 #include "Analysis.h"
 #include "Random.h"
 #include "DataSet_Vector.h"
+#include "Timer.h"
 class DataSet_Mat3x3;
 /// Estimate rotational diffusion tensors from MD simulations
 /** To estimate rotational diffusion tensors from MD simulations along the
@@ -27,6 +28,21 @@ class Analysis_Rotdif: public Analysis {
   private:
     Analysis::RetType Setup(ArgList&, AnalysisSetup&, int);
     Analysis::RetType Analyze();
+
+    DataSet_Vector RandomVectors();
+    int direct_compute_corr(DataSet_Vector const&, int, std::vector<double>&);
+    int fft_compute_corr(DataSet_Vector const&, int, std::vector<double>&);
+    double calcEffectiveDiffusionConst(double );
+
+    static void PrintMatrix(CpptrajFile&, const char*, Matrix_3x3 const&);
+    static void PrintVector(CpptrajFile&, const char*, Vec3 const&);
+    static void PrintVec6(CpptrajFile&, const char*, std::vector<double> const&);
+    void PrintTau( std::vector<double> const& );
+    int Tensor_Fit(std::vector<double>&);
+    int DetermineDeffs();
+    void PrintDeffs(std::string const&) const;
+
+    int DetermineDeffsAlt();
 
     int debug_;
     int rseed_;          ///< Random seed
@@ -66,20 +82,12 @@ class Analysis_Rotdif: public Analysis {
     DataSet_Vector random_vectors_; ///< Hold nvecs random vectors
     std::vector<double> D_eff_;     ///< Hold calculated effective D values for each vector
 //    std::vector<double> sumc2_;      
-
-    DataSet_Vector RandomVectors();
-    int direct_compute_corr(DataSet_Vector const&, int, std::vector<double>&);
-    int fft_compute_corr(DataSet_Vector const&, int, std::vector<double>&);
-    double calcEffectiveDiffusionConst(double );
-
-    static void PrintMatrix(CpptrajFile&, const char*, Matrix_3x3 const&);
-    static void PrintVector(CpptrajFile&, const char*, Vec3 const&);
-    static void PrintVec6(CpptrajFile&, const char*, std::vector<double> const&);
-    void PrintTau( std::vector<double> const& );
-    int Tensor_Fit(std::vector<double>&);
-    int DetermineDeffs();
-    void PrintDeffs(std::string const&) const;
-
-    int DetermineDeffsAlt();
+    Timer t_total_;
+    Timer t_rvec_;
+    Timer t_transposeRmat_;
+    Timer t_determineDeffs_;
+    Timer t_tensorFit_;
+    Timer t_minimize_;
+    Timer t_gridSearch_;
 };
 #endif  

--- a/src/Analysis_Rotdif.h
+++ b/src/Analysis_Rotdif.h
@@ -40,6 +40,7 @@ class Analysis_Rotdif: public Analysis {
     void PrintTau( std::vector<double> const& );
     int Tensor_Fit(std::vector<double>&);
     int DetermineDeffs();
+    int DetermineDeffs_Threaded();
     void PrintDeffs(std::string const&) const;
 
     int DetermineDeffsAlt();

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V5.3.4"
+#define CPPTRAJ_INTERNAL_VERSION "V5.3.5"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 5.3.5.

This tends to be the most time-consuming part of a `rotdif` calculation (especially for large numbers of vectors), so divide the vector calculations among available threads. It parallelizes pretty well, around 90% efficient at 4 threads. Will have to test more, but seems like a solid speed gain so far.