### PR TITLE
Add check for non-bonded parameters for GIST

### DIFF
--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -503,6 +503,11 @@ Action::RetType Action_GIST::Setup(ActionSetup& setup) {
   #endif
 
   if (!skipE_) {
+    // Ensure we have nonbonded parameters
+    if (!setup.Top().Nonbond().HasNonbond()) {
+      mprinterr("Error: Topology does not have nonbonded parameters required for GIST energy calc.\n");
+      return Action::ERR;
+    }
     E_UV_.resize( numthreads_ );
     E_VV_.resize( numthreads_ );
     neighborPerThread_.resize( numthreads_ );

--- a/src/Action_GIST.cpp
+++ b/src/Action_GIST.cpp
@@ -503,9 +503,14 @@ Action::RetType Action_GIST::Setup(ActionSetup& setup) {
   #endif
 
   if (!skipE_) {
+    // Warn if no charge info
+    if (!setup.Top().HasChargeInfo())
+      mprintf("Warning: No charges in topology '%s'.\n", setup.Top().c_str());
     // Ensure we have nonbonded parameters
     if (!setup.Top().Nonbond().HasNonbond()) {
-      mprinterr("Error: Topology does not have nonbonded parameters required for GIST energy calc.\n");
+      mprinterr("Error: Topology '%s' does not have nonbonded parameters\n"
+                "Error:  required for GIST energy calc. Use a topology file with non-bonded\n"
+                "Error:  parameters.\n", setup.Top().c_str());
       return Action::ERR;
     }
     E_UV_.resize( numthreads_ );

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -2781,6 +2781,15 @@ void Topology::AssignNonbondParams(ParmHolder<AtomType> const& newTypes, ParmHol
   }
 }
 
+/** \return True if any atom has a non-zero charge. */
+bool Topology::HasChargeInfo() const {
+  for (std::vector<Atom>::const_iterator at = atoms_.begin();
+                                         at != atoms_.end(); ++at)
+    if (at->Charge() > 0.0 || at->Charge() < 0.0)
+      return true;
+  return false;
+}
+
 // -----------------------------------------------------------------------------
 
 /** Update/add to parameters in this topology with those from given set. */

--- a/src/Topology.h
+++ b/src/Topology.h
@@ -151,6 +151,8 @@ class Topology {
     /// \return Lennard-Jones 6-12 parameters for given pair of atoms
     inline NonbondType const& GetLJparam(int, int) const;
     void AssignNonbondParams(ParmHolder<AtomType> const&, ParmHolder<NonbondType> const&);
+    /// \return True if any charge is non-zero
+    bool HasChargeInfo() const;
     // ----- Water Cap Info ----------------------
     CapParmType const& Cap()    const { return cap_; }
     CapParmType&       SetCap()       { return cap_; }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.15.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.15.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.15.2.

Adds a check for nonbonded parameters for the GIST action. Previously, if using a topology without nonbonded parameters, cpptraj would segfault. This adds an informative error message, and also adds a warning if there is no charge information.