### PR TITLE
Add ability to give separate data set and file names for cluster pairwise matrix

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -42448,7 +42448,7 @@ cluster
 \end_layout
 
 \begin_layout LyX-Code
-	[pairdist <name>] [pwrecalc]
+	[pairdist <name> [pairdistfile <file>]] [pwrecalc]
 \end_layout
 
 \begin_layout LyX-Code
@@ -43058,6 +43058,24 @@ Pairwise Distance Matrix Options:
  distances.
 \end_layout
 
+\begin_deeper
+\begin_layout Description
+[pairdistfile
+\begin_inset space ~
+\end_inset
+
+<file>] File name to use for pairwise cache; if not specified and 
+\series bold
+'pairdist'
+\series default
+ specified, uses 
+\series bold
+'pairdist'
+\series default
+.
+\end_layout
+
+\end_deeper
 \begin_layout Description
 [pwrecalc] If the loaded pairwise distance matrix does not match the current
  setup, force recalculation.

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.16.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.16.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Cluster_Cache/RunTest.sh
+++ b/test/Test_Cluster_Cache/RunTest.sh
@@ -3,7 +3,7 @@
 . ../MasterTest.sh
 
 CleanFiles cluster.in *.cnumvtime.dat *.info.dat *.summary.dat PW0 PW1 \
-           CpptrajPairwiseCache
+           CpptrajPairwiseCache MyMatrix.nc MyMatrix.2.nccmatrix
 
 INPUT="-i cluster.in"
 TESTNAME='Cluster pairwise cache tests'
@@ -75,6 +75,18 @@ DoTest sieve5.mem.save.info.dat.save sieve5.nocache.save.info.dat
 # Test loading pairwise cache with different sieve
 Cluster sieve3.mem.load "sieve 3" "loadpairdist pairdist PW1 pwrecalc"
 DoTest sieve3.mem.load.info.dat.save sieve3.mem.load.info.dat
+
+# Test using different set and file names
+UNITNAME='Test using different set and file names'
+cat > cluster.in <<EOF
+parm ../tz2.parm7
+trajin ../tz2.nc
+cluster @CA sieve 5 hieragglo clusters 5 pairdist MyMatrix pairdistfile MyMatrix.nc
+run
+writedata MyMatrix.2.nccmatrix MyMatrix 
+EOF
+RunCpptraj "$UNITNAME"
+NcTest MyMatrix.2.nccmatrix MyMatrix.nc
 
 # Test sieving
 #Cluster nosieve


### PR DESCRIPTION
Version 6.16.2.

Adds a new keyword to the `cluster` command, `pairdistfile`, which can be used to specify the pairwise cluster matrix file name. Previously `pairdist` was used to set both the data set name and file name. This is still the behavior if `pairdist` is specified and `pairdistfile` is not.

Updated the manual and added a test.