### PR TITLE
Fix the cmake MPI build

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,10 @@ jobs:
             compiler: "gnu"
             use_mpi: "yes"
             use_cmake: "0"
+          - use_openmp: "no"
+            compiler: "gnu"
+            use_mpi: "yes"
+            use_cmake: "1"
 
     env:
       COMPILER: ${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(cpptraj NONE)
 #version number
 #---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 set(cpptraj_MAJOR_VERSION 6)
-set(cpptraj_MINOR_VERSION 0)
-set(cpptraj_TWEAK_VERSION 0)
+set(cpptraj_MINOR_VERSION 2)
+set(cpptraj_TWEAK_VERSION 7)
 
 set(cpptraj_VERSION "${cpptraj_MAJOR_VERSION}.${cpptraj_MINOR_VERSION}.${cpptraj_TWEAK_VERSION}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory(xdrfile)
-add_subdirectory(Cluster)
 
 #---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # Parse cpptrajfiles
@@ -100,6 +99,7 @@ if(fftw_DISABLED)
 endif()
 
 add_library(cpptraj_common_obj OBJECT ${CPPTRAJ_COMMON_SOURCES})
+add_subdirectory(Cluster)
 make_pic_if_needed(cpptraj_common_obj)
 
 #normally this would be applied by target_link_libraries, but since we use that intermediary object library, we have to apply it manually
@@ -114,7 +114,7 @@ target_include_directories(cpptraj_common_obj PRIVATE $<TARGET_PROPERTY:xdrfile,
 
 add_executable(cpptraj $<TARGET_OBJECTS:cpptraj_common_obj> ${SOURCES})
 
-target_link_libraries(cpptraj cpptraj_cluster netcdf netlib xdrfile)
+target_link_libraries(cpptraj netcdf netlib xdrfile)
 
 install(TARGETS cpptraj DESTINATION ${BINDIR})
 #------------------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ install(TARGETS cpptraj DESTINATION ${BINDIR})
 add_library(libcpptraj $<TARGET_OBJECTS:cpptraj_common_obj> ${LIBCPPTRAJ_OBJECTS})
 set_property(TARGET libcpptraj PROPERTY COMPILE_DEFINITIONS LIBCPPTRAJ)
 
-target_link_libraries(libcpptraj cpptraj_cluster netlib netcdf xdrfile)
+target_link_libraries(libcpptraj netlib netcdf xdrfile)
 remove_prefix(libcpptraj)
 install_libraries(libcpptraj)
 

--- a/src/Cluster/CMakeLists.txt
+++ b/src/Cluster/CMakeLists.txt
@@ -1,47 +1,32 @@
 #CMake buildfile for CPPTRAJ Cluster subdirectory.
-set(CLUSTER_SOURCES
-  Algorithm.cpp
-  Algorithm_DBscan.cpp
-  Algorithm_DPeaks.cpp
-  Algorithm_HierAgglo.cpp
-  Algorithm_Kmeans.cpp
-  BestReps.cpp
-  Centroid_Coord.cpp
-  CentroidArray.cpp
-  Cframes.cpp
-  Cmatrix_Binary.cpp
-  Cmatrix_NC.cpp
-  Control.cpp
-  DBI.cpp
-  DrawGraph.cpp
-  DynamicMatrix.cpp
-  List.cpp
-  MetricArray.cpp
-  Metric_DME.cpp
-  Metric_RMS.cpp
-  Metric_Scalar.cpp
-  Metric_SRMSD.cpp
-  Metric_Torsion.cpp
-  Node.cpp
-  Output.cpp
-  PseudoF.cpp
-  Results_Coords.cpp
-  Sieve.cpp
-  Silhouette.cpp
+target_sources(cpptraj_common_obj PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/Algorithm.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Algorithm_DBscan.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Algorithm_DPeaks.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Algorithm_HierAgglo.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Algorithm_Kmeans.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/BestReps.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Centroid_Coord.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/CentroidArray.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Cframes.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Cmatrix_Binary.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Cmatrix_NC.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Control.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/DBI.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/DrawGraph.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/DynamicMatrix.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/List.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/MetricArray.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Metric_DME.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Metric_RMS.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Metric_Scalar.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Metric_SRMSD.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Metric_Torsion.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Node.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Output.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/PseudoF.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Results_Coords.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Sieve.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Silhouette.cpp
 )
 
-#------------------------------------------------------------------------------------------
-#I assume that this library should be optimized
-#add_compile_options(${OPT_CXXFLAGS_SPC})
-set_property(SOURCE ${CLUSTER_SOURCES} PROPERTY COMPILE_FLAGS "${OPT_CXXFLAGS_SPC}")
-
-#if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
-#	# xdrfile is not set up to build as a Windows shared library.  Someone would need to add dll exports to all of the symbols (bluh)
-#	add_library(xdrfile STATIC ${CLUSTER_SOURCES})
-#else()
-	add_library(cpptraj_cluster STATIC ${CLUSTER_SOURCES})
-        make_pic_if_needed(cpptraj_cluster)
-#endif()
-
-target_include_directories(cpptraj_cluster PUBLIC . PRIVATE $<TARGET_PROPERTY:netcdf,INTERFACE_INCLUDE_DIRECTORIES>)
-install_libraries(cpptraj_cluster)

--- a/src/readline/CMakeLists.txt
+++ b/src/readline/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Amber buildfile for cpptraj's internal readline.
+# This readline has been modified to not depend on an external termcap library.
+
+set(CPPTRAJ_READLINE_SOURCES
+	bind.c 
+	callback.c 
+	compat.c 
+	complete.c 
+	display.c 
+	funmap.c 
+	histexpand.c 
+	histfile.c 
+	history.c 
+	histsearch.c 
+	input.c 
+	isearch.c 
+	keymaps.c 
+	kill.c 
+	macro.c 
+	mbutil.c 
+	misc.c 
+	nls.c 
+	parens.c 
+	readline.c 
+	rltty.c 
+	savestring.c 
+	search.c 
+	shell.c 
+	signals.c 
+	termcap.c 
+	terminal.c 
+	text.c 
+	tilde.c 
+	tparam.c 
+	undo.c 
+	util.c 
+	version.c 
+	vi_mode.c 
+	xmalloc.c)
+
+add_compile_options(${OPT_CFLAGS})
+
+add_library(readline STATIC ${CPPTRAJ_READLINE_SOURCES})
+target_compile_definitions(readline PRIVATE HAVE_CONFIG_H=1) # make sure the code uses the premade config.h
+make_pic_if_needed(readline)
+target_include_directories(readline PUBLIC .)

--- a/src/tng/CMakeLists.txt
+++ b/src/tng/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Amber buildfile for cpptraj's internal libtng_io.
+
+set(TNG_IO_SOURCES
+	md5.c 
+	tng_io.c 
+	tng_compress.c 
+	coder.c 
+	warnmalloc.c 
+	fixpoint.c 
+	xtc3.c 
+	bwlzh.c 
+	xtc2.c 
+	widemuldiv.c 
+	huffmem.c 
+	vals16.c 
+	bwt.c 
+	mtf.c 
+	rle.c 
+	lz77.c 
+	dict.c 
+	huffman.c 
+	merge_sort.c)
+
+add_compile_options(${OPT_CFLAGS})
+
+# add library
+add_library(tng_io STATIC ${TNG_IO_SOURCES})
+make_pic_if_needed(tng_io)
+target_include_directories(tng_io PUBLIC .)
+
+# checks based on tng_io's cmake script
+check_all_includes(C inttypes.h)
+if (TNG_HAVE_INTTYPES_H)
+    target_compile_definitions(tng_io PUBLIC USE_STD_INTTYPES_H)
+endif()
+
+include(TestBigEndian)
+test_big_endian(BIGENDIAN)
+if(BIGENDIAN)
+  set_property(SOURCE md5.c APPEND PROPERTY COMPILE_DEFINITIONS TNG_INTEGER_BIG_ENDIAN)
+endif()
+
+


### PR DESCRIPTION
I think the cmake MPI build has been broken since #915, and I think it has to do with the fact that I initially had the Cluster subdirectory build as a separate library. The code would build, but trying to run any cluster-related code would segfault with strange backtraces. Making the Cluster subdirectory part of the cpptraj common objects seems to have fixed it.

Also adding a cmake MPI build to CI to hopefully prevent this from happening again.