### PR TITLE
Some 'configure' improvements for OSX

### DIFF
--- a/configure
+++ b/configure
@@ -880,6 +880,9 @@ EOF
     if [ $? -ne 0 ] ; then
       if [ "${LIB_STAT[$LFFTW3]}" = 'optional' ] ; then
         WrnMsg "FFTW test failed. CPPTRAJ will use the built-in PubFFT routines."
+        if [ $BUILD_LIBS -eq 1 ] ; then
+          echo "To force CPPTRAJ to build its own FFTW, reconfigure and specify '-fftw3'."
+        fi
         LIB_STAT[$LFFTW3]='off'
       elif [ "${LIB_STAT[$LFFTW3]}" = 'enabled' ] ; then
         # See if there is already a version of FFTW in CPPTRAJHOME

--- a/get_library.sh
+++ b/get_library.sh
@@ -50,8 +50,13 @@ if [ ! -f "$SRCTAR" ] ; then
   WGET=`which wget`
 
   if [ -z "$WGET" ] ; then
-    echo "Error: 'wget' not found. Cannot download $LIBNAME"
-    exit 1
+    echo "Warning: 'wget' not found. Trying curl."
+    WGET=`which curl`
+    if [ -z "$WGET" ] ; then
+      echo "Error: 'wget' and 'curl' not found. Cannot download $LIBNAME"
+      exit 1
+    fi
+    WGET="$WGET -O"
   fi
 
   $WGET $URL
@@ -176,6 +181,13 @@ echo "Success."
 # Determine make command
 if [ -z "$MAKE_COMMAND" ] ; then
   NPROC=`nproc`
+  if [ -z "$NPROC" ] ; then
+    # Check for sysctl, OSX
+    SYSCTL=`which sysctl`
+    if [ ! -z "$SYSCTL" ] ; then
+      NPROC=`$SYSCTL -n hw.logicalcpu`
+    fi
+  fi
   if [ -z "$NPROC" ] ; then
     MAKE_COMMAND='make'
   elif [ $NPROC -le 2 ] ; then


### PR DESCRIPTION
OSX may not have `wget` and/or `nproc`. Replace with `curl` and `sysctl` respectively. Tested on Big Sur.