### PR TITLE
Fix some pairwise cache behavior in clustering, fix ASCII pairwise cache files

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -40301,6 +40301,10 @@ cluster
 \end_layout
 
 \begin_layout LyX-Code
+    [useframesincache]
+\end_layout
+
+\begin_layout LyX-Code
   Algorithm Args: [{hieragglo|dbscan|kmeans|dpeaks}]
 \end_layout
 
@@ -40504,6 +40508,11 @@ cnvtset
 \end_layout
 
 \end_deeper
+\begin_layout Description
+[useframesincache] If a pairwise cache is specified, cluster on the frames
+ stored in the cache.
+\end_layout
+
 \begin_layout Standard
 Algorithms:
 \end_layout

--- a/src/Cluster/Cframes.h
+++ b/src/Cluster/Cframes.h
@@ -20,6 +20,7 @@ class Cframes {
     iterator begin()             { return frames_.begin(); }
     iteratir end() */
     int front()                      const { return frames_.front(); }
+    int back()                       const { return frames_.back();  }
     int operator[](unsigned int idx) const { return frames_[idx];    }
     int& operator[](unsigned int idx)      { return frames_[idx];    }
     void push_back(int i)                  { frames_.push_back( i ); }

--- a/src/Cluster/Control.cpp
+++ b/src/Cluster/Control.cpp
@@ -705,7 +705,8 @@ int Cpptraj::Cluster::Control::Run() {
       mprinterr("Error: Cluster frame selection failed.\n");
       return 1;
     }
-  } else {
+  } else if (frameSieve_.FramesToCluster().empty()) {
+    // Sanity check
     mprinterr("Internal Error: Cluster::Control::Run(): Unhandled frame selection type.\n");
   }
 

--- a/src/Cluster/Control.cpp
+++ b/src/Cluster/Control.cpp
@@ -311,7 +311,8 @@ int Cpptraj::Cluster::Control::SetupClustering(DataSetList const& setsToCluster,
     mprintf("Warning: 'includesieved_cdist' may be very slow.\n");
 
   // Determine how frames to cluster will be chosen
-  if (frameSelect_ == UNSPECIFIED) {
+  bool allow_frameSelect_from_cache = analyzeArgs.hasKey("useframesincache");
+  if (allow_frameSelect_from_cache && frameSelect_ == UNSPECIFIED) {
     // If no other frame selection option like sieve provided and an already
     // set up cache is present, use the cached frames.
     if (sieve_ == 1 && metrics_.HasCache() && metrics_.Cache().Size() > 0)
@@ -504,7 +505,8 @@ int Cpptraj::Cluster::Control::SetupClustering(DataSetList const& setsToCluster,
 void Cpptraj::Cluster::Control::Help() {
   mprintf("\t[<name>] [<Algorithm>] [<Metric>] [<Pairwise>] [<Sieve>] [<BestRep>]\n"
           "\t[<Output>] [<Coord. Output>] [<Graph>]\n"
-          "\t[readinfo {infofile <info file> | cnvtset <dataset>}]\n");
+          "\t[readinfo {infofile <info file> | cnvtset <dataset>}]\n"
+          "\t[useframesincache]\n");
   mprintf("  Algorithm Args: [%s]\n", AlgorithmArgs_);
   Algorithm_HierAgglo::Help();
   Algorithm_DBscan::Help();

--- a/src/Cluster/List.h
+++ b/src/Cluster/List.h
@@ -16,6 +16,7 @@ class List {
     List() {}
     /// Set debug level
     void SetDebug(int d) { debug_ = d; }
+
     /// Iterator over clusters
     typedef std::list<Node>::iterator cluster_it;
     /// Iterator to beginning
@@ -28,18 +29,20 @@ class List {
     const cluster_iterator begincluster() const { return clusters_.begin(); }
     /// Const iterator to end
     const cluster_iterator endcluster()   const { return clusters_.end();   }
+
     /// \return first cluster
     Node const& front()                   const { return clusters_.front(); }
     /// \return last cluster
     Node const& back()                    const { return clusters_.back();  }
     /// \return current number of clusters.
-    int Nclusters()        const { return (int)clusters_.size(); }
+    int Nclusters()                       const { return (int)clusters_.size(); }
     /// \return true if no clusters
-    bool empty()           const { return clusters_.empty(); }
+    bool empty()                          const { return clusters_.empty(); }
     /// \return Array containing noise points
-    Cframes const& Noise() const { return noise_; }
+    Cframes const& Noise()                const { return noise_; }
     /// Print clusters to stdout
     void PrintClusters() const;
+
     /// Add new cluster
     void AddCluster( Node const& n )     { clusters_.push_back( n ); }
     /// Remove existing cluster via iterator
@@ -48,10 +51,6 @@ class List {
     void RemoveEmptyClusters();
     /// Remove all clusters
     void Clear();
-    /// Generate cluster number vs time data set
-    int CreateCnumVsTime(DataSet_integer&, unsigned int, int, int) const;
-    /// Generate number unique clusters vs time data set
-    int NclustersObserved(DataSet_integer&, unsigned int, int) const;
     /// Sort clusters by population and renumber.
     int Sort();
     /// Add given frame as noise.
@@ -62,6 +61,11 @@ class List {
     void AddFramesByCentroid(Cframes const&, MetricArray&);
     /// Add given frames to clusters based on distance to centroid and cutoff.
     void AddFramesByCentroid(Cframes const&, MetricArray&, bool, double);
+
+    /// Generate cluster number vs time data set
+    int CreateCnumVsTime(DataSet_integer&, unsigned int, int, int) const;
+    /// Generate number unique clusters vs time data set
+    int NclustersObserved(DataSet_integer&, unsigned int, int) const;
 
     /// Calculate the Davies-Bouldin index.
     double ComputeDBI(std::vector<double>&, MetricArray&) const;

--- a/src/Cluster/MetricArray.cpp
+++ b/src/Cluster/MetricArray.cpp
@@ -138,6 +138,7 @@ int Cpptraj::Cluster::MetricArray::setupPairwiseCache(ArgList& analyzeArgs,
     }
   }*/
 
+  pw_mismatch_fatal_ = !analyzeArgs.hasKey("pwrecalc");
   cache_ = 0;
   if (load_pair ||
       (!save_pair && !pairdistname.empty()))
@@ -170,7 +171,7 @@ int Cpptraj::Cluster::MetricArray::setupPairwiseCache(ArgList& analyzeArgs,
         return 1;
       }
       cache_ = (DataSet_PairwiseCache*)ds;
-      if (cache_ != 0 && save_pair) {
+      if (cache_ != 0 && save_pair && pw_mismatch_fatal_) {
         mprintf("Warning: 'savepairdist' specified but pairwise cache loaded from file.\n"
                 "Warning: Disabling 'savepairdist'.\n");
         save_pair = false;
@@ -264,7 +265,6 @@ int Cpptraj::Cluster::MetricArray::setupPairwiseCache(ArgList& analyzeArgs,
       }
     }
   }
-  pw_mismatch_fatal_ = !analyzeArgs.hasKey("pwrecalc");
 
   return 0;
 }

--- a/src/Cluster/MetricArray.cpp
+++ b/src/Cluster/MetricArray.cpp
@@ -245,11 +245,15 @@ int Cpptraj::Cluster::MetricArray::setupPairwiseCache(ArgList& analyzeArgs,
     if (cache_ == 0) {
       mprintf("Warning: Not caching distances; ignoring 'savepairdist'\n");
     } else {
-      if (pairdistname.empty())
+      if (pairdistname.empty()) {
+        // Use default name and type
         pairdistname = DEFAULT_PAIRDIST_NAME_;
-      if (pairdisttype == DataFile::UNKNOWN_DATA)
         pairdisttype = DEFAULT_PAIRDIST_TYPE_;
-      // TODO enable saving for other set types?
+      } else {
+        // pairwise distance name specified. See if the extension is recognized. 
+        if (pairdisttype == DataFile::UNKNOWN_DATA)
+          pairdisttype = DataFile::WriteFormatFromFname( pairdistname, DEFAULT_PAIRDIST_TYPE_ );
+      }
       if (cache_->Type() == DataSet::PMATRIX_MEM) {
         DataFile* pwd_file = DFL.AddDataFile( pairdistname, pairdisttype, ArgList() );
         if (pwd_file == 0) return 1;

--- a/src/Cluster/MetricArray.cpp
+++ b/src/Cluster/MetricArray.cpp
@@ -717,10 +717,12 @@ int Cpptraj::Cluster::MetricArray::CacheDistances(Cframes const& framesToCache, 
     // The frames to cache must match cached frames.
     if (!cache_->CachedFramesMatch( framesToCache )) {
       if (pw_mismatch_fatal_) {
-        mprinterr("Error: Frames to cache do not match those in existing cache.\n");
+        mprinterr("Error: Frames to cluster do not match those in existing cache.\n"
+                  "Error: To force recalculation specify 'pwrecalc' (and\n"
+                  "Error:  'savepairdist' if the old matrix should be overwritten.\n");
         return 1;
       } else {
-        mprintf("Warning: Frames to cache do not match those in existing cache.\n"
+        mprintf("Warning: Frames to cluster do not match those in existing cache.\n"
                 "Warning: Re-calculating pairwise cache.\n");
         do_cache = true;
       }

--- a/src/Cluster/MetricArray.cpp
+++ b/src/Cluster/MetricArray.cpp
@@ -723,7 +723,7 @@ int Cpptraj::Cluster::MetricArray::CacheDistances(Cframes const& framesToCache, 
       if (pw_mismatch_fatal_) {
         mprinterr("Error: Frames to cluster do not match those in existing cache.\n"
                   "Error: To force recalculation specify 'pwrecalc' (and\n"
-                  "Error:  'savepairdist' if the old matrix should be overwritten.\n");
+                  "Error:  'savepairdist' if the old matrix should be overwritten).\n");
         return 1;
       } else {
         mprintf("Warning: Frames to cluster do not match those in existing cache.\n"

--- a/src/Cluster/Sieve.cpp
+++ b/src/Cluster/Sieve.cpp
@@ -96,6 +96,11 @@ int Cpptraj::Cluster::Sieve::SetupFromCache(DataSet_PairwiseCache const& cache,
     //mprinterr("Error: Cannot setup frames to cluster from empty cache.\n");
     return 1;
   }
+  if (cache.Nrows() != maxFrames) {
+    //mprinterr("Error: # frames in cache (%zu) != # frames to cluster (%zu).\n",
+    //          cache.Nrows(), maxFrames);
+    return 2;
+  }
   frameIsPresent_.clear();
   framesToCluster_.clear();
   sievedOut_.clear();

--- a/src/Cluster/Sieve.cpp
+++ b/src/Cluster/Sieve.cpp
@@ -96,15 +96,17 @@ int Cpptraj::Cluster::Sieve::SetupFromCache(DataSet_PairwiseCache const& cache,
     //mprinterr("Error: Cannot setup frames to cluster from empty cache.\n");
     return 1;
   }
-  if (cache.Nrows() != maxFrames) {
-    //mprinterr("Error: # frames in cache (%zu) != # frames to cluster (%zu).\n",
-    //          cache.Nrows(), maxFrames);
-    return 2;
-  }
+
   frameIsPresent_.clear();
   framesToCluster_.clear();
   sievedOut_.clear();
   DetermineTypeFromSieve( cache.SieveVal() );
+
+  if (type_ == NONE && (cache.Nrows() != maxFrames)) {
+    // # of frames in cache does not match frames to cluster
+    return 2;
+  }
+
   unsigned int frm = 0;
   for (; frm != cache.FrameToIdx().size(); frm++)
   {
@@ -112,6 +114,14 @@ int Cpptraj::Cluster::Sieve::SetupFromCache(DataSet_PairwiseCache const& cache,
       sievedOut_.push_back( frm );
     else
       framesToCluster_.push_back( frm );
+  }
+  // Check that # of sieved frames in the cache matches # to cluster
+  if (cache.Nrows() != framesToCluster_.size()) {
+    //mprinterr("Error: # frames in cache (%zu) != # frames to cluster (%zu).\n",
+    //          cache.Nrows(), maxFrames);
+    framesToCluster_.clear();
+    sievedOut_.clear();
+    return 2;
   }
   // Anything left is consiedered sieved out.
   for (; frm < maxFrames; frm++)

--- a/src/DataFile.h
+++ b/src/DataFile.h
@@ -32,6 +32,10 @@ class DataFile {
     static DataFormatType WriteFormatFromArg(ArgList& a, DataFormatType def) {
       return (DataFormatType)FileTypes::GetFormatFromArg(DF_WriteKeyArray,a,def);
     }
+    /// \return Write format type from file name extension
+    static DataFormatType WriteFormatFromFname(FileName const& f, DataFormatType def) {
+      return (DataFormatType)FileTypes::GetTypeFromExtension(DF_WriteKeyArray,f.Ext(),def);
+    }
     /// \return string corresponding to format.
     static const char* FormatString(DataFormatType t) {
       return FileTypes::FormatDescription(DF_AllocArray, t);

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -1186,8 +1186,9 @@ int DataIO_Std::WriteCmatrix(CpptrajFile& file, DataSetList const& Sets) {
       continue;
     }
     DataSet_PairwiseCache const& cm = static_cast<DataSet_PairwiseCache const&>( *(*ds) );
+    DataSet_PairwiseCache::Cframes frames = cm.PresentFrames();
     int nrows = cm.Nrows();
-    int col_width = std::max(3, DigitWidth( nrows ) + 1);
+    int col_width = std::max(3, DigitWidth( frames.back() ) + 1);
     int dat_width = std::max(cm.Format().Width(), (int)cm.Meta().Legend().size()) + 1;
     WriteNameToBuffer(file, "F1",               col_width, true);
     WriteNameToBuffer(file, "F2",               col_width, false);
@@ -1201,7 +1202,6 @@ int DataIO_Std::WriteCmatrix(CpptrajFile& file, DataSetList const& Sets) {
     dat_fmt.SetFormatWidth( dat_width );
     std::string total_fmt = col_fmt.Fmt() + col_fmt.Fmt() + dat_fmt.Fmt() + "\n";
     //mprintf("DEBUG: format '%s'\n", total_fmt.c_str());
-    DataSet_PairwiseCache::Cframes frames = cm.PresentFrames();
     int ntotal = (int)frames.size();
     for (int idx1 = 0; idx1 != ntotal; idx1++) {
       int row = frames[idx1];

--- a/src/DataIO_Std.cpp
+++ b/src/DataIO_Std.cpp
@@ -452,9 +452,11 @@ int DataIO_Std::ReadCmatrix(FileName const& fname,
     Vals.push_back( val );
   }
   // DEBUG
-  mprintf("Sieved array:\n");
-  for (unsigned int i = 0; i < sieveStatus.size(); i++)
-    mprintf("\t%6u %c\n", i+1, sieveStatus[i]);
+  if (debug_ > 0) {
+    mprintf("Sieved array:\n");
+    for (unsigned int i = 0; i < sieveStatus.size(); i++)
+      mprintf("\t%6u %c\n", i+1, sieveStatus[i]);
+  }
   // Try to determine if sieve is random or not.
   int sieveDelta = 1;
   f1 = -1;

--- a/src/DataSet_PairwiseCache.cpp
+++ b/src/DataSet_PairwiseCache.cpp
@@ -35,20 +35,15 @@ int DataSet_PairwiseCache::SetupFrameToIdx(Cframes const& framesToCache, unsigne
   return 0;
 }
 
-/** Check that the given frames match the already-cached frames. */
+/** Check that the given frames are all present in the cache. */
 bool DataSet_PairwiseCache::CachedFramesMatch(Cframes const& framesIn) const
 {
-  Cframes_it frm0 = framesIn.begin();
-  for (int frm1 = 0; frm1 != (int)frameToIdx_.size(); frm1++)
+  for (Cframes_it frm0 = framesIn.begin(); frm0 != framesIn.end(); ++frm0)
   {
-    if (frameToIdx_[frm1] != -1) {
-      //if (frm0 != framesIn.end()) mprintf("DEBUG frameToCluster= %i cachedFrame= %i\n",
-      //                                    *frm0, frm1);
-      if (frm0 == framesIn.end() || *frm0 != frm1) return false;
-      ++frm0;
-    }
+    if ((unsigned int)*frm0 >= frameToIdx_.size() ||
+        frameToIdx_[*frm0] == -1)
+      return false;
   }
-  if (frm0 != framesIn.end()) return false;
   return true;
 }
 

--- a/src/DataSet_PairwiseCache.cpp
+++ b/src/DataSet_PairwiseCache.cpp
@@ -42,10 +42,13 @@ bool DataSet_PairwiseCache::CachedFramesMatch(Cframes const& framesIn) const
   for (int frm1 = 0; frm1 != (int)frameToIdx_.size(); frm1++)
   {
     if (frameToIdx_[frm1] != -1) {
+      //if (frm0 != framesIn.end()) mprintf("DEBUG frameToCluster= %i cachedFrame= %i\n",
+      //                                    *frm0, frm1);
       if (frm0 == framesIn.end() || *frm0 != frm1) return false;
       ++frm0;
     }
   }
+  if (frm0 != framesIn.end()) return false;
   return true;
 }
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.2.0"
+#define CPPTRAJ_INTERNAL_VERSION "V6.2.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Cluster/RunTest.sh
+++ b/test/Test_Cluster/RunTest.sh
@@ -65,7 +65,7 @@ EOF
   DoTest normframe.agr.save normframe.agr
 fi
 
-# Test writing/reading ASCII cluster pairwise file
+# Test writing ASCII cluster pairwise file
 cat > cluster.in <<EOF
 parm ../tz2.parm7
 trajin ../tz2.crd
@@ -73,15 +73,28 @@ cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat.save nofit savepairdist p
   sieve 6 random sieveseed 2 info cascii1.info
 EOF
 RunCpptraj "Cluster command test, write ASCII pairwise distances."
+
+# Test reading ASCII cluster pairwise file, using cached frames
 cat > cluster.in <<EOF
 parm ../tz2.parm7
 trajin ../tz2.crd
 cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat nofit loadpairdist pairdist pw.dat \
-  info cascii2.info
+  useframesincache info cascii2.info
+EOF
+RunCpptraj "Cluster command test, read ASCII pairwise distances, use cached frames."
+DoTest cascii.dat.save cascii.dat
+DoTest cascii1.info cascii2.info
+
+# Test reading ASCII cluster pairwise file
+cat > cluster.in <<EOF
+parm ../tz2.parm7
+trajin ../tz2.crd
+cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat nofit loadpairdist pairdist pw.dat \
+  sieve 6 random sieveseed 2 info cascii3.info
 EOF
 RunCpptraj "Cluster command test, read ASCII pairwise distances."
 DoTest cascii.dat.save cascii.dat
-DoTest cascii1.info cascii2.info
+DoTest cascii1.info cascii3.info
 
 EndTest
 

--- a/test/Test_Cluster/RunTest.sh
+++ b/test/Test_Cluster/RunTest.sh
@@ -6,7 +6,7 @@
 # NOTE: CpptrajPairDist name defined in Action_Clustering.cpp
 CleanFiles cluster.in cnumvtime.dat avg.summary.dat summary.dat CpptrajPairDist \
            cpop.agr summary2.dat Cmatrix.nccmatrix Cmatrix.cmatrix summary3.dat \
-           normpop.agr normframe.agr cascii.dat.save cascii.dat pw.out \
+           normpop.agr normframe.agr cascii.dat.save cascii.dat pw.dat \
            cinfo.dat mysil.cluster.dat mysil.frame.dat cascii?.info
 
 TESTNAME='Hierarchical agglomerative clustering tests'
@@ -69,14 +69,14 @@ fi
 cat > cluster.in <<EOF
 parm ../tz2.parm7
 trajin ../tz2.crd
-cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat.save nofit savepairdist pairdist pw.out \
+cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat.save nofit savepairdist pairdist pw.dat \
   sieve 6 random sieveseed 2 info cascii1.info
 EOF
 RunCpptraj "Cluster command test, write ASCII pairwise distances."
 cat > cluster.in <<EOF
 parm ../tz2.parm7
 trajin ../tz2.crd
-cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat nofit loadpairdist pairdist pw.out \
+cluster C1 :2-10 clusters 3 epsilon 4.0 out cascii.dat nofit loadpairdist pairdist pw.dat \
   info cascii2.info
 EOF
 RunCpptraj "Cluster command test, read ASCII pairwise distances."


### PR DESCRIPTION
Version 6.2.1.

Previously, if a previously generated pairwise cache was being used CPPTRAJ would always try to use the frames from the cache explicitly. This is OK if doing multiple runs on the same frames, but could lead to unwanted behavior if the frames change (e.g. if user wants to cluster on more frames and a pairwise cache is present, only the frames in the cache would be clustered on). This PR fixes this behavior by adding a new keyword to the cluster command to explicitly turn on this behavior called `useframesincache`.  This also tidies up the cache error checking and makes it possible to e.g. cluster on a small subset of frames present in the cache (e.g. you generated a cache with `sieve 5`, can use for `sieve 10`, `sieve 15` etc). 

This PR also fixes detection of pairwise cache format; if the filename has `.dat` extension, will now correctly write out an ASCII pairwise file. The ASCII pairwise file index column size detection has also been fixed. 

Updated some tests to test the new behavior and updated the manual.