### PR TITLE
Allow 'resrange' keyword of 'multidihedral' action to accept a mask expression.

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -32378,7 +32378,7 @@ name "subsec:cpptraj_multidihedral"
 \end_layout
 
 \begin_layout LyX-Code
-multidihedral [<name>] <dihedral types> [resrange <range>] [out <filename>]
+multidihedral [<name>] <dihedral types> [resrange <range/mask>] [out <filename>]
  [range360]
 \end_layout
 
@@ -32434,8 +32434,10 @@ types> Dihedral types to look for.
 \begin_inset space ~
 \end_inset
 
-<range>] Residue range to look for dihedrals in.
+<range/mask>] Residue range to look for dihedrals in.
  Default is all solute residues.
+ If a mask expression is given, use residues selected by the mask expression;
+ if any part of a residue is selcted it will be used.
 \end_layout
 
 \begin_layout Description
@@ -32496,7 +32498,7 @@ run
 \end_layout
 
 \begin_layout Standard
-Calculate specified dihedral angle types for residues in given range.
+Calculate specified dihedral angle types for residues in given range/mask.
  By default, dihedral angles are identified based on standard Amber atom
  names.
  The resulting data sets will have aspect equal to [<dihedral type>] and

--- a/src/Action_MultiDihedral.cpp
+++ b/src/Action_MultiDihedral.cpp
@@ -82,8 +82,9 @@ Action::RetType Action_MultiDihedral::Setup(ActionSetup& setup) {
   Range actualRange;
   if (use_mask_expression_) {
     if (setup.Top().SetupIntegerMask( resMask_ )) return Action::ERR;
-    resMask_.MaskInfo(); // DEBUG
+    if (debug_ > 0) resMask_.MaskInfo();
     std::vector<int> rnums = setup.Top().ResnumsSelectedBy( resMask_ );
+    mprintf("\tMask '%s' selects %zu residues.\n", resMask_.MaskString(), rnums.size());
     for (std::vector<int>::const_iterator rnum = rnums.begin(); rnum != rnums.end(); ++rnum)
       actualRange.AddToRange( *rnum );
   } else {

--- a/src/Action_MultiDihedral.cpp
+++ b/src/Action_MultiDihedral.cpp
@@ -5,13 +5,16 @@
 #include "TorsionRoutines.h"
 #include "StringRoutines.h" // convertToInteger
 
+/** CONSTRUCTOR */
 Action_MultiDihedral::Action_MultiDihedral() :
   minTorsion_(-180.0),
   debug_(0),
   outfile_(0),
-  masterDSL_(0)
+  masterDSL_(0),
+  use_mask_expression_(false)
 {}
 
+// Action_MultiDihedral::Help() 
 void Action_MultiDihedral::Help() const {
   mprintf("\t[<name>] [<dihedral types>] [resrange <range>] [out <filename>] [range360]\n");
   mprintf("\t[%s]\n", DihedralSearch::newTypeArgsHelp());
@@ -21,6 +24,7 @@ void Action_MultiDihedral::Help() const {
   mprintf("  Calculate specified dihedral angle types for residues in given <range>.\n");
 }
 
+// Action_MultiDihedral::Init()
 Action::RetType Action_MultiDihedral::Init(ArgList& actionArgs, ActionInit& init, int debugIn)
 {
   debug_ = debugIn;
@@ -31,8 +35,16 @@ Action::RetType Action_MultiDihedral::Init(ArgList& actionArgs, ActionInit& init
   else
     minTorsion_ = -180.0;
   std::string resrange_arg = actionArgs.GetStringKey("resrange");
-  if (!resrange_arg.empty())
-    if (resRange_.SetRange( resrange_arg )) return Action::ERR;
+  use_mask_expression_ = false;
+  if (!resrange_arg.empty()) {
+    if ( StrIsMask( resrange_arg ) ) {
+      use_mask_expression_ = true;
+      if (resMask_.SetMaskString( resrange_arg )) return Action::ERR;
+    } else {
+      use_mask_expression_ = false;
+      if (resRange_.SetRange( resrange_arg )) return Action::ERR;
+    }
+  }
   // Search for known dihedral keywords
   dihSearch_.SearchForArgs(actionArgs);
   // Get custom dihedral arguments: dihtype <name>:<a0>:<a1>:<a2>:<a3>[:<offset>]
@@ -45,10 +57,14 @@ Action::RetType Action_MultiDihedral::Init(ArgList& actionArgs, ActionInit& init
 
   mprintf("    MULTIDIHEDRAL: Calculating");
   dihSearch_.PrintTypes();
-  if (!resRange_.Empty())
-    mprintf(" dihedrals for residues in range %s\n", resRange_.RangeArg());
-  else
-    mprintf(" dihedrals for all solute residues.\n");
+  if (use_mask_expression_) {
+    mprintf(" dihedrals for residues selected by mask '%s'\n", resMask_.MaskString());
+  } else {
+    if (!resRange_.Empty())
+      mprintf(" dihedrals for residues in range %s\n", resRange_.RangeArg());
+    else
+      mprintf(" dihedrals for all solute residues.\n");
+  }
   if (!dsetname_.empty())
     mprintf("\tDataSet name: %s\n", dsetname_.c_str());
   if (outfile_ != 0) mprintf("\tOutput to %s\n", outfile_->DataFilename().base());
@@ -64,15 +80,23 @@ Action::RetType Action_MultiDihedral::Init(ArgList& actionArgs, ActionInit& init
 // Action_MultiDihedral::Setup();
 Action::RetType Action_MultiDihedral::Setup(ActionSetup& setup) {
   Range actualRange;
-  // If range is empty (i.e. no resrange arg given) look through all 
-  // solute residues.
-  if (resRange_.Empty())
-    actualRange = setup.Top().SoluteResidues();
-  else {
-    // If user range specified, create new range shifted by -1 since internal
-    // resnums start from 0.
-    actualRange = resRange_;
-    actualRange.ShiftBy(-1);
+  if (use_mask_expression_) {
+    if (setup.Top().SetupIntegerMask( resMask_ )) return Action::ERR;
+    resMask_.MaskInfo(); // DEBUG
+    std::vector<int> rnums = setup.Top().ResnumsSelectedBy( resMask_ );
+    for (std::vector<int>::const_iterator rnum = rnums.begin(); rnum != rnums.end(); ++rnum)
+      actualRange.AddToRange( *rnum );
+  } else {
+    // If range is empty (i.e. no resrange arg given) look through all 
+    // solute residues.
+    if (resRange_.Empty())
+      actualRange = setup.Top().SoluteResidues();
+    else {
+      // If user range specified, create new range shifted by -1 since internal
+      // resnums start from 0.
+      actualRange = resRange_;
+      actualRange.ShiftBy(-1);
+    }
   }
   // Exit if no residues specified
   if (actualRange.Empty()) {
@@ -82,7 +106,12 @@ Action::RetType Action_MultiDihedral::Setup(ActionSetup& setup) {
   // Search for specified dihedrals in each residue in the range
   if (dihSearch_.FindDihedrals(setup.Top(), actualRange))
     return Action::SKIP;
-  mprintf("\tResRange=[%s]", resRange_.RangeArg());
+  if (use_mask_expression_)
+    mprintf("\tMask=[%s]", resMask_.MaskString());
+  else if (!resRange_.Empty())
+    mprintf("\tResRange=[%s]", resRange_.RangeArg());
+  else
+    mprintf("\tAll solute residues");
   dihSearch_.PrintTypes();
   mprintf(", %i dihedrals.\n", dihSearch_.Ndihedrals());
 

--- a/src/Action_MultiDihedral.cpp
+++ b/src/Action_MultiDihedral.cpp
@@ -16,12 +16,12 @@ Action_MultiDihedral::Action_MultiDihedral() :
 
 // Action_MultiDihedral::Help() 
 void Action_MultiDihedral::Help() const {
-  mprintf("\t[<name>] [<dihedral types>] [resrange <range>] [out <filename>] [range360]\n");
+  mprintf("\t[<name>] [<dihedral types>] [resrange <range/mask>] [out <filename>] [range360]\n");
   mprintf("\t[%s]\n", DihedralSearch::newTypeArgsHelp());
   DihedralSearch::OffsetHelp();
   mprintf("\t<dihedral types> = ");
   DihedralSearch::ListKnownTypes();
-  mprintf("  Calculate specified dihedral angle types for residues in given <range>.\n");
+  mprintf("  Calculate specified dihedral angle types for residues in given <range/mask>.\n");
 }
 
 // Action_MultiDihedral::Init()

--- a/src/Action_MultiDihedral.h
+++ b/src/Action_MultiDihedral.h
@@ -22,5 +22,7 @@ class Action_MultiDihedral : public Action {
     DataFile* outfile_;
     // TODO: Replace these with new DataSet type
     DataSetList* masterDSL_;
+    bool use_mask_expression_;    ///< If true, using a mask expression instead of range
+    AtomMask resMask_;            ///< The mask to use if use_mask_expression_
 };
 #endif 

--- a/src/ArgList.cpp
+++ b/src/ArgList.cpp
@@ -282,30 +282,7 @@ std::string const& ArgList::GetStringNext() {
 
 /** \return true if argument at position is a potential mask. */
 bool ArgList::ArgIsMask(unsigned int pos) const {
-  //size_t found = arglist_[pos].find_first_of(":@*");
-  //return (found != std::string::npos);
-  // NOTE: The below method is more rigorous but potentially allows more
-  //       "bad" masks through as *. For example, with previous method above,
-  //       'select test@' fails with 'Tokenize: Wrong syntax' because 'test@'
-  //       is treated as a mask, but with new method below 'test@' is ignored
-  //       and 'select' assumes no mask present and selects all.
-  std::string::const_iterator p = arglist_[pos].begin();
-  // Advance past any negate operator or open parentheses. Assume token not empty.
-  while (*p == '!' || *p == '(') {
-    ++p;
-    if (p == arglist_[pos].end()) return false;
-  }
-  // Determine if character could start a mask expression.
-  bool isMask;
-  switch ( *p ) {
-    case '@':
-    case ':':
-    case '^':
-    case '*':
-    case '=': isMask = true; break;
-    default : isMask = false;
-  }
-  return isMask;
+  return StrIsMask( arglist_[pos] );
 }
 
 // ArgList::GetMaskNext()

--- a/src/StringRoutines.cpp
+++ b/src/StringRoutines.cpp
@@ -279,6 +279,33 @@ bool validDouble(std::string const& argument) {
 */
 }
 
+/** \return True if this is a recognized CPPTRAJ mask expression.
+  * NOTE: The previous method for this was:
+  *   size_t found = arglist_[pos].find_first_of(":@*");
+  *   return (found != std::string::npos);
+  * Which could potentially let something weird through like 'test@'.
+  */
+bool StrIsMask(std::string const& str) {
+  if (str.empty()) return false;
+  std::string::const_iterator p = str.begin();
+  // Advance past any negate operator or open parentheses.
+  while (*p == '!' || *p == '(') {
+    ++p;
+    if (p == str.end()) return false;
+  }
+  // Determine if character could start a mask expression.
+  bool isMask;
+  switch ( *p ) {
+    case '@':
+    case ':':
+    case '^':
+    case '*':
+    case '=': isMask = true; break;
+    default : isMask = false;
+  }
+  return isMask;
+}
+
 // -----------------------------------------------------------------------------
 // NOTE: I think this serves as a great example of how printf syntax is way
 //       easier than iostream stuff (same printf command is only 3 lines). -DRR

--- a/src/StringRoutines.h
+++ b/src/StringRoutines.h
@@ -45,6 +45,8 @@ std::string doubleToString(double);
 bool validInteger(std::string const&);
 /// \return true if given string represents a valid floating point number,
 bool validDouble(std::string const&);
+/// \return true if the string is a CPPTRAJ mask selection expression.
+bool StrIsMask(std::string const&);
 /// \return the current date/time with format 'mm/dd/yy  hh:mm:ss'
 std::string TimeString();
 /// BYTE_BINARY: Sizes are based on 1024^X. BYTE_DECIMAL: Sizes are based on 1000^X.

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.16.3"
+#define CPPTRAJ_INTERNAL_VERSION "V6.16.4"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Multidihedral/RunTest.sh
+++ b/test/Test_Multidihedral/RunTest.sh
@@ -3,7 +3,7 @@
 . ../MasterTest.sh
 
 CleanFiles dih.in multidih.dat dihedral.dat custom.dat dihedral2.dat all.dat \
-           chin.dat arg.dat cyclic.dat
+           chin.dat arg.dat cyclic.dat all.bymask.dat
 
 TESTNAME='Multidihedral tests'
 Requires maxthreads 10
@@ -31,10 +31,12 @@ EOF
   done
   echo "multidihedral dihtype chi1:N:CA:CB:CG out custom.dat" >> dih.in
   echo "multidihedral out all.dat resrange 1-3" >> dih.in
+  echo "multidihedral out all.bymask.dat resrange :1-3" >> dih.in
   RunCpptraj "$UNITNAME"
   DoTest dihedral.dat multidih.dat
   DoTest dihedral2.dat custom.dat
   DoTest all.dat.save all.dat
+  DoTest all.dat.save all.bymask.dat
 fi
 
 # Test nucleic acid chi

--- a/unitTests/Makefile
+++ b/unitTests/Makefile
@@ -13,11 +13,15 @@ unit.ArgList:
 unit.GistEntropyUtils:
 	@-cd GistEntropyUtils && ./UnitTest.sh $(OPT)
 
+unit.StringRoutines:
+	@-cd StringRoutines && ./UnitTest.sh $(OPT)
+
 # ----- Every unit test should go here -----------
 COMPLETETESTS= \
   unit.NameType \
   unit.ArgList \
-  unit.GistEntropyUtils
+  unit.GistEntropyUtils \
+  unit.StringRoutines
 
 test.cpptraj: $(COMPLETETESTS)
 

--- a/unitTests/StringRoutines/UnitTest.sh
+++ b/unitTests/StringRoutines/UnitTest.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. ../UnitMaster.sh
+
+CleanFiles Makefile main.o StringRoutines.o a.out CpptrajStdio.o
+
+UNITSOURCES='StringRoutines.cpp CpptrajStdio.cpp'
+
+CreateMakefile
+
+RunMake "StringRoutines unit test."
+
+EndTest

--- a/unitTests/StringRoutines/main.cpp
+++ b/unitTests/StringRoutines/main.cpp
@@ -1,0 +1,19 @@
+// Unit test for NameType class
+#include <cstdio>
+#include "StringRoutines.h"
+
+static const int Err(const char* msg) {
+  fprintf(stderr, "Error: %s\n", msg);
+  return 1;
+}
+
+int main() {
+  // Test a valid mask
+  if (!StrIsMask(":1-12&!@H="))
+    return Err("StrIsMask failed for valid mask.");
+  // Test an invalid mask
+  if (StrIsMask("test@"))
+    return Err("StrIsMask failed for invalid mask.");
+
+  return 0;
+}


### PR DESCRIPTION
Version 6.16.4.

This provides some more flexibility when selecting residues for the `multidihedral` action (e.g. selecting by PDB residue number).

Adds a test and updates the manual.