### PR TITLE
Fix Amber ASCII REMD trajectory write in parallel

### DIFF
--- a/src/BufferedFrame.cpp
+++ b/src/BufferedFrame.cpp
@@ -118,8 +118,14 @@ int BufferedFrame::SeekToFrame(size_t set) {
   return Seek( (off_t)((set * frameSize_) + offset_) );
 }
 
-/** Set buffer pointer to beginning of buffer, past any header bytes. */
+/** Set buffer pointer to beginning of buffer. */
 void BufferedFrame::BufferBegin() {
+  bufferPosition_ = buffer_;
+  col_ = 0;
+}
+
+/** Set buffer pointer to beginning of buffer, past any header bytes. */
+void BufferedFrame::BufferBeginAfterHeader() {
   bufferPosition_ = buffer_ + headerSize_;
   col_ = 0;
 }

--- a/src/BufferedFrame.h
+++ b/src/BufferedFrame.h
@@ -35,8 +35,10 @@ class BufferedFrame : public CpptrajFile {
 
     /// Seek to a specific frame in the file
     int SeekToFrame(size_t);
-    /// Set buffer position to beginning of buffer (past any header bytes).
+    /// Set buffer position to beginning of buffer.
     void BufferBegin();
+    /// Set buffer position to beginning of buffer, past any header bytes.
+    void BufferBeginAfterHeader();
 
     /// Attempt to read frameSize_ bytes.
     int AttemptReadFrame();

--- a/src/Traj_AmberCoord.cpp
+++ b/src/Traj_AmberCoord.cpp
@@ -115,7 +115,7 @@ int Traj_AmberCoord::readFrame(int set, Frame& frameIn) {
     }
   }
   // Get Coordinates; offset is hasREMD (size in bytes of REMD header)
-  file_.BufferBegin();
+  file_.BufferBeginAfterHeader();
   file_.BufferToDouble(frameIn.xAddress(), natom3_);
   if (numBoxCoords_ != 0) {
     double xyzabg[6];
@@ -136,7 +136,7 @@ int Traj_AmberCoord::readVelocity(int set, Frame& frameIn) {
   file_.SeekToFrame( set );
   // Read frame into the char buffer
   if (file_.ReadFrame()) return 1;
-  file_.BufferBegin();
+  file_.BufferBeginAfterHeader();
   file_.BufferToDouble(frameIn.vAddress(), natom3_);
   return 0;
 }
@@ -145,7 +145,7 @@ int Traj_AmberCoord::readForce(int set, Frame& frameIn) {
   file_.SeekToFrame( set );
   // Read frame into the char buffer
   if (file_.ReadFrame()) return 1;
-  file_.BufferBegin();
+  file_.BufferBeginAfterHeader();
   file_.BufferToDouble(frameIn.fAddress(), natom3_);
   return 0;
 }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.17.0"
+#define CPPTRAJ_INTERNAL_VERSION "V6.17.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.17.1. 

#1009 broke writing Amber ASCII REMD trajectories in parallel - even though we want to seek past the header, we do not want to start the buffer there since it will have already be written by e.g a `Printf`. This PR restores the original behavior of `BufferedFrame::BufferBegin()` and re-implements the old `BufferBeginAt()` as `BufferBeginAfterHeader()`.