### PR TITLE
Speed up six-dimensional entropy calculation in GIST

### DIFF
--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -1326,13 +1326,16 @@ void Action_GIST::TransEntropy(float VX, float VY, float VZ,
     double dd = dx*dx+dy*dy+dz*dz;
     if (dd < NNd && dd > 0) { NNd = dd; }
 
-    int q1 = n1 * 4; // index into V_Q for n1
-    double rR = 2.0 * acos( fabs(W4 * V_Q[q1  ] +
-                            X4 * V_Q[q1+1] +
-                            Y4 * V_Q[q1+2] +
-                            Z4 * V_Q[q1+3] )); //add fabs for quaternions distance calculation
-    double ds = rR*rR + dd;
-    if (ds < NNs && ds > 0) { NNs = ds; }
+    if (dd < NNs)
+    {
+      int q1 = n1 * 4; // index into V_Q for n1
+      double rR = 2.0 * acos( fabs(W4 * V_Q[q1  ] +
+                              X4 * V_Q[q1+1] +
+                              Y4 * V_Q[q1+2] +
+                              Z4 * V_Q[q1+3] )); //add fabs for quaternions distance calculation
+      double ds = rR*rR + dd;
+      if (ds < NNs && ds > 0) { NNs = ds; }
+    }
   }
 }
 
@@ -1580,13 +1583,15 @@ void Action_GIST::Print() {
             double dz = (double)(VZ - voxel_xyz_[gr_pt][i1+2]);
             double dd = dx*dx+dy*dy+dz*dz;
             if (dd < NNd && dd > 0) { NNd = dd; }
-            int q1 = n1 * 4; // index into voxel_Q_ for n1
-            double rR = 2 * acos( fabs(W4*voxel_Q_[gr_pt][q1  ] +
-                                  X4*voxel_Q_[gr_pt][q1+1] +
-                                  Y4*voxel_Q_[gr_pt][q1+2] +
-                                  Z4*voxel_Q_[gr_pt][q1+3] )); //add fabs for quaternion distance calculation
-            double ds = rR*rR + dd;
-            if (ds < NNs && ds > 0) { NNs = ds; }
+            if (dd < NNs) {
+              int q1 = n1 * 4; // index into voxel_Q_ for n1
+              double rR = 2 * acos( fabs(W4*voxel_Q_[gr_pt][q1  ] +
+                                    X4*voxel_Q_[gr_pt][q1+1] +
+                                    Y4*voxel_Q_[gr_pt][q1+2] +
+                                    Z4*voxel_Q_[gr_pt][q1+3] )); //add fabs for quaternion distance calculation
+              double ds = rR*rR + dd;
+              if (ds < NNs && ds > 0) { NNs = ds; }
+            }
           }
         } // END self loop over all waters for this voxel
         //mprintf("DEBUG1: self NNd=%f NNs=%f\n", NNd, NNs);

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.2.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.2.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
In GIST, the six-dimensional entropy calculation requires the translational and orientational distance to the nearest neighbor (NN). However, if the translational distance is larger than the 6D distance to the current NN, the orientational distance can be skipped safely.  This is a significant speedup (about 2x in my test), since the orientational distance contains an arccos.

I benchmarked using 10000 frames from a simulation of water around benzene (2700 water molecules). The box size was 80x80x80, with 0.5A spacing. I get the same entropy results, and the time in "Action Post" (from the cpptraj output) reduces from 545 to 263 seconds. I used the OMP version of cpptraj (with CUDA for the energy, but that shouldn't matter).