### PR TITLE
Try to fix Appveyor builds by using more recent Visual Studio version.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 platform:
   - x64
 
-image: Previous Visual Studio 2019
+image: Visual Studio 2022
 
 clone_folder: c:\projects\cpptraj
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 platform:
   - x64
 
-image: Visual Studio 2022
+image: Previous Visual Studio 2019
 
 clone_folder: c:\projects\cpptraj
 

--- a/devtools/ci/appveyor/setup-environment.bat
+++ b/devtools/ci/appveyor/setup-environment.bat
@@ -32,6 +32,7 @@ if %BUILD_TYPE% equ cmake-vs (
 	set CC=%MINGWPREFIX%-gcc.exe
 	set CXX=%MINGWPREFIX%-g++.exe
 	set FC=%MINGWPREFIX%-gfortran.exe
+        sh -lc "pacman-key --refresh-keys"
 	sh -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-netcdf mingw-w64-x86_64-openblas mingw-w64-x86_64-arpack mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-ncurses mingw-w64-x86_64-readline diffutils"
 
 	rem build NetCDF (we need our own version since the one in Pacman has an unwanted dependency on HDF5 and Termcap)


### PR DESCRIPTION
Recently appveyor updated their VS2019 image which broke all cpptraj CI testing on appveyor. Reverting to the previous image worked for a while, but now there are strange netcdf-related problems:
```
Checking NetCDF: Failed.
Error: NetCDF build/link failed: x86_64-w64-mingw32-g++.exe  -Wall  -O3  -fPIC   -std=gnu++11 -I/mingw64//include -o testp testp.cpp -L/mingw64//lib -lnetcdf    
Error: Error message follows:
Error: testp.cpp:2:10: fatal error: netcdf.h: No such file or directory
    2 | #include "netcdf.h"
      |          ^~~~~~~~~~
compilation terminated.
```

In this PR I will try using the VS2022 image to see if that fixes the builds.