### PR TITLE
Fix potential segfault in COORDS DataSet

### DIFF
--- a/src/DataSet_Coords_CRD.cpp
+++ b/src/DataSet_Coords_CRD.cpp
@@ -125,7 +125,7 @@ static inline void ArrayToFrame(int idx, Frame& fOut, CompactFrameArray const& f
   if (frames_.HasComponent(CoordinateInfo::REDOX)) fOut.SetRedOx(frames_.GetVal(idx, CoordinateInfo::REDOX));
   if (frames_.HasComponent(CoordinateInfo::TIME)) fOut.SetTime(frames_.GetVal(idx, CoordinateInfo::TIME));
   if (frames_.HasComponent(CoordinateInfo::STEP)) fOut.SetStep(frames_.GetVal(idx, CoordinateInfo::STEP));
-  if (frames_.HasComponent(CoordinateInfo::REMD_INDICES)) frames_.GetToIntPtr(fOut.iAddress(), idx, CoordinateInfo::REMD_INDICES);
+  if (frames_.HasComponent(CoordinateInfo::REMD_INDICES) && !fOut.RemdIndices().empty()) frames_.GetToIntPtr(fOut.iAddress(), idx, CoordinateInfo::REMD_INDICES);
   if (frames_.HasComponent(CoordinateInfo::REPIDX)) fOut.SetRepIdx(frames_.GetVal(idx, CoordinateInfo::REPIDX));
   if (frames_.HasComponent(CoordinateInfo::CRDIDX)) fOut.SetCrdIdx(frames_.GetVal(idx, CoordinateInfo::CRDIDX));
 }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V5.4.1"
+#define CPPTRAJ_INTERNAL_VERSION "V5.4.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 5.4.2. Would attempt write to remd_indices_ even if not allocated, causing a segfault. Fixed.