### PR TITLE
Fix nvcc flags based on CUDA toolkit version.

### DIFF
--- a/configure
+++ b/configure
@@ -1906,7 +1906,7 @@ SetupMKL() {
 #  9.X                    .....................................................................
 # 10.X                    ...........................................................................
 # 11.X                                ...........................................................................
-CUDA_SM_LIST='sm_20 sm_21 sm_30 sm_32 sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86'
+CUDA_SM_LIST='sm_20 sm_21 sm_30 sm_32 sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87'
 
 # SetSupportedSM <major v> <minor v>
 # Set Shader models supported by current cuda version
@@ -1935,11 +1935,20 @@ SetSupportedSM() {
   elif [ $1 -eq 8 ] ; then
     CUDA_SM_LIST='sm_20 sm_21 sm_30 sm_32 sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62'
   elif [ $1 -eq 9 ] ; then
-    CUDA_SM_LIST='sm_30 sm_32 sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72'
+    CUDA_SM_LIST='sm_30 sm_32 sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70'
   elif [ $1 -eq 10 ] ; then
     CUDA_SM_LIST='sm_30 sm_32 sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75'
-  else # >= 11
-    CUDA_SM_LIST='sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86'
+  elif [ $1 -eq 11 ] ; then
+    if [ $2 -lt 1 ] ; then
+      CUDA_SM_LIST='sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80'
+    elif [ $2 -gt 4 ] ; then
+      CUDA_SM_LIST='sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87'
+    else
+      CUDA_SM_LIST='sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86'
+    fi
+  else
+    echo "Automatic support for CUDA $1.$2 is currently unsupported. Set SHADER_MODEL manually."
+    exit 1
   fi
   echo "  Supported shader models: $CUDA_SM_LIST"
 }
@@ -1948,7 +1957,12 @@ SetSupportedSM() {
 # Set CUDA_ARCH variable with compute_XX value for given SM
 SetCudaArch() {
   smversion=${1#sm_}
-  CUDA_ARCH="compute_$smversion"
+  # compute_21 is not a thing
+  if [ "$smversion" = '21' ] ; then
+    CUDA_ARCH="compute_20"
+  else
+    CUDA_ARCH="compute_$smversion"
+  fi
   #echo "$1 $CUDA_ARCH"
 }
 


### PR DESCRIPTION
For certain versions of CUDA (e.g. 9) incorrect `sm_X` and/or `compute_X flags were being passed to nvcc. This fixes that.