### PR TITLE
Fix centroid/metric mismatch during best rep. find in summary by parts

### DIFF
--- a/src/Cluster/MetricArray.cpp
+++ b/src/Cluster/MetricArray.cpp
@@ -485,11 +485,13 @@ void Cpptraj::Cluster::MetricArray::Info() const {
 void Cpptraj::Cluster::MetricArray::NewCentroid(CentroidArray& centroids, Cframes const& framesIn)
 const
 {
+  //mprintf("DEBUG: Calling MetricArray::NewCentroid for %zu frames.\n", framesIn.size());
   centroids.Clear();
   for (std::vector<Metric*>::const_iterator it = metrics_.begin(); it != metrics_.end(); ++it)
   {
     centroids.push_back( (*it)->NewCentroid( framesIn ) );
   }
+  //mprintf("DEBUG: There are %zu centroids for %zu metrics.\n", centroids.size(), metrics_.size());
 }
 
 /** Calculate centroids in given list. */
@@ -497,7 +499,7 @@ void Cpptraj::Cluster::MetricArray::CalculateCentroid(CentroidArray& centroids, 
 const
 {
   if (centroids.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::CalculateCentroid: centroids and metrics_ sizes do not match.\n");
+    mprinterr("Internal Error: MetricArray::CalculateCentroid: centroids (%zu) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
     return;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)
@@ -510,7 +512,7 @@ void Cpptraj::Cluster::MetricArray::FrameOpCentroid(int f1, CentroidArray& centr
 const
 {
   if (centroids.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::FrameOpCentroid: centroids and metrics_ sizes do not match.\n");
+    mprinterr("Internal Error: MetricArray::FrameOpCentroid: centroids (%zu) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
     return;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)
@@ -549,7 +551,7 @@ double Cpptraj::Cluster::MetricArray::DistCalc(std::vector<double> const& arrayI
 double Cpptraj::Cluster::MetricArray::FrameCentroidDist(int frame, CentroidArray const& centroids )
 {
   if (centroids.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::FrameCentroidDist: centroids and metrics_ sizes do not match.\n");
+    mprinterr("Internal Error: MetricArray::FrameCentroidDist: centroids (%zu) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
     return -1.0;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)
@@ -561,7 +563,7 @@ double Cpptraj::Cluster::MetricArray::FrameCentroidDist(int frame, CentroidArray
 double Cpptraj::Cluster::MetricArray::CentroidDist(CentroidArray const& C1, CentroidArray const& C2)
 {
   if (C1.size() != metrics_.size() || C2.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::CentroidDist: centroids and metrics_ sizes do not match.\n");
+    mprinterr("Internal Error: MetricArray::CentroidDist: centroids (%zu, %zu) and metrics_ (%zu) sizes do not match.\n", C1.size(), C2.size(), metrics_.size());
     return -1.0;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)

--- a/src/Cluster/MetricArray.cpp
+++ b/src/Cluster/MetricArray.cpp
@@ -499,7 +499,7 @@ void Cpptraj::Cluster::MetricArray::CalculateCentroid(CentroidArray& centroids, 
 const
 {
   if (centroids.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::CalculateCentroid: centroids (%zu) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
+    mprinterr("Internal Error: MetricArray::CalculateCentroid: centroids (%u) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
     return;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)
@@ -512,7 +512,7 @@ void Cpptraj::Cluster::MetricArray::FrameOpCentroid(int f1, CentroidArray& centr
 const
 {
   if (centroids.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::FrameOpCentroid: centroids (%zu) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
+    mprinterr("Internal Error: MetricArray::FrameOpCentroid: centroids (%u) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
     return;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)
@@ -551,7 +551,7 @@ double Cpptraj::Cluster::MetricArray::DistCalc(std::vector<double> const& arrayI
 double Cpptraj::Cluster::MetricArray::FrameCentroidDist(int frame, CentroidArray const& centroids )
 {
   if (centroids.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::FrameCentroidDist: centroids (%zu) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
+    mprinterr("Internal Error: MetricArray::FrameCentroidDist: centroids (%u) and metrics_ (%zu) sizes do not match.\n", centroids.size(), metrics_.size());
     return -1.0;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)
@@ -563,7 +563,7 @@ double Cpptraj::Cluster::MetricArray::FrameCentroidDist(int frame, CentroidArray
 double Cpptraj::Cluster::MetricArray::CentroidDist(CentroidArray const& C1, CentroidArray const& C2)
 {
   if (C1.size() != metrics_.size() || C2.size() != metrics_.size()) {
-    mprinterr("Internal Error: MetricArray::CentroidDist: centroids (%zu, %zu) and metrics_ (%zu) sizes do not match.\n", C1.size(), C2.size(), metrics_.size());
+    mprinterr("Internal Error: MetricArray::CentroidDist: centroids (%u, %u) and metrics_ (%zu) sizes do not match.\n", C1.size(), C2.size(), metrics_.size());
     return -1.0;
   }
   for (unsigned int idx = 0; idx != metrics_.size(); idx++)

--- a/src/Cluster/Output.cpp
+++ b/src/Cluster/Output.cpp
@@ -420,6 +420,8 @@ void Cpptraj::Cluster::Output::Summary_Part(CpptrajFile& outfile,
       if (node->Nframes() == 0) {
         outfile.Printf(" %8i", -1);
       } else {
+        // Since we just created these clusters, ensure centroid is updated
+        node->CalculateCentroid( pmatrix );
         findBestReps.FindBestRepFrames(*node, pmatrix, framesToCluster);
         // TODO handle multiple best reps?
         //if (node->BestReps().size() < 2)

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.0.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.0.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.0.2.

Summary by parts creates temporary cluster nodes to find best rep. frames in each part. However, the centroids for these were not being properly generated. This fixes that.