### PR TITLE
Fix minor bug in PME GIST

### DIFF
--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -1448,7 +1448,7 @@ Action::RetType Action_GIST::DoAction(int frameNum, ActionFrame& frm) {
 
       if ( U_G[0] <= G_max_[0] && U_G[0] >= -1.5 &&
            U_G[1] <= G_max_[1] && U_G[1] >= -1.5 &&
-           U_G[2] <= G_max_[2] && U_G[2] >- -1.5)
+           U_G[2] <= G_max_[2] && U_G[2] >= -1.5)
       {
         int voxel = calcVoxelIndex(u_XYZ[0], u_XYZ[1], u_XYZ[2]);
         if ( voxel != OFF_GRID_ )

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.14.0"
+#define CPPTRAJ_INTERNAL_VERSION "V6.15.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_GIST/Gist4-Info.dat.save
+++ b/test/Test_GIST/Gist4-Info.dat.save
@@ -1,6 +1,6 @@
 Maximum number of waters found in one voxel for 10 frames = 3
 Number of singly-occupied voxels: 1434
-Total referenced orientational entropy of the grid: dTSorient = -21.29450 kcal/mol, Nf=10
+Total referenced orientational entropy of the grid: dTSorient = -21.29451 kcal/mol, Nf=10
 watcount in vol = 161
 watcount in subvol = 1011
 Total referenced translational entropy of the grid: dTStrans = -61.13316 kcal/mol, Nf=10
@@ -8,6 +8,6 @@ Total 6d if all one vox:  -1.36755 kcal/mol
 Total t if all one vox:  -0.60468 kcal/mol
 Total o if all one vox:  -1.32264 kcal/mol
 Ensemble total water energy on the grid: -1542.80744 Kcal/mol 
-Ensemble total solute energy on the grid: -1254.32084 Kcal/mol 
+Ensemble total solute energy on the grid: -1270.79410 Kcal/mol 
 Total water-solute energy of the grid: Esw = -379.83753 kcal/mol
-Total unreferenced water-water energy of the grid: Eww = -1352.88869 kcal/mol
+Total unreferenced water-water energy of the grid: Eww = -1352.88868 kcal/mol

--- a/test/Test_GIST/Gist4-Solute-Etot-pme-dens.dx.save
+++ b/test/Test_GIST/Gist4-Solute-Etot-pme-dens.dx.save
@@ -3905,7 +3905,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 0 3.82435
 3.12915 0 0
-0 0 0
+0 0 -16.3441
 0 0 0
 0 0 0
 0 0 0
@@ -4433,7 +4433,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 -12.8585 0
 0 0 0
-0 0 0
+0 -14.588 0
 -16.8944 0 0
 0 0 0
 0 0 0
@@ -4457,7 +4457,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 0 0
 3.70805 0 0
-0 0 0
+0 0 -16.0252
 0 0 0
 0 0 0
 0 0 0
@@ -4985,7 +4985,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 0 -7.7103
 0 0 0
-0 0 0
+0 0 -19.2124
 0 19.7485 0
 0 0 0
 0 0 0
@@ -5117,7 +5117,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
+0 0 -0.567892
 0 -4.86291 0
 0 0 -12.5117
 0 0 0
@@ -5501,7 +5501,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0.977509 0 0
 0 0 0
-0 0 0
+0 0 -32.2309
 -17.2726 21.3992 0
 0 0 0
 0 0 0
@@ -5513,7 +5513,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
+0 0 -15.6156
 0 45.3987 0
 0 0 0
 0.78632 0 0
@@ -5525,7 +5525,7 @@ object 3 class array type double rank 0 items 53856 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
+0 0 -17.2021
 0 0 0
 0 0.297466 0
 0.408126 0 0

--- a/test/Test_GIST/Gist5-Info.dat.save
+++ b/test/Test_GIST/Gist5-Info.dat.save
@@ -8,6 +8,6 @@ Total 6d if all one vox:  -1.22187 kcal/mol
 Total t if all one vox:  -0.52857 kcal/mol
 Total o if all one vox:  -0.95735 kcal/mol
 Ensemble total water energy on the grid: -1749.06437 Kcal/mol 
-Ensemble total solute energy on the grid: -1257.14298 Kcal/mol 
+Ensemble total solute energy on the grid: -1256.27394 Kcal/mol 
 Total water-solute energy of the grid: Esw = -380.03311 kcal/mol
 Total unreferenced water-water energy of the grid: Eww = -1559.04805 kcal/mol

--- a/test/Test_GIST/Gist5-Solute-Etot-pme-dens.dx.save
+++ b/test/Test_GIST/Gist5-Solute-Etot-pme-dens.dx.save
@@ -3705,7 +3705,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 -8.53841 0
+0 -8.53842 0
 0 0 0
 0 0 0
 0 0 0
@@ -5163,7 +5163,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
--4.10575 0 -0.501806
+-4.10575 0 -0.501807
 0 0 0
 0 0 0
 0 0 0
@@ -5597,7 +5597,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 -97.8307
+0 0 -97.8306
 -25.0476 0 0
 0 0 0
 0 0 0
@@ -12232,7 +12232,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
+0 1.85021 0
 -11.7442 0 0
 0 0 0
 0 0 0
@@ -12245,7 +12245,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
+0 -0.625858 0
 0 -8.55231 0
 0 0 0
 0 0 0
@@ -12712,6 +12712,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
+0 2.91404 0
 0 0 0
 0 0 0
 0 0 0
@@ -12724,8 +12725,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
-0 0 0
+0 0 -0.119051
 0 -5.84586 0
 0 0 0
 0 0 0
@@ -12739,7 +12739,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 -0.928563 0
+0.134361 -0.928563 0
 0 0 0
 0 0 0
 0 0 0
@@ -13112,7 +13112,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 0 0
+0 2.79862 0
 0 0 0
 0 0 0
 0 0 0
@@ -14129,7 +14129,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
--8.93328 -19.7806 -11.6859
+-8.93328 -19.7805 -11.6859
 0 0 0
 0 0 0
 0 0 0
@@ -15594,7 +15594,7 @@ object 3 class array type double rank 0 items 60480 data follows
 0 0 0
 0 0 0
 0 0 0
-0 -8.61014 0
+0 -8.61013 0
 0 0 0
 0 0 0
 0 0 0


### PR DESCRIPTION
Version 6.15.0.

When checking if something was on the GIST grid when using PME, the Z comparison was mistakenly using `>-` instead of `>=`. Affects results slightly, test output updated. @fwaibl @tkurtzman @EricChen521 