### PR TITLE
Fix '*' wildcard matching.

### DIFF
--- a/src/StringRoutines.cpp
+++ b/src/StringRoutines.cpp
@@ -36,6 +36,8 @@ std::string AppendNumber(std::string const &fname, int number) {
   *   '?': A single character.
   */
 int WildcardMatch(std::string const& S1, std::string const& S2) {
+  //mprintf("DEBUG: wildcard string : '%s'\n", S1.c_str());
+  //mprintf("DEBUG: string to match : '%s'\n", S2.c_str());
   std::string::const_iterator c1 = S1.begin();
   std::string::const_iterator c2 = S2.begin();
   while ( c1 != S1.end() || c2 != S2.end() ) {
@@ -43,15 +45,20 @@ int WildcardMatch(std::string const& S1, std::string const& S2) {
     if (*c1 == '*') {
       ++c1;
       if (c1 == S1.end()) return 1;
-      bool match = false;
-      while (c2 != S2.end()) {
-        if (*c2 == *c1) {
-          match = true;
-          break;
-        }
-        ++c2;
+      // Search for the last instance of c1 in s2
+      int last_idx = -1;
+      for (unsigned int i2 = (unsigned int)(c2 - S2.begin());
+                        i2 != S2.size(); ++i2)
+      {
+        if (S2[i2] == *c1)
+          last_idx = (int)i2;
       }
-      if (!match) return 0;
+      if (last_idx == -1) {
+        // c1 was not found in S2. No match.
+        return 0;
+      }
+      // c1 was found in S2. Adjust c2.
+      c2 = S2.begin() + last_idx;
     } else if (c2 == S2.end()) {
       return 0;
     } else if (*c1 == '?') {

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.17.4"
+#define CPPTRAJ_INTERNAL_VERSION "V6.17.5"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/unitTests/StringRoutines/main.cpp
+++ b/unitTests/StringRoutines/main.cpp
@@ -14,6 +14,19 @@ int main() {
   // Test an invalid mask
   if (StrIsMask("test@"))
     return Err("StrIsMask failed for invalid mask.");
+  // Test wildcard matching
+  int is_match = WildcardMatch("E*.VU", "Eh5md.VU");
+  if (is_match != 1)
+    return Err("WildcardMatch E*.VU Eh5md.VU failed.");
+  is_match = WildcardMatch("E*.VU", "Eh5md.V");
+  if (is_match != 0)
+    return Err("WildcardMatch E*.VU Eh5md.V failed.");
+  is_match = WildcardMatch("E*.VU", "Egz.h5md.VU");
+  if (is_match != 1)
+    return Err("WildcardMatch E*.VU Egz.h5md.VU failed.");
+  is_match = WildcardMatch("E*.VU", "Egz.h5md.V");
+  if (is_match != 0)
+    return Err("WildcardMatch E*.VU Egz.h5md.V failed.");
 
   return 0;
 }


### PR DESCRIPTION
Version 6.17.5.

Previously, wildcard `*` matching would stop at the first found character instead of the last. So for example, the string `E*.VU` would match `Enc3.VU` but not `Egz.h5md.VU` (since matching would stop at the first `.`). This PR fixes this behavior. Also adds a unit test.