### PR TITLE
Fix mask 'for' loop behavior when zero atoms are selected.

### DIFF
--- a/src/ForLoop_mask.cpp
+++ b/src/ForLoop_mask.cpp
@@ -77,7 +77,11 @@ int ForLoop_mask::BeginFor(DataSetList const& DSL) {
   // Set up mask
   if (currentTop_->SetupIntegerMask( currentMask )) return LOOP_ERROR;
   currentMask.MaskInfo();
-  if (currentMask.None()) return 0; // No iterations
+  if (currentMask.None()) {
+    // No iterations. Ensure idx_ is set though so EndFor() works.
+    idx_ = Idxs_.end();
+    return 0;
+  }
   // Set up indices
   if (mtype_ == ATOMS)
     Idxs_ = currentMask.Selected();

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.2.5"
+#define CPPTRAJ_INTERNAL_VERSION "V6.2.6"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.2.6. 

The mask `for` loop would still try to execute with undefined behavior when no atoms were selected; this PR fixes the issue.