### PR TITLE
Update behavior of some info commands. Fix library for ambpdb.

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -12104,7 +12104,7 @@ atominfo | atoms | printatoms
 \end_layout
 
 \begin_layout LyX-Code
-atominfo [parm <name> | parmindex <#> | <#>] [<mask>] [out <file>]
+atominfo [parm <name> | parmindex <#> | <#>] <mask> [out <file>]
 \end_layout
 
 \begin_deeper
@@ -12138,7 +12138,7 @@ parmindex
 \end_layout
 
 \begin_layout Description
-[<mask>] Mask selecting atoms to print info for.
+<mask> Mask selecting atoms to print info for.
 \end_layout
 
 \begin_layout Description
@@ -12624,7 +12624,7 @@ charge
 \end_layout
 
 \begin_layout LyX-Code
-charge [parm <name> | parmindex <#> | <#>] [<mask>] [out <file>] [name <set>]
+charge [parm <name> | parmindex <#> | <#>] <mask> [out <file>] [name <set>]
 \end_layout
 
 \begin_deeper
@@ -12649,7 +12649,7 @@ parmindex
 \end_layout
 
 \begin_layout Description
-[<mask>] Atom(s) to calculate total charge for (default all).
+<mask> Atom(s) to calculate total charge for (default all).
 \end_layout
 
 \begin_layout Description
@@ -12955,8 +12955,8 @@ mass
 \end_layout
 
 \begin_layout LyX-Code
-[<parmindex>] [parm <name> | parmindex <#> | <#>] [<mask>] [out <file>]
- [name <set>]
+[<parmindex>] [parm <name> | parmindex <#> | <#>] <mask> [out <file>] [name
+ <set>]
 \end_layout
 
 \begin_deeper
@@ -12981,7 +12981,7 @@ parmindex
 \end_layout
 
 \begin_layout Description
-[<mask>] Atom(s) to calculate total mass for (default all).
+<mask> Atom(s) to calculate total mass for (default all).
 \end_layout
 
 \begin_layout Description
@@ -13012,7 +13012,7 @@ molinfo
 \end_layout
 
 \begin_layout LyX-Code
-molinfo [parm <name> | parmindex <#> | <#>] [<mask>] [out <file>]
+molinfo [parm <name> | parmindex <#> | <#>] <mask> [out <file>]
 \end_layout
 
 \begin_deeper
@@ -13046,7 +13046,7 @@ parmindex
 \end_layout
 
 \begin_layout Description
-[<mask>] Mask selecting molecules to print info for.
+<mask> Mask selecting molecules to print info for.
 \end_layout
 
 \begin_layout Description
@@ -13085,7 +13085,24 @@ Natom
 Name
 \family default
  are the residue number and residue name of the first residue in the molecule
- respectively, and C is the chain ID of the first residue.
+ respectively, and 
+\family typewriter
+C
+\family default
+ is the chain ID of the first residue.
+ If the molecule is composed on non-consecutive fragments, 
+\family typewriter
+#Res
+\family default
+, 
+\family typewriter
+Name
+\family default
+, and 
+\family typewriter
+C
+\family default
+ will be printed for each fragment.
  
 \family typewriter
 SOLVENT
@@ -13840,7 +13857,7 @@ parmresinfo
 
 \end_inset
 
- [parm <name> | parmindex <#> | <#>] [<mask>] [short [maxwidth <#res>]]
+ [parm <name> | parmindex <#> | <#>] <mask> [short [maxwidth <#res>]]
 \end_layout
 
 \begin_layout LyX-Code
@@ -13878,7 +13895,7 @@ parmindex
 \end_layout
 
 \begin_layout Description
-[<mask>] Mask selecting residues to print info for.
+<mask> Mask selecting residues to print info for.
 \end_layout
 
 \begin_layout Description

--- a/src/Action_Channel.cpp
+++ b/src/Action_Channel.cpp
@@ -56,7 +56,7 @@ Action::RetType Action_Channel::Setup(ActionSetup& setup) {
       mprinterr("Error: No box information to set up grid.\n");
       return Action::ERR;
     } else if (box.Is_X_Aligned_Ortho()) {
-      // FIXME: May need to update parm box info or set up on first frame.
+      // TODO: May need to update parm box info or set up on first frame.
       if (GRID.Allocate_X_C_D(box.Lengths(), box.Center(), dxyz_)) return Action::ERR; 
     } else {
       Vec3 nxyz = box.Lengths() / dxyz_;

--- a/src/Action_Closest.cpp
+++ b/src/Action_Closest.cpp
@@ -104,8 +104,12 @@ Action::RetType Action_Closest::Init(ArgList& actionArgs, ActionInit& init, int 
 
   // Get Masks
   std::string mask1 = actionArgs.GetStringKey("solventmask");
-  if (!mask1.empty())
-    solventMask_.SetMaskString( mask1 );
+  if (!mask1.empty()) {
+    if (solventMask_.SetMaskString( mask1 )) {
+      mprinterr("Error: Could not set solvent mask string.\n");
+      return Action::ERR;
+    }
+  }
   mask1 = actionArgs.GetMaskNext();
   if (mask1.empty()) {
     mprinterr("Error: No mask specified.\n");

--- a/src/Action_VelocityAutoCorr.cpp
+++ b/src/Action_VelocityAutoCorr.cpp
@@ -130,7 +130,7 @@ Action::RetType Action_VelocityAutoCorr::DoAction(int frameNum, ActionFrame& frm
     previousFrame_ = frm.Frm();
   } else {
     // Use velocity information in the frame.
-    // FIXME: Eventually dont assume V is in Amber units.
+    // Assume V is in Amber units.
     VelArray::iterator vel = Vel_.begin();
     for (AtomMask::const_iterator atom = mask_.begin();
                                   atom != mask_.end(); 

--- a/src/Analysis_EvalPlateau.cpp
+++ b/src/Analysis_EvalPlateau.cpp
@@ -444,8 +444,6 @@ Analysis::RetType Analysis_EvalPlateau::Analyze() {
     data_[ONEA1]->Add(oidx, &onea1);
     //data_[FVAL]->Add(oidx, &Fval);
     data_[CORR]->Add(oidx, &corr_coeff);
-    // FIXME hijacking ValA temporarily
-    //ValA = Params[2]-Params[0];
     //if (ValA < 0.0) ValA = -ValA;
     data_[VALA]->Add(oidx, &ValA);
     //data_[LCHISQ]->Add(oidx, &linChiSq);

--- a/src/Exec_Top.cpp
+++ b/src/Exec_Top.cpp
@@ -148,7 +148,7 @@ Exec::RetType Exec_ImproperInfo::Execute(CpptrajState& State, ArgList& argIn) {
 
 // -----------------------------------------------------------------------------
 void Exec_AtomInfo::Help() const {
-  mprintf("\t[%s] [<mask>] [out <file>]\n", DataSetList::TopIdxArgs);
+  mprintf("\t[%s] <mask> [out <file>]\n", DataSetList::TopIdxArgs);
   mprintf("  Print information on atoms in <mask> for specified topology (first by default).\n");
 }
 
@@ -161,7 +161,7 @@ Exec::RetType Exec_AtomInfo::Execute(CpptrajState& State, ArgList& argIn) {
 
 // -----------------------------------------------------------------------------
 void Exec_ResInfo::Help() const {
-  mprintf("\t[%s] [<mask>] [short [maxwidth <#res>]]\n\t[out <file>]\n", DataSetList::TopIdxArgs);
+  mprintf("\t[%s] <mask> [short [maxwidth <#res>]]\n\t[out <file>]\n", DataSetList::TopIdxArgs);
   mprintf("  Print info for residues in <mask> for specified topology (first by default).\n"
           "  If 'short' is specified print residue info in shorter form.\n");
 }
@@ -180,7 +180,7 @@ Exec::RetType Exec_ResInfo::Execute(CpptrajState& State, ArgList& argIn) {
 }
 // -----------------------------------------------------------------------------
 void Exec_MolInfo::Help() const {
-  mprintf("\t[%s] [<mask>] [short] [out <file>]\n", DataSetList::TopIdxArgs);
+  mprintf("\t[%s] <mask> [short] [out <file>]\n", DataSetList::TopIdxArgs);
   mprintf("  Print info for molecules in <mask> for specfied topology (first by default).\n"
           "  If 'short' is specified print counts of each unique molecule.\n");
 }
@@ -199,7 +199,7 @@ Exec::RetType Exec_MolInfo::Execute(CpptrajState& State, ArgList& argIn) {
 }
 // -----------------------------------------------------------------------------
 void Exec_ChargeInfo::Help() const {
-  mprintf("\t[%s] [<mask>] [out <file>] [name <set>]\n", DataSetList::TopIdxArgs);
+  mprintf("\t[%s] <mask> [out <file>] [name <set>]\n", DataSetList::TopIdxArgs);
   mprintf("  Print total charge of atoms in <mask> for specified topology (first by default).\n");
 }
 
@@ -221,7 +221,7 @@ Exec::RetType Exec_ChargeInfo::Execute(CpptrajState& State, ArgList& argIn) {
 }
 // -----------------------------------------------------------------------------
 void Exec_MassInfo::Help() const {
-  mprintf("\t[%s] [<mask>] [out <file>] [name <set>]\n", DataSetList::TopIdxArgs);
+  mprintf("\t[%s] <mask> [out <file>] [name <set>]\n", DataSetList::TopIdxArgs);
   mprintf("  Print total mass of atoms in <mask> for specified topology (first by default).\n");
 }
 

--- a/src/MaskToken.cpp
+++ b/src/MaskToken.cpp
@@ -301,13 +301,16 @@ int MaskTokenArray::Tokenize() {
           return 1;
         }
       }
-      if (*p == '=') { // The AMBER9 definition of wildcard '=' is equivalent to '*'.
-        if (flag > 0)
+      if (*p == '=') {
+        // The AMBER >= 9 definition of wildcard '=' is equivalent to '*', but
+        // only after @ etc.
+        //if (flag > 0)
+        // NOTE: If flag was zero it will have been set to 1 up above anyway.
           *p = '*';
-        else {
-          mprinterr("Error: Tokenize: '=' not in name list syntax\n");
-          return 1;
-        }
+        //else {
+        //  mprinterr("Error: Tokenize: '=' not in name list syntax\n");
+        //  return 1;
+        //}
       }
       buffer += *p;
     } else if ( *p == ':' ) {

--- a/src/TopInfo.cpp
+++ b/src/TopInfo.cpp
@@ -104,7 +104,7 @@ int TopInfo::maxAtomNamesWidth(AtomMask const& mask) const {
 // TopInfo::PrintAtomInfo()
 int TopInfo::PrintAtomInfo(std::string const& maskExpression) const {
   if (maskExpression.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given to select atoms.\n");
     return 1;
   }
   AtomMask mask( maskExpression );
@@ -161,7 +161,7 @@ int TopInfo::maxResNameWidth(std::vector<int> const& resNums) const {
 // TopInfo::PrintResidueInfo()
 int TopInfo::PrintResidueInfo(std::string const& maskExpression) const {
   if (maskExpression.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given to select residues.\n");
     return 1;
   }
   AtomMask mask( maskExpression );
@@ -205,7 +205,7 @@ int TopInfo::PrintResidueInfo(std::string const& maskExpression) const {
 /** Print residue info using single char names. */ // TODO use Topology::ResnumsSelectedBy
 int TopInfo::PrintShortResInfo(std::string const& maskString, int maxChar) const {
   if (maskString.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given for short residue info.\n");
     return 1;
   }
   AtomMask mask( maskString );
@@ -272,7 +272,7 @@ int TopInfo::maxMolNameWidth(std::vector<int> const& molNums) const {
 // TopInfo::PrintMoleculeInfo()
 int TopInfo::PrintMoleculeInfo(std::string const& maskString) const {
   if (maskString.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given to select molecules.\n");
     return 1;
   }
   if (parm_->Nmol() < 1)
@@ -327,7 +327,7 @@ int TopInfo::PrintMoleculeInfo(std::string const& maskString) const {
 // TopInfo::PrintShortMolInfo()
 int TopInfo::PrintShortMolInfo(std::string const& maskString) const {
   if (maskString.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given for short molecule info.\n");
     return 1;
   }
   if (parm_->Nmol() < 1)
@@ -373,7 +373,7 @@ int TopInfo::PrintShortMolInfo(std::string const& maskString) const {
 // TopInfo::PrintChargeInfo()
 int TopInfo::PrintChargeInfo(std::string const& maskExpression, double& sumQ) const {
   if (maskExpression.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given to calculate charge.\n");
     return 1;
   }
   AtomMask mask( maskExpression );
@@ -389,7 +389,7 @@ int TopInfo::PrintChargeInfo(std::string const& maskExpression, double& sumQ) co
 // TopInfo::PrintMassInfo()
 int TopInfo::PrintMassInfo(std::string const& maskExpression, double& sumM) const {
   if (maskExpression.empty()) {
-    mprinterr("Error: No valid mask given.\n");
+    mprinterr("Error: No valid mask given to calculate mass.\n");
     return 1;
   }
   AtomMask mask( maskExpression );

--- a/src/TopInfo.cpp
+++ b/src/TopInfo.cpp
@@ -103,6 +103,10 @@ int TopInfo::maxAtomNamesWidth(AtomMask const& mask) const {
 
 // TopInfo::PrintAtomInfo()
 int TopInfo::PrintAtomInfo(std::string const& maskExpression) const {
+  if (maskExpression.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   AtomMask mask( maskExpression );
   if (parm_->SetupIntegerMask( mask )) return 1;
   if ( mask.None() )
@@ -156,6 +160,10 @@ int TopInfo::maxResNameWidth(std::vector<int> const& resNums) const {
 
 // TopInfo::PrintResidueInfo()
 int TopInfo::PrintResidueInfo(std::string const& maskExpression) const {
+  if (maskExpression.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   AtomMask mask( maskExpression );
   if (parm_->SetupIntegerMask( mask )) return 1;
   if ( mask.None() )
@@ -196,6 +204,10 @@ int TopInfo::PrintResidueInfo(std::string const& maskExpression) const {
 
 /** Print residue info using single char names. */ // TODO use Topology::ResnumsSelectedBy
 int TopInfo::PrintShortResInfo(std::string const& maskString, int maxChar) const {
+  if (maskString.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   AtomMask mask( maskString );
   if (parm_->SetupIntegerMask( mask )) return 1;
   if ( mask.None() )
@@ -259,6 +271,10 @@ int TopInfo::maxMolNameWidth(std::vector<int> const& molNums) const {
 
 // TopInfo::PrintMoleculeInfo()
 int TopInfo::PrintMoleculeInfo(std::string const& maskString) const {
+  if (maskString.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   if (parm_->Nmol() < 1)
     mprintf("\t'%s' No molecule info.\n", parm_->c_str());
   else {
@@ -310,6 +326,10 @@ int TopInfo::PrintMoleculeInfo(std::string const& maskString) const {
 
 // TopInfo::PrintShortMolInfo()
 int TopInfo::PrintShortMolInfo(std::string const& maskString) const {
+  if (maskString.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   if (parm_->Nmol() < 1)
     mprintf("\t'%s' No molecule info.\n", parm_->c_str());
   else {
@@ -352,6 +372,10 @@ int TopInfo::PrintShortMolInfo(std::string const& maskString) const {
 
 // TopInfo::PrintChargeInfo()
 int TopInfo::PrintChargeInfo(std::string const& maskExpression, double& sumQ) const {
+  if (maskExpression.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   AtomMask mask( maskExpression );
   if (parm_->SetupIntegerMask( mask )) return 1;
   sumQ = 0.0;
@@ -364,6 +388,10 @@ int TopInfo::PrintChargeInfo(std::string const& maskExpression, double& sumQ) co
 
 // TopInfo::PrintMassInfo()
 int TopInfo::PrintMassInfo(std::string const& maskExpression, double& sumM) const {
+  if (maskExpression.empty()) {
+    mprinterr("Error: No valid mask given.\n");
+    return 1;
+  }
   AtomMask mask( maskExpression );
   if (parm_->SetupIntegerMask( mask )) return 1;
   sumM = 0.0;

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -57,10 +57,6 @@ void Topology::ResetPDBinfo() {
 }
 
 /** Used to set box info from currently associated trajectory. */
-// FIXME: This routine is here for potential backwards compatibility issues
-//        since the topology box information was previously modified by
-//        trajectory box information, but may no longer be necessary or
-//        desirable.
 void Topology::SetBoxFromTraj(Box const& boxIn) {
   if (!boxIn.HasBox()) {
     // No incoming box.
@@ -248,8 +244,8 @@ std::string Topology::TruncAtomNameNum(int atom) const {
   * "<resname>:<resnum>", e.g. "ARG:11".
   * Truncate residue name so there are no blanks.
   */
-// FIXME: Add residue bounds check.
 std::string Topology::TruncResNameNum(int res) const {
+  if (res < 0 || res >= (int)residues_.size()) return std::string("");
   // Residue name with no trailing spaces.
   return residues_[res].Name().Truncated() + ":" + integerToString( res+1 );
 }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V5.3.9"
+#define CPPTRAJ_INTERNAL_VERSION "V5.4.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -497,6 +497,7 @@ LIBCPPTRAJ_FILE_OBJECTS= \
   Mol2File.o \
   PDBfile.o \
   SDFfile.o \
+  TextBlockBuffer.o \
   TinkerFile.o
 
 # These objects are required for Gromacs XTC support in libcpptraj_traj.a

--- a/test/Test_CmdLine/RunTest.sh
+++ b/test/Test_CmdLine/RunTest.sh
@@ -29,14 +29,14 @@ DoTest test1.crd.save test1.crd
 cat > cmd.in <<EOF
 parm ../tz2.parm7
 parm ../tz2.pdb
-resinfo out res.save parmindex 0
-resinfo out res.save parmindex 1
+resinfo out res.save parmindex 0 *
+resinfo out res.save parmindex 1 *
 EOF
 INPUT='-i cmd.in'
 RunCpptraj "Command line wildcard test, part 1"
 cat > cmd.in <<EOF
-resinfo out res parmindex 0
-resinfo out res parmindex 1
+resinfo out res parmindex 0 *
+resinfo out res parmindex 1 *
 EOF
 INPUT='../tz2.p* cmd.in'
 RunCpptraj "Command line wildcard test, part 2"

--- a/test/Test_TopInfo/RunTest.sh
+++ b/test/Test_TopInfo/RunTest.sh
@@ -12,10 +12,10 @@ parm ../tz2.parm7
 atoms :3
 atoms :3 out atoms.dat
 
-resinfo
-resinfo out residues.dat
-resinfo short
-resinfo short out residues.dat
+resinfo *
+resinfo out residues.dat *
+resinfo short *
+resinfo short out residues.dat *
 
 bonds :1
 bonds :1 out bonds.dat
@@ -32,15 +32,15 @@ dihedralinfo @1 out dihedrals.dat
 dihedralinfo @N @CA @CB @%H1
 dihedralinfo @N @CA @CB @%H1 out dihedrals.dat
 
-mass out masscharge.dat name Mass
-charge out masscharge.dat name Charge
+mass out masscharge.dat name Mass *
+charge out masscharge.dat name Charge *
 writedata ChargeMass.dat Charge Mass noheader noxcol
 
 parm ../dna30.parm7
 molinfo !:WAT 1
 molinfo !:WAT out molecules.dat 1
-molinfo short 1
-molinfo short out molshort.dat 1
+molinfo short 1 *
+molinfo short out molshort.dat 1 *
 resinfo ^2,5-7,100 out molselect.dat parm dna30.parm7
 atoms ^1:DC@P,O?P out molselect2.dat parmindex 1
 quit


### PR DESCRIPTION
Version 5.4.0

This PR makes it so that the `atoms`, `resinfo`, `molinfo`, `charge`, and `mass` commands now explicitly require a mask. This makes it easier to trap mask errors with these commands; previously if an invalid mask was specified, sometimes all atoms could be selected.

Also adds TextBlockBuffer to libcpptraj_file to fix ambpdb compile.

Several minor code fixes/cleanup as well.