### PR TITLE
Add cluster sieve restore by epsilon checks for non-density-based cluster algorithms

### DIFF
--- a/src/Cluster/Control.cpp
+++ b/src/Cluster/Control.cpp
@@ -29,7 +29,7 @@ Cpptraj::Cluster::Control::Control() :
   sieve_(1),
   sieveSeed_(-1),
   sieveRestore_(NO_RESTORE),
-  restoreEpsilon_(0.0),
+  restoreEpsilon_(0),
   includeSieveInCalc_(false),
   includeSieveCdist_(false),
   bestRep_(BestReps::NO_REPS),
@@ -357,7 +357,7 @@ int Cpptraj::Cluster::Control::SetupClustering(DataSetList const& setsToCluster,
           sieveRestore_ = CLOSEST_CENTROID;
       }
     }
-    // Determine sieve restore epsilon
+    // Determine sieve restore epsilon if needed
     if (sieveRestore_ == EPSILON_FRAME ||
         sieveRestore_ == EPSILON_CENTROID)
     {
@@ -368,11 +368,18 @@ int Cpptraj::Cluster::Control::SetupClustering(DataSetList const& setsToCluster,
         // Using a density-based algorithm with epsilon-based restore;
         // use restore epsilon from algorithm.
         restoreEpsilon_ = algorithm_->Epsilon();
+      } else
+        mprintf("Warning: Using sievetoframe/sievetocentroid with a non-density-based cluster algorithm.\n"
+                "Warning:   Restore epsilon 'repsilon' should be chosen with care.\n");
+      double rEps = analyzeArgs.getKeyDouble("repsilon", -1.0);
+      if (rEps > 0)
+        restoreEpsilon_ = rEps;
+      else if (restoreEpsilon_ <= 0) {
+        mprinterr("Error: For this cluster algorithm, sievetoframe/sievetocentroid requires 'repsilon' > 0 (%f).\n",
+                  restoreEpsilon_);
+        return 1;
       }
     }
-    double rEps = analyzeArgs.getKeyDouble("repsilon", -1.0);
-    if (rEps > 0)
-      restoreEpsilon_ = rEps;
   }
 
   // Best rep options

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.2.9"
+#define CPPTRAJ_INTERNAL_VERSION "V6.2.10"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
6.2.10.

Normally the non-density-based cluster algorithms (hierarchical agglomerative and kmeans) restore sieved frames by closest distance to centroid. Previously, if an epsilon-based sieve restore keyword was specified ( `sievetoframe` or `sievetocentroid`) without an epsilon (`repsilon`), the epsilon would be zero and nothing would be restored. This PR adds a check for this and a warning when using an epsilon-based restore with a non-density-based clustering algorithm.