### PR TITLE
Fix minor 'for in' loop issue.

### DIFF
--- a/src/DataSetList.cpp
+++ b/src/DataSetList.cpp
@@ -878,6 +878,7 @@ std::string DataSetList::GetVariable(std::string const& varnameIn) const {
 int DataSetList::ReplaceVariables(std::string& varname, std::string const& varnameIn)
 const
 {
+  //mprintf("DEBUG: ReplaceVariables in '%s'\n", varnameIn.c_str());
   int nReplaced = 0;
   varname = varnameIn;
   size_t pos = varname.find("$");

--- a/src/ForLoop_list.cpp
+++ b/src/ForLoop_list.cpp
@@ -54,6 +54,7 @@ int ForLoop_list::BeginFor(DataSetList const& CurrentVars) {
       // Allow wildcard expansion to fail with a warning.
       if (!files.empty() && files.front().Full().compare( listEntry ) == 0) {
         mprintf("Warning: '%s' selects no files.\n", it->c_str());
+        List_.push_back( listEntry );
       } else {
         for (File::NameArray::const_iterator fn = files.begin(); fn != files.end(); ++fn)
           List_.push_back( fn->Full() );

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.17.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.17.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/test/Test_Control/RunTest.sh
+++ b/test/Test_Control/RunTest.sh
@@ -156,7 +156,13 @@ UNITNAME='Test for filename wildcards and oversets'
 CheckFor notos windows
 if [ $? -eq 0 ] ; then
   cat > for.in <<EOF
-for FILE in distance.dat.save,last10.dat.save,doesnot*,TRP.*.dat.save
+# NOTE: Previously this test chcked for a file wildcard that
+#       does not exist, 'doesnot*', which would be silently
+#       ignored. This is now an error. The original behavior
+#       can be recovered by specifying the 'noexitonerror' flag.
+#noexitonerror
+#for FILE in distance.dat.save,last10.dat.save,doesnot*,TRP.*.dat.save
+for FILE in distance.dat.save,last10.dat.save,TRP.*.dat.save
   readdata \$FILE
 done
 


### PR DESCRIPTION
Version 6.17.2.

Previously, a `for in` loop like this:
```
for DIR in MD,MD2,MD3 PREFIX in md.???.nc,run.???/mdcrd.nc,run.???/mdcrd.nc
  trajin $DIR/$PREFIX
done
```
Would fail because DIR and PREFIX are processed separately, so the full path is not available and file expansion fails. This PR fixes the behavior so that if expansion fails the unexpanded string is used with the expectation it will be expanded when used (in the above case expansion will occur in the `trajin` command).