### PR TITLE
Fix potential issue installing files to 'dat' directory

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -58,12 +58,12 @@ $(CPPTRAJLIB)/libcpptraj$(SHARED_SUFFIX): $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(
 
 # Data directory -----------------------
 install_dat:
-	cp ../dat/ATOMTYPE_CHECK.TAB $(CPPTRAJDAT)/
-	cp ../dat/BONDTYPE_CHECK.TAB $(CPPTRAJDAT)/
-	cp ../dat/Karplus.txt        $(CPPTRAJDAT)/
-	cp ../dat/README             $(CPPTRAJDAT)/
-	cp ../dat/Carbohydrate_PDB_Glycam_Names.txt $(CPPTRAJDAT)/
-	cp ../dat/PDB_ResidueNames.txt $(CPPTRAJDAT)/
+	-cp ../dat/ATOMTYPE_CHECK.TAB $(CPPTRAJDAT)/
+	-cp ../dat/BONDTYPE_CHECK.TAB $(CPPTRAJDAT)/
+	-cp ../dat/Karplus.txt        $(CPPTRAJDAT)/
+	-cp ../dat/README             $(CPPTRAJDAT)/
+	-cp ../dat/Carbohydrate_PDB_Glycam_Names.txt $(CPPTRAJDAT)/
+	-cp ../dat/PDB_ResidueNames.txt $(CPPTRAJDAT)/
 
 # Static libraries ---------------------
 #$(CPPTRAJLIB)/libcpptraj.a: $(LIBCPPTRAJ_OBJECTS) $(FFT_TARGET) $(CUDA_TARGET)


### PR DESCRIPTION
Add '-' before copy commands to the `dat` install directory to fix a potential issue if the files are already present.