### PR TITLE
Fixes for nastruct,  ZDNA and parallel DNA

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -32847,6 +32847,10 @@ nastruct
 \end_layout
 
 \begin_layout LyX-Code
+         [bpmode {3dna|babcock}]
+\end_layout
+
+\begin_layout LyX-Code
      	[hbcut <hbcut>] [origincut <origincut>] [altona | cremer]
 \end_layout
 
@@ -32943,6 +32947,32 @@ naout
 <file>] Specify a custom nucleic acid base reference.
  One file per custom residue; multiple 'baseref' keywords may be present.
  See below for details.
+\end_layout
+
+\begin_layout Description
+[bpmode
+\begin_inset space ~
+\end_inset
+
+{3dna|babcock}] Specify axis conventions for calculating base pair parameters.
+ If '3dna' (default), use conventions of 3DNA
+\begin_inset CommandInset citation
+LatexCommand citep
+key "Lu2003"
+literal "true"
+
+\end_inset
+; flip Y and Z of
+ complimentary base for antiparallel.
+ If 'babcock', use conventions of Babcock et al.
+\begin_inset CommandInset citation
+LatexCommand citep
+key "Babcock94"
+literal "true"
+
+\end_inset
+ ; flip Y and Z of complimentary base for antiparallel, flip
+ X and Y for parallel.
 \end_layout
 
 \begin_layout Description
@@ -33059,19 +33089,6 @@ ref
 [allframes] If specified determine base pairing each frame.
 \end_layout
 
-\begin_layout Description
-[guessbp
-\begin_inset space ~
-\end_inset
-
-[bptype{anti|para}]] If specified base pairing will be determined based
- on selected NA strands.
- It is assumed that consecutive strands will be base-paired and that they
- are arranged 5' to 3'.
- The specific type of base pairing between strands can be specified with
- one or more 'bptype' arguments.
-\end_layout
-
 \begin_layout Standard
 DataSets Created:
 \end_layout
@@ -33124,6 +33141,10 @@ Base pairs:
 \begin_layout Description
 <name>[minor]:X (If groovecalc simple) Minor groove width calculated between
  O4 atoms of each base.
+\end_layout
+
+\begin_layout Description
+<name>[nxyz]:X Base pair axis normal (Z) vector.
 \end_layout
 
 \begin_layout Standard
@@ -33318,8 +33339,14 @@ literal "true"
 \shape italic
 cpptraj
 \shape default
- nastruct gives the exact same numbers as 3DNA.
  
+\series bold
+\emph on
+nastruct
+\series default
+\emph default
+ should give the exact same numbers as 3DNA.
+ One notable exception are parameters for G-quadruplex structures.
 \end_layout
 
 \begin_layout Standard

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1037,8 +1037,9 @@ int Action_NAstruct::DetermineStrandParameters(int frameNum) {
   * Z axis should point in the 5' to 3' direction.
   */
 int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
-  // Ensure base Z vector points 5' to 3'
   if (base1.HasC1atom()) {
+    // Ensure base Z vector points 5' to 3'
+    // TODO check 3 and 5 base c1 atom
     int c3residx = base1.C3resIdx();
     int c5residx = base1.C5resIdx();
     if (c3residx > -1 || c5residx > -1) {
@@ -1069,6 +1070,19 @@ int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
       } else
         mprintf("DEBUG: Z is OK, points 5' to 3'.\n");
     }
+    // Check that Y axis points towards attached strand.
+    // Axis origin to C1 should roughly align with Y axis vector.
+    const double* this_c1xyz = base1.C1xyz();
+    Vec3 toStrand_vec = Vec3(this_c1xyz) - base1.Axis().Oxyz();
+    toStrand_vec.Normalize();
+    toStrand_vec.Print("to strand vec");
+    base1.Axis().Ry().Print("Axis Y");
+    double ts_angle = base1.Axis().Ry().Angle( toStrand_vec );
+    mprintf("DEBUG: Angle between to-strand vector and Axis Y = %f\n", ts_angle * Constants::RADDEG);
+    if (ts_angle > Constants::PIOVER2) {
+      mprintf("DEBUG: Y should be flipped.\n");
+    } else
+      mprintf("DEBUG: Y is OK, points to strand.\n");
   }
   return 0;
 }

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1057,7 +1057,8 @@ int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
         return 1;
       }
 #     ifdef NASTRUCTDEBUG
-      mprintf("DEBUG: c5res_c1xyz = %f %f %f  c3res_c1xyz = %f %f %f\n",
+      mprintf("DEBUG: Res %i  c5res_c1xyz = %f %f %f  c3res_c1xyz = %f %f %f\n",
+              base1.ResNum()+1,
               c5res_c1xyz[0], c5res_c1xyz[1], c5res_c1xyz[2],
               c3res_c1xyz[0], c3res_c1xyz[1], c3res_c1xyz[2]);
 #     endif

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -569,6 +569,10 @@ int Action_NAstruct::DetermineBasePairing() {
 //                base1->ResNum()+1, base1->ResName(), 
 //                base2->ResNum()+1, base2->ResName(), sqrt(dist2));
 //#       endif
+        // Determine if base Z axis vectors are aligned with strand direction
+        int b1_5to3 = axis_points_5p_to_3p( *base1 );
+        int b2_5to3 = axis_points_5p_to_3p( *base2 );
+        // TODO trap errors here
         // Determine if base Z axis vectors point in same (theta <= 90) or
         // opposite (theta > 90) directions.
         NA_Axis b2Axis = base2->Axis();
@@ -584,6 +588,10 @@ int Action_NAstruct::DetermineBasePairing() {
           z_deviation_from_linear = Constants::PI - z_theta;
           // Antiparallel - flip Y and Z axes of complimentary base
           b2Axis.FlipYZ();
+          // If antiparallel and both bases are aligned 3' to 5', may be ZDNA
+          if (b1_5to3 == 0 && b2_5to3 == 0) {
+            mprintf("Antiparallel and both bases aligned 3' to 5', ZDNA\n");
+          }
         } else {
 #         ifdef NASTRUCTDEBUG
           mprintf("\t%s is parallel to %s (%g deg)\n", base1->ResName(), base2->ResName(),

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -585,7 +585,9 @@ int Action_NAstruct::DetermineBasePairing() {
         // TODO trap errors here
         // If antiparallel and both bases are aligned 3' to 5', may be ZDNA
         if (b1_5to3 == 0 && b2_5to3 == 0) {
+#         ifdef NASTRUCTDEBUG
           mprintf("Both bases aligned 3' to 5', ZDNA\n");
+#         endif
           b1Axis.FlipXZ();
           b2Axis.FlipXZ();
           is_z = true;

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1474,15 +1474,29 @@ int Action_NAstruct::DetermineStepParameters(int frameNum) {
         calculateParameters(BP1.bpaxis_, BP2.bpaxis_, &midFrame, Param);
         // Calculate zP
         float Zp = 0.0;
+        NA_Base const* s1base = 0;
         NA_Base const* s2base = 0;
         if (BP1.isAnti_) {
-          if (base2.HasPatom()) s2base = &base2;
+          if (base3.HasPatom() && base2.HasPatom()) {
+            s2base = &base3;
+            s1base = &base2;
+            //pVec = Vec3(base3.Pxyz()) - Vec3(s2base->Pxyz());
+          }
         } else {
-          if (base4.HasPatom()) s2base = &base4;
+          if (base2.HasPatom() && base3.HasPatom()) {
+            s2base = &base2;
+            s1base = &base3;
+            //pVec = Vec3(s2base->Pxyz()) - Vec3(base3.Pxyz());
+          }
         }
         if (s2base != 0) {
-          Vec3 xyzP = midFrame.Rot().TransposeMult((Vec3(base3.Pxyz()) - Vec3(s2base->Pxyz())) / 2);
-          //xyzP.Print("xyzP"); // TODO: Check/fix Xp
+          Vec3 pVec = Vec3(s2base->Pxyz()) - Vec3(s1base->Pxyz());
+          Vec3 xyzP = midFrame.Rot().TransposeMult(pVec / 2);
+#         ifdef NASTRUCTDEBUG
+          mprintf("  Zp calculation between base %i and base %i\n", s1base->ResNum()+1, s2base->ResNum()+1);
+          pVec.Print("pVec");
+          xyzP.Print("xyzP"); // TODO: Check/fix Xp
+#         endif
           Zp = (float)xyzP[2];
         }
         currentStep.Zp_->Add(frameNum, &Zp);

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -569,15 +569,22 @@ int Action_NAstruct::DetermineBasePairing() {
 //                base1->ResNum()+1, base1->ResName(), 
 //                base2->ResNum()+1, base2->ResName(), sqrt(dist2));
 //#       endif
+        NA_Axis b1Axis = base1->Axis();
+        NA_Axis b2Axis = base2->Axis();
         // Determine if base Z axis vectors are aligned with strand direction
         int b1_5to3 = axis_points_5p_to_3p( *base1 );
         int b2_5to3 = axis_points_5p_to_3p( *base2 );
         // TODO trap errors here
+        // If antiparallel and both bases are aligned 3' to 5', may be ZDNA
+        if (b1_5to3 == 0 && b2_5to3 == 0) {
+          mprintf("Both bases aligned 3' to 5', ZDNA\n");
+          b1Axis.FlipXZ();
+          b2Axis.FlipXZ();
+        }
         // Determine if base Z axis vectors point in same (theta <= 90) or
         // opposite (theta > 90) directions.
-        NA_Axis b2Axis = base2->Axis();
         bool is_antiparallel;
-        double z_theta = base1->Axis().Rz().Angle( base2->Axis().Rz() );
+        double z_theta = b1Axis.Rz().Angle( b2Axis.Rz() );
         double z_deviation_from_linear;
         if (z_theta > Constants::PIOVER2) { // If theta(Z) > 90 deg.
 #         ifdef NASTRUCTDEBUG
@@ -588,10 +595,7 @@ int Action_NAstruct::DetermineBasePairing() {
           z_deviation_from_linear = Constants::PI - z_theta;
           // Antiparallel - flip Y and Z axes of complimentary base
           b2Axis.FlipYZ();
-          // If antiparallel and both bases are aligned 3' to 5', may be ZDNA
-          if (b1_5to3 == 0 && b2_5to3 == 0) {
-            mprintf("Antiparallel and both bases aligned 3' to 5', ZDNA\n");
-          }
+          
         } else {
 #         ifdef NASTRUCTDEBUG
           mprintf("\t%s is parallel to %s (%g deg)\n", base1->ResName(), base2->ResName(),
@@ -610,7 +614,7 @@ int Action_NAstruct::DetermineBasePairing() {
         // Calculate parameters between axes.
         double Param[6];
         //calculateParameters(base1->Axis(), base2->Axis(), 0, Param);
-        calculateParameters(b2Axis, base1->Axis(), 0, Param);
+        calculateParameters(b2Axis, b1Axis, 0, Param);
 #       ifdef NASTRUCTDEBUG
         mprintf("    Shear= %6.2f  Stretch= %6.2f  Stagger= %6.2f  Buck= %6.2f  Prop= %6.2f  Open= %6.2f\n",
                 Param[0], Param[1], Param[2], Param[5]*Constants::RADDEG, Param[4]*Constants::RADDEG, Param[3]*Constants::RADDEG);

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -230,8 +230,8 @@ Action::RetType Action_NAstruct::Init(ArgList& actionArgs, ActionInit& init, int
       mprintf("\tSingle strand parameters written to %s\n", ssout_->Filename().full());
   }
   switch (bpConvention_) {
-    case BP_3DNA : mprintf("\tUsing 3DNA conventions for base pairing (no XY flip for parallel strands).\n");
-    case BP_BABCOCK : mprintf("\tUsing Babcock et al. conventions for base pairing (XY flip for parallel strands).\n");
+    case BP_3DNA : mprintf("\tUsing 3DNA conventions for base pairing (no XY flip for parallel strands).\n"); break;
+    case BP_BABCOCK : mprintf("\tUsing Babcock et al. conventions for base pairing (XY flip for parallel strands).\n"); break;
   }
   mprintf("\tHydrogen bond cutoff for determining base pairs is %.2f Angstroms.\n",
           sqrt( HBdistCut2_ ) );

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -559,7 +559,7 @@ int Action_NAstruct::DetermineBasePairing() {
       double dist2 = DIST2_NoImage(base1->Axis().Oxyz(), base2->Axis().Oxyz());
 #     ifdef NASTRUCTDEBUG
       double axes_distance = sqrt(dist2);
-      mprintf("  Axes distance for %i:%s -- %i:%s is %f\n",
+      mprintf("\n  ----- Axes distance for %i:%s -- %i:%s is %f -----\n",
               base1->ResNum()+1, base1->ResName(), 
               base2->ResNum()+1, base2->ResName(), axes_distance);
 #     endif
@@ -569,6 +569,13 @@ int Action_NAstruct::DetermineBasePairing() {
 //                base1->ResNum()+1, base1->ResName(), 
 //                base2->ResNum()+1, base2->ResName(), sqrt(dist2));
 //#       endif
+#       ifdef NASTRUCTDEBUG
+        // Glycosidic N-N distance
+        if (base1->HasNXatom() && base2->HasNXatom()) {
+          double n_n_dist2 = DIST2_NoImage(base1->NXxyz(), base2->NXxyz());
+          mprintf("DEBUG: NX-NX distance= %f\n", sqrt(n_n_dist2));
+        }
+#       endif
         NA_Axis b1Axis = base1->Axis();
         NA_Axis b2Axis = base2->Axis();
         // Determine if base Z axis vectors are aligned with strand direction

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -16,9 +16,11 @@
 Action_NAstruct::Action_NAstruct() :
   puckerMethod_(NA_Base::ALTONA),
   HBdistCut2_(12.25),     // Hydrogen Bond distance cutoff^2: 3.5^2
-  // NOTE: Is this too big?
-  originCut2_(6.25),      // Origin cutoff^2 for base-pairing: 2.5^2
+  // NOTE: should this be bigger? 3dna cutoff is 15 ang
+  originCut2_(25.0),      // Origin cutoff^2 for base-pairing: 5.0^2
+  // NOTE: should this be smaller? 3dna cutoff is 1.5 Ang
   staggerCut_(2.0),       // Vertical separation cutoff
+  // NOTE: should this be smaller? 3dna cutoff is 30 deg.
   z_angle_cut_(1.134464), // Z angle cutoff in radians (65 deg)
   maxResSize_(0),
   debug_(0),
@@ -143,9 +145,10 @@ Action::RetType Action_NAstruct::Init(ArgList& actionArgs, ActionInit& init, int
     findBPmode_ = REFERENCE;
   else if (actionArgs.hasKey("allframes"))
     findBPmode_ = ALL;
-  else if (actionArgs.hasKey("guessbp"))
-    findBPmode_ = GUESS;
-  else if (actionArgs.hasKey("first"))
+  else if (actionArgs.hasKey("guessbp")) {
+    mprintf("Warning: 'guessbp' is deprecated. Defaulting to 'first'.\n");
+    findBPmode_ = FIRST;
+  } else if (actionArgs.hasKey("first"))
     findBPmode_ = FIRST;
   else 
     findBPmode_ = FIRST;

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -733,7 +733,7 @@ int Action_NAstruct::calculateParameters(NA_Axis const& Axis1, NA_Axis const& Ax
 # ifdef NASTRUCTDEBUG
   // Print rotated R1 and R2
   RotatedR1.Print("Rotated R1");
-  RotatedR1.Print("Rotated R2");
+  RotatedR2.Print("Rotated R2");
   if (calcparam_) {
     tempAxis.StoreRotMatrix(RotatedR1, Axis1.Oxyz()); 
     WriteAxes(paramfile, 1, "R1'", tempAxis);

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -362,10 +362,9 @@ int Action_NAstruct::SetupBaseAxes(Frame const& InputFrame) {
       mprintf("Base %i: RMS of RefCoords from ExpCoords is %f\n",base->ResNum(), rmsd);
       base->Axis().PrintAxisInfo("BaseAxes");
     }
+
 #   ifdef NASTRUCTDEBUG
-    // DEBUG - Write base axis to file
-    WriteAxes(baseaxesfile, base->ResNum()+1, base->ResName(), base->Axis());
-     // Overlap ref coords onto input coords.
+    // Overlap ref coords onto input coords.
     Frame reftemp = base->Ref(); 
     reftemp.Trans_Rot_Trans(TransVec, RotMatrix, refTrans);
     // DEBUG - Write reference frame to file
@@ -376,6 +375,17 @@ int Action_NAstruct::SetupBaseAxes(Frame const& InputFrame) {
     }
 #   endif
   } // END loop over bases
+  // Check that base axes correspond to EMBO guidelines
+  for (std::vector<NA_Base>::iterator base = Bases_.begin(); 
+                                      base != Bases_.end(); ++base)
+  {
+    // Check the base axis strand direction
+    check_base_axis_strand_direction( *base );
+#   ifdef NASTRUCTDEBUG
+    // DEBUG - Write base axis to file
+    WriteAxes(baseaxesfile, base->ResNum()+1, base->ResName(), base->Axis());
+#   endif
+  }
   return 0;
 }
 
@@ -1085,8 +1095,6 @@ int Action_NAstruct::DeterminePairParameters(int frameNum) {
     NA_Base& base1 = Bases_[b1];
     NA_Base& base2 = Bases_[b2]; //TODO copy? 
 
-    check_base_axis_strand_direction( base1 );
-    check_base_axis_strand_direction( base2 );
 #   ifdef NASTRUCTDEBUG
     mprintf("BasePair %i:%s to %i:%s", b1+1, base1.ResName(), b2+1, base2.ResName());
     if (BP.isAnti_)

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -606,7 +606,7 @@ int Action_NAstruct::DetermineBasePairing() {
   */
 int Action_NAstruct::GuessBasePairing(Topology const& Top) {
 # ifdef NASTRUCTDEBUG
-  mprintf("\n=================== Setup Base Pairing ===================\n");
+  mprintf("\n=================== Guess Base Pairing ===================\n");
 # endif
   if (Strands_.size() < 2) {
     mprinterr("Error: Need at least 2 strands to guess base pairing, have %zu\n",

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1056,20 +1056,23 @@ int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
         mprinterr("Error: 5' res and/ord 3' res missing C1 atom coords.\n");
         return 1;
       }
+#     ifdef NASTRUCTDEBUG
       mprintf("DEBUG: c5res_c1xyz = %f %f %f  c3res_c1xyz = %f %f %f\n",
               c5res_c1xyz[0], c5res_c1xyz[1], c5res_c1xyz[2],
               c3res_c1xyz[0], c3res_c1xyz[1], c3res_c1xyz[2]);
+#     endif
       Vec3 strand_vec( c3res_c1xyz[0] - c5res_c1xyz[0],
                        c3res_c1xyz[1] - c5res_c1xyz[1],
                        c3res_c1xyz[2] - c5res_c1xyz[2] );
       strand_vec.Normalize();
+      double s_angle = base1.Axis().Rz().Angle( strand_vec );
+#     ifdef NASTRUCTDEBUG
       strand_vec.Print("strand vector");
       base1.Axis().Rz().Print("Axis Z");
-      double s_angle = base1.Axis().Rz().Angle( strand_vec );
       mprintf("DEBUG: Angle between strand and Axis Z = %f\n", s_angle * Constants::RADDEG);
+#     endif
       if (s_angle > Constants::PIOVER2) {
         // Z has flipped, likely due to rotation around chi.
-        mprintf("DEBUG: Z should be flipped.\n");
         // Sanity check to ensure the Y axis still points towards the
         // strand backbone, which should be the case if Z has flipped
         // due to a chi rotation. In that case X also needs to be flipped.
@@ -1079,21 +1082,31 @@ int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
         toStrand_vec.Print("to strand vec");
         base1.Axis().Ry().Print("Axis Y");
         double ts_angle = base1.Axis().Ry().Angle( toStrand_vec );
+#       ifdef NASTRUCTDEBUG
+        mprintf("DEBUG: Z should be flipped.\n");
         mprintf("DEBUG: Angle between to-strand vector and Axis Y = %f\n", ts_angle * Constants::RADDEG);
+#       endif
         if (ts_angle > Constants::PIOVER2) {
           // Y is flipped so it points away from the strand backbone. This
           // should never happen.
           mprinterr("Error: Base Y axis has flipped. There may be corruption or\n"
                     "Error:  distortion in the input coordinates.\n");
           return 1;
-        } else
+        }
+#       ifdef NASTRUCTDEBUG
+        else
           mprintf("DEBUG: Y is OK, points to strand.\n");
-
+#       endif
         base1.Axis().FlipXZ();
+#       ifdef NASTRUCTDEBUG
         base1.Axis().Rz().Print("Flipped Axes X and Z");
-      } else
+#       endif
+      }
+#     ifdef NASTRUCTDEBUG
+      else
         // Z points 5' to 3' as it should.
         mprintf("DEBUG: Z is OK, points 5' to 3'.\n");
+#     endif
     }
   }
   return 0;

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -379,17 +379,12 @@ int Action_NAstruct::SetupBaseAxes(Frame const& InputFrame) {
     }
 #   endif
   } // END loop over bases
-  // Check that base axes correspond to EMBO guidelines
+# ifdef NASTRUCTDEBUG
+    // DEBUG - Write base axis to file
   for (std::vector<NA_Base>::iterator base = Bases_.begin(); 
                                       base != Bases_.end(); ++base)
-  {
-    // Check the base axis strand direction
-    //check_base_axis_strand_direction( *base );
-#   ifdef NASTRUCTDEBUG
-    // DEBUG - Write base axis to file
     WriteAxes(baseaxesfile, base->ResNum()+1, base->ResName(), base->Axis());
 #   endif
-  }
   return 0;
 }
 
@@ -1076,89 +1071,6 @@ int Action_NAstruct::axis_points_5p_to_3p(NA_Base const& base1) const {
   }
   // If we are here, either not enough coords or not enough res. Assume aligned. TODO OK?
   return 1;
-}
-
-/** Check that the base axis is pointing in the right direction
-  * according to EMBO 1988 guidelines.
-  * Z axis should point in the 5' to 3' direction. TODO deprecate
-  */
-int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
-  if (base1.HasC1atom()) {
-    // Ensure base Z vector points 5' to 3'
-    int c3residx = base1.C3resIdx();
-    int c5residx = base1.C5resIdx();
-    if (c3residx > -1 || c5residx > -1) {
-      const double *c5res_c1xyz = 0;
-      const double *c3res_c1xyz = 0;
-      if (c3residx == -1)
-        c3res_c1xyz = base1.C1xyz();
-      else if (Bases_[c3residx].HasC1atom())
-        c3res_c1xyz = Bases_[c3residx].C1xyz();
-      if (c5residx == -1)
-        c5res_c1xyz = base1.C1xyz();
-      else if (Bases_[c5residx].HasC1atom())
-        c5res_c1xyz = Bases_[c5residx].C1xyz();
-      if (c5res_c1xyz == 0 || c3res_c1xyz == 0) {
-        mprinterr("Error: 5' res and/ord 3' res missing C1 atom coords.\n");
-        return 1;
-      }
-#     ifdef NASTRUCTDEBUG
-      mprintf("DEBUG: Res %i  c5res_c1xyz = %f %f %f  c3res_c1xyz = %f %f %f\n",
-              base1.ResNum()+1,
-              c5res_c1xyz[0], c5res_c1xyz[1], c5res_c1xyz[2],
-              c3res_c1xyz[0], c3res_c1xyz[1], c3res_c1xyz[2]);
-#     endif
-      Vec3 strand_vec( c3res_c1xyz[0] - c5res_c1xyz[0],
-                       c3res_c1xyz[1] - c5res_c1xyz[1],
-                       c3res_c1xyz[2] - c5res_c1xyz[2] );
-      strand_vec.Normalize();
-      double s_angle = base1.Axis().Rz().Angle( strand_vec );
-#     ifdef NASTRUCTDEBUG
-      strand_vec.Print("strand vector");
-      base1.Axis().Rz().Print("Axis Z");
-      mprintf("DEBUG: Angle between strand and Axis Z = %f\n", s_angle * Constants::RADDEG);
-#     endif
-      if (s_angle > Constants::PIOVER2) {
-        // Z has flipped, likely due to rotation around chi.
-        // Sanity check to ensure the Y axis still points towards the
-        // strand backbone, which should be the case if Z has flipped
-        // due to a chi rotation. In that case X also needs to be flipped.
-        const double* this_c1xyz = base1.C1xyz();
-        Vec3 toStrand_vec = Vec3(this_c1xyz) - base1.Axis().Oxyz();
-        toStrand_vec.Normalize();
-#       ifdef NASTRUCTDEBUG
-        toStrand_vec.Print("to strand vec");
-        base1.Axis().Ry().Print("Axis Y");
-#       endif
-        double ts_angle = base1.Axis().Ry().Angle( toStrand_vec );
-#       ifdef NASTRUCTDEBUG
-        mprintf("DEBUG: Z should be flipped.\n");
-        mprintf("DEBUG: Angle between to-strand vector and Axis Y = %f\n", ts_angle * Constants::RADDEG);
-#       endif
-        if (ts_angle > Constants::PIOVER2) {
-          // Y is flipped so it points away from the strand backbone. This
-          // should never happen.
-          mprinterr("Error: Base Y axis has flipped. There may be corruption or\n"
-                    "Error:  distortion in the input coordinates.\n");
-          return 1;
-        }
-#       ifdef NASTRUCTDEBUG
-        else
-          mprintf("DEBUG: Y is OK, points to strand.\n");
-#       endif
-        base1.Axis().FlipXZ();
-#       ifdef NASTRUCTDEBUG
-        base1.Axis().Rz().Print("Flipped Axes X and Z");
-#       endif
-      }
-#     ifdef NASTRUCTDEBUG
-      else
-        // Z points 5' to 3' as it should.
-        mprintf("DEBUG: Z is OK, points 5' to 3'.\n");
-#     endif
-    }
-  }
-  return 0;
 }
 
 // Action_NAstruct::DeterminePairParameters()

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1285,6 +1285,8 @@ int Action_NAstruct::DeterminePairParameters(int frameNum) {
 int Action_NAstruct::DetermineStepParameters(int frameNum) {
   double Param[6];
 # ifdef NASTRUCTDEBUG
+  PDBfile stepaxesfile;
+  stepaxesfile.OpenWrite("stepaxes.pdb");
   mprintf("\n=================== Determine BPstep Parameters ===================\n");
 # endif
   if (BasePairs_.size() < 2) return 0;
@@ -1394,6 +1396,41 @@ int Action_NAstruct::DetermineStepParameters(int frameNum) {
             s1base = &base3;
             //pVec = Vec3(s2base->Pxyz()) - Vec3(base3.Pxyz());
           }
+#         ifdef NASTRUCTDEBUG
+          // DEBUG
+          NA_Base const* pbase1 = &base3;
+          NA_Base const* pbase2;
+          if (BP1.isAnti_)
+            pbase2 = &base2;
+          else
+            pbase2 = &base4;
+          //Vec3 p1xyz( pbase1->Pxyz() );
+          //Vec3 p2xyz( pbase2->Pxyz() );
+          Vec3 p1xyz = midFrame.Rot().TransposeMult( Vec3(pbase1->Pxyz()) - midFrame.Oxyz() );
+          Vec3 p2xyz = midFrame.Rot().TransposeMult( Vec3(pbase2->Pxyz()) - midFrame.Oxyz() );
+          mprintf("ZPCALC: SI '%3s' P %6.2f %6.2f %6.2f  |  SII '%3s' P %6.2f %6.2f %6.2f\n",
+                  pbase1->BaseName().c_str(), p1xyz[0], p1xyz[1], p1xyz[2],
+                  pbase2->BaseName().c_str(), p2xyz[0], p2xyz[1], p2xyz[2]);
+/*
+          typedef std::vector<NA_Base const*> TARRAY;
+          TARRAY tmp_bases;
+          tmp_bases.push_back( &base1 );
+          tmp_bases.push_back( &base2 );
+          tmp_bases.push_back( &base3 );
+          tmp_bases.push_back( &base4 );
+          mprintf("ZPCALC:\n");
+          for (unsigned int t1 = 0; t1 != tmp_bases.size(); t1++) {
+            for (unsigned int t2 = 0; t2 != tmp_bases.size(); t2++) {
+              if (t1 != t2) {
+                Vec3 tmp_pVec = Vec3(tmp_bases[t1]->Pxyz()) - Vec3(tmp_bases[t2]->Pxyz());
+                Vec3 tmp_xyzP = midFrame.Rot().TransposeMult(tmp_pVec / 2);
+                //Vec3 tmp_xyzP = midFrame.Rot() * (tmp_pVec / 2);
+                mprintf("ZPCALC: base %2u '%3s' - base %2u '%3s' : %6.2f %6.2f %6.2f\n", t1+1, tmp_bases[t1]->BaseName().c_str(), t2+1, tmp_bases[t2]->BaseName().c_str(), tmp_xyzP[0], tmp_xyzP[1], tmp_xyzP[2]);
+              }
+            }
+          }*/
+          // END DEBUG
+#         endif
         }
         if (s2base != 0) {
           Vec3 pVec = Vec3(s2base->Pxyz()) - Vec3(s1base->Pxyz());
@@ -1462,8 +1499,12 @@ int Action_NAstruct::DetermineStepParameters(int frameNum) {
         currentStep.incl_->Add(frameNum, &incl);
         currentStep.tip_->Add(frameNum, &tip);
         currentStep.htwist_->Add(frameNum, &htwist);
+#       ifdef NASTRUCTDEBUG
+        // DEBUG - write base pair step axes
+        WriteAxes(stepaxesfile, base1.ResNum()+1, base1.ResName(), midFrame);
+#       endif
       } // END second base pair found
-    } // END second base pair valid 
+    } // END second base pair valid
   } // END loop over base pairs 
   return 0;
 }

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1079,8 +1079,10 @@ int Action_NAstruct::check_base_axis_strand_direction(NA_Base& base1) const {
         const double* this_c1xyz = base1.C1xyz();
         Vec3 toStrand_vec = Vec3(this_c1xyz) - base1.Axis().Oxyz();
         toStrand_vec.Normalize();
+#       ifdef NASTRUCTDEBUG
         toStrand_vec.Print("to strand vec");
         base1.Axis().Ry().Print("Axis Y");
+#       endif
         double ts_angle = base1.Axis().Ry().Angle( toStrand_vec );
 #       ifdef NASTRUCTDEBUG
         mprintf("DEBUG: Z should be flipped.\n");

--- a/src/Action_NAstruct.cpp
+++ b/src/Action_NAstruct.cpp
@@ -1049,6 +1049,7 @@ int Action_NAstruct::DeterminePairParameters(int frameNum) {
       mprintf(" Anti-parallel.\n");
     else
       mprintf(" Parallel.\n");
+    base2.Axis().Rot().Print("Original base2 axis");
 #   endif
     // Check Antiparallel / Parallel
     // Flip YZ (rotate around X) for antiparallel

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -47,8 +47,8 @@ class Action_NAstruct: public Action {
     enum HbondType { WC = 0, HOOG, OTHER };
     enum GrooveType { PP_OO = 0, HASSAN_CALLADINE };
     enum BP_ConventionType { BP_3DNA = 0, BP_BABCOCK };
-    /// How to find base pairs: first frame, reference structure, all frames, guess.
-    enum FindType { FIRST = 0, REFERENCE, ALL, GUESS };
+    /// How to find base pairs: first frame, reference structure, all frames.
+    enum FindType { FIRST = 0, REFERENCE, ALL };
     // ----- Data Structures ---------------------
     /// Hold consecutive bases
     struct Stype {
@@ -141,8 +141,6 @@ class Action_NAstruct: public Action {
     BPmap::iterator AddBasePair(int, NA_Base const&, int, NA_Base const&);
     /// Determine which bases are paired geometrically, set base pair data.
     int DetermineBasePairing();
-    /// Guess which bases are paired based on strand layout.
-    int GuessBasePairing(Topology const&);
     /// Calculate translational/rotational parameters between two axes.
     int calculateParameters(NA_Axis const&, NA_Axis const&, NA_Axis*, double*);
     /// Calculate helical parameters between two axes.
@@ -195,7 +193,6 @@ class Action_NAstruct: public Action {
     CpptrajFile* stepout_;              ///< Base pair step out (BPstep.<suffix>).
     CpptrajFile* helixout_;             ///< Helical parameters out (Helix.<suffix>).
     std::string dataname_;              ///< NA DataSet name (default NA).
-    std::vector<bool> BpTypes_;         ///< Hold specified base pairing types for strands
     // TODO: Replace these with new DataSet type
     DataSetList* masterDSL_;
 #   ifdef NASTRUCTDEBUG

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -150,6 +150,8 @@ class Action_NAstruct: public Action {
     int GetBaseIdxStep(int, int) const;
     /// Determine individual base parameters in single strands.
     int DetermineStrandParameters(int);
+    /// Check that base Z axis points 5' to 3'
+    int axis_points_5p_to_3p(NA_Base const&) const;
     /// Check that base axis points in correct direction
     int check_base_axis_strand_direction(NA_Base&) const;
     /// Determine individual base and base pair parameters.

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -82,7 +82,8 @@ class Action_NAstruct: public Action {
       unsigned int base2idx_; ///< Index of second base in Bases_
       int nhb_;               ///< Current # of hydrogen bonds in base pair.
       int n_wc_hb_;           ///< Number of WC hydrogen bonds in base pair.
-      bool isAnti_;
+      bool isAnti_;           ///< True if base Z axes are not aligned
+      bool isZ_;              ///< True if Z axes are aligned 3' to 5' instead of 5' to 3'
     };
     /// Hold a base pair step.
     struct StepType {

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -21,6 +21,12 @@
   *   Westhof E, Wolberger C, Berman H, "A Standard Reference Frame for the 
   *   Description of Nucleic Acid Base-pair Geometry", J. Mol. Biol. (2001)
   *   313, 229-237.
+  * Default conventions for determining base pairing etc are those used in 
+  * 3DNA:
+  *   Lu XJ, Olson WK. "3DNA: a software package for the analysis, rebuilding
+  *   and visualization of three-dimensional nucleic acid structures".
+  *   Nucleic Acids Res. 2003 Sep 1;31(17):5108-21.
+  *   doi: 10.1093/nar/gkg680. PMID: 12930962; PMCID: PMC212791.
   */
 class Action_NAstruct: public Action {
   public:
@@ -40,6 +46,7 @@ class Action_NAstruct: public Action {
     // ----- Enumerations ------------------------
     enum HbondType { WC = 0, HOOG, OTHER };
     enum GrooveType { PP_OO = 0, HASSAN_CALLADINE };
+    enum BP_ConventionType { BP_3DNA = 0, BP_BABCOCK };
     /// How to find base pairs: first frame, reference structure, all frames, guess.
     enum FindType { FIRST = 0, REFERENCE, ALL, GUESS };
     // ----- Data Structures ---------------------
@@ -173,6 +180,7 @@ class Action_NAstruct: public Action {
     int nframes_;                       ///< Total number of frames calculated.
     FindType findBPmode_;               ///< How base pairs are to be found.
     GrooveType grooveCalcType_;         ///< Type of groove calc to perform
+    BP_ConventionType bpConvention_;    ///< Conventions to use when determining base pairing.
     Range resRange_;                    ///< Range to search for NA residues.
     bool printheader_;                  ///< If true, print header to naout files.
     bool seriesUpdated_;                ///< If false, check that time series data is nframes long

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -151,8 +151,6 @@ class Action_NAstruct: public Action {
     int DetermineStrandParameters(int);
     /// Check that base Z axis points 5' to 3'
     int axis_points_5p_to_3p(NA_Base const&) const;
-    /// Check that base axis points in correct direction
-    int check_base_axis_strand_direction(NA_Base&) const;
     /// Determine individual base and base pair parameters.
     int DeterminePairParameters(int);
     /// Determine base pair steps and step parameters, including HC groove calc.

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -141,6 +141,8 @@ class Action_NAstruct: public Action {
     int GetBaseIdxStep(int, int) const;
     /// Determine individual base parameters in single strands.
     int DetermineStrandParameters(int);
+    /// Check that base axis points in correct direction
+    int check_base_axis_strand_direction(NA_Base&) const;
     /// Determine individual base and base pair parameters.
     int DeterminePairParameters(int);
     /// Determine base pair steps and step parameters, including HC groove calc.

--- a/src/Action_NAstruct.h
+++ b/src/Action_NAstruct.h
@@ -68,6 +68,8 @@ class Action_NAstruct: public Action {
       DataSet_1D* isBP_;
       DataSet_1D* major_;
       DataSet_1D* minor_;
+      //DataSet*    axes_oxyz_; ///< Base pair axes origin vectors
+      DataSet*    axes_nxyz_; ///< Base pair axes Z (i.e. mean normal) vectors
       unsigned int bpidx_;
       unsigned int base1idx_; ///< Index of first base in Bases_
       unsigned int base2idx_; ///< Index of second base in Bases_

--- a/src/AxisType.cpp
+++ b/src/AxisType.cpp
@@ -684,3 +684,13 @@ void NA_Axis::FlipXY() {
   RX_.Neg();
   RY_.Neg();
 }
+
+/** Flip the Z axis. Done to ensure Z points in 5' to 3' strand
+  * direction.
+  */
+void NA_Axis::FlipZ() {
+  R_[2] = -R_[2]; // -Zx
+  R_[5] = -R_[5]; // -Zy
+  R_[8] = -R_[8]; // -Zz
+  RZ_.Neg();
+}

--- a/src/AxisType.cpp
+++ b/src/AxisType.cpp
@@ -685,12 +685,17 @@ void NA_Axis::FlipXY() {
   RY_.Neg();
 }
 
-/** Flip the Z axis. Done to ensure Z points in 5' to 3' strand
-  * direction.
+/** Flip the X and Z axes. Equivalent to rotation around the Y axis.
+  * This can happen because of a rotation around chi and is done to
+  * ensure Z points in 5' to 3' strand direction.
   */
-void NA_Axis::FlipZ() {
+void NA_Axis::FlipXZ() {
+  R_[0] = -R_[0]; // -Xx
+  R_[3] = -R_[3]; // -Xy
+  R_[6] = -R_[6]; // -Xz
   R_[2] = -R_[2]; // -Zx
   R_[5] = -R_[5]; // -Zy
   R_[8] = -R_[8]; // -Zz
+  RX_.Neg();
   RZ_.Neg();
 }

--- a/src/AxisType.cpp
+++ b/src/AxisType.cpp
@@ -389,7 +389,7 @@ NA_Base::NA_Base() :
   bchar_('?'),
   type_(UNKNOWN_BASE)
 {
-  std::fill( atomIdx_, atomIdx_+6, -1 );
+  std::fill( atomIdx_, atomIdx_+7, -1 );
 }
 
 // COPY CONSTRUCTOR
@@ -414,7 +414,7 @@ NA_Base::NA_Base(const NA_Base& rhs) :
   inpFitMask_(rhs.inpFitMask_),
   refFitMask_(rhs.refFitMask_)
 {
-  std::copy( rhs.atomIdx_, rhs.atomIdx_+6, atomIdx_ );
+  std::copy( rhs.atomIdx_, rhs.atomIdx_+7, atomIdx_ );
 }
 
 // ASSIGNMENT
@@ -436,7 +436,7 @@ NA_Base& NA_Base::operator=(const NA_Base& rhs) {
 #   endif
     Inp_ = rhs.Inp_;
     hb_ = rhs.hb_;
-    std::copy( rhs.atomIdx_, rhs.atomIdx_+6, atomIdx_ );
+    std::copy( rhs.atomIdx_, rhs.atomIdx_+7, atomIdx_ );
     parmMask_ = rhs.parmMask_;
     inpFitMask_ = rhs.inpFitMask_;
     refFitMask_ = rhs.refFitMask_;
@@ -479,7 +479,7 @@ int NA_Base::Setup_Base(RefBase const& REF, Residue const& RES, int resnum,
   // Save atom names for input coords. Look for specific atom names for
   // calculating things like groove width and pucker.
   int inpatom = 0;
-  std::fill( atomIdx_, atomIdx_+6, -1 );
+  std::fill( atomIdx_, atomIdx_+7, -1 );
   for (int atom = resstart; atom < resstop; ++atom) {
     anames_.push_back( Atoms[atom].Name() );
     // Is this atom P?
@@ -496,6 +496,15 @@ int NA_Base::Setup_Base(RefBase const& REF, Residue const& RES, int resnum,
       atomIdx_[C3p] = inpatom;
     else if (anames_.back() == "C4' " || anames_.back() == "C4* ")
       atomIdx_[C4p] = inpatom;
+    else if (type_ == ADE || type_ == GUA) {
+      // Purine-specific
+      if (anames_.back() == "N9")
+        atomIdx_[NX] = inpatom;
+    } else if (type_ == CYT || type_ == THY || type_ == URA) {
+      // Pyrimidine-specific
+      if (anames_.back() == "N1")
+        atomIdx_[NX] = inpatom;
+    }
     inpatom++;
   }
   // Determine whether sugar atoms are all present.

--- a/src/AxisType.h
+++ b/src/AxisType.h
@@ -21,7 +21,7 @@ class NA_Axis {
     void PrintAxisInfo(const char*) const;
     void FlipYZ();
     void FlipXY();
-    void FlipZ();
+    void FlipXZ();
     Matrix_3x3 const& Rot() const { return R_;      }
     Vec3 const& Oxyz()      const { return origin_; }
     Vec3 const& Rx()        const { return RX_;     }

--- a/src/AxisType.h
+++ b/src/AxisType.h
@@ -21,6 +21,7 @@ class NA_Axis {
     void PrintAxisInfo(const char*) const;
     void FlipYZ();
     void FlipXY();
+    void FlipZ();
     Matrix_3x3 const& Rot() const { return R_;      }
     Vec3 const& Oxyz()      const { return origin_; }
     Vec3 const& Rx()        const { return RX_;     }
@@ -75,6 +76,7 @@ class NA_Base {
     std::string const& BaseName()  const { return basename_;       }
     bool HasPatom()                const { return atomIdx_[PHOS] != -1; }
     bool HasO4atom()               const { return atomIdx_[O4p] != -1;  }
+    bool HasC1atom()               const { return atomIdx_[C1p] != -1;  }
 #   ifdef NASTRUCTDEBUG
     const char* ResName()       const { return *rname_;         }
     const char* RefName(int i)  const { return *(refnames_[i]); }
@@ -84,9 +86,9 @@ class NA_Base {
     const double* HBxyz(int i) const { return Inp_.XYZ(i);              }
     const double* Pxyz()       const { return Inp_.XYZ(atomIdx_[PHOS]); }
     const double* O4xyz()      const { return Inp_.XYZ(atomIdx_[O4p]);  }
+    const double* C1xyz()      const { return Inp_.XYZ(atomIdx_[C1p]);  }
     DataSet_1D* Pucker()       const { return pucker_;                  }
   private:
-    const double* C1xyz()      const { return Inp_.XYZ(atomIdx_[C1p]);  }
     const double* C2xyz()      const { return Inp_.XYZ(atomIdx_[C2p]);  }
     const double* C3xyz()      const { return Inp_.XYZ(atomIdx_[C3p]);  }
     const double* C4xyz()      const { return Inp_.XYZ(atomIdx_[C4p]);  }

--- a/src/AxisType.h
+++ b/src/AxisType.h
@@ -40,8 +40,8 @@ class NA_Axis {
 class RefBase;
 /// Hold information for NA base.
 class NA_Base {
-    /// Type for phosphate/sugar atoms (index into atomIdx_).
-    enum PSType { PHOS, O4p, C1p, C2p, C3p, C4p };
+    /// Type for phosphate/sugar/glycosidic nitrogen atoms (index into atomIdx_).
+    enum PSType { PHOS, O4p, C1p, C2p, C3p, C4p, NX };
   public:
     enum PmethodType { ALTONA=0, CREMER };
     /// Type for each standard NA base.
@@ -77,6 +77,7 @@ class NA_Base {
     bool HasPatom()                const { return atomIdx_[PHOS] != -1; }
     bool HasO4atom()               const { return atomIdx_[O4p] != -1;  }
     bool HasC1atom()               const { return atomIdx_[C1p] != -1;  }
+    bool HasNXatom()               const { return atomIdx_[NX] != -1; }
 #   ifdef NASTRUCTDEBUG
     const char* ResName()       const { return *rname_;         }
     const char* RefName(int i)  const { return *(refnames_[i]); }
@@ -87,6 +88,7 @@ class NA_Base {
     const double* Pxyz()       const { return Inp_.XYZ(atomIdx_[PHOS]); }
     const double* O4xyz()      const { return Inp_.XYZ(atomIdx_[O4p]);  }
     const double* C1xyz()      const { return Inp_.XYZ(atomIdx_[C1p]);  }
+    const double* NXxyz()      const { return Inp_.XYZ(atomIdx_[NX]);   }
     DataSet_1D* Pucker()       const { return pucker_;                  }
   private:
     const double* C2xyz()      const { return Inp_.XYZ(atomIdx_[C2p]);  }
@@ -112,7 +114,7 @@ class NA_Base {
 #   endif  
     Frame Inp_;                     ///< Input coords.
     std::vector<HBType> hb_;        ///< Hydrogen bond type of each Input atom.
-    int atomIdx_[6];                ///< Indices of Input phosphate/sugar atoms.
+    int atomIdx_[7];                ///< Indices of Input phosphate/sugar atoms.
     AtomMask parmMask_;             ///< Mask corresponding to atoms in parm.
     AtomMask inpFitMask_;           ///< Mask of input atoms to be used in RMS fit.
     AtomMask refFitMask_;           ///< Mask of ref atoms to be used in RMS fit.

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.17.5"
+#define CPPTRAJ_INTERNAL_VERSION "V6.18.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.18.0.

- ZDNA (left handed) is now properly detected and parameters have the correct sign.
- Improved base pair detection, especially for parallel strands and/or Hoogsteen base pairing. Renders `guessbp` obsolete.
- Parameters for parallel DNA can now be calculated using 3DNA-type conventions (new default) or Babcock et al. conventions (previous behavior). Can switch with new keyword, `bpmode`.
- Improved Zp parameter calculation; fixed for parallel DNA.
- Add new data set, `<name>[nxyz]` for printing the base pair axes normal (Z) vector.