### PR TITLE
Update version of NetCDF that CPPTRAJ will try to build.

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -96,10 +96,10 @@ jobs:
           fi
 
           if [ "$USE_CMAKE" = "1" ]; then
-            curl -OL ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.6.1.tar.gz
-            tar -zxf netcdf-4.6.1.tar.gz
-            cd netcdf-4.6.1
-            ./configure --disable-netcdf-4 --disable-dap --disable-doxygen --prefix=$HOME
+            curl -OL https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.2.tar.gz
+            tar -zxf v4.9.2.tar.gz
+            cd netcdf-c-4.9.2
+            ./configure --disable-byterange --disable-libxml2 --disable-netcdf-4 --disable-dap --disable-doxygen --prefix=$HOME
             make -j2
             make install
             cd ..

--- a/configure
+++ b/configure
@@ -130,11 +130,11 @@ COMPERR='cpptrajcfg.compile.err'
 COMPOUT='cpptrajcfg.compile.out'
 
 # ----- Variables for downloading libraries ------
-NETCDF_SRCTAR='netcdf-4.6.1.tar.gz'
-NETCDF_SRCDIR='netcdf-4.6.1'
-NETCDF_URL="ftp://ftp.unidata.ucar.edu/pub/netcdf/$NETCDF_SRCTAR"
-NETCDF_OPTS=" --disable-netcdf-4 --disable-dap $windows_hostflag --disable-shared --disable-doxygen"
-NETCDF4_OPTS=" --disable-dap $windows_hostflag --disable-shared --disable-doxygen"
+NETCDF_SRCTAR='v4.9.2.tar.gz'
+NETCDF_SRCDIR='netcdf-c-4.9.2'
+NETCDF_URL="https://github.com/Unidata/netcdf-c/archive/refs/tags/$NETCDF_SRCTAR"
+NETCDF_OPTS=" --disable-byterange --disable-libxml2 --disable-netcdf-4 --disable-dap $windows_hostflag --disable-shared --disable-doxygen"
+NETCDF4_OPTS=" --disable-byterange --disable-libxml2 --disable-dap $windows_hostflag --disable-shared --disable-doxygen"
 
 HDF5_SRCTAR='hdf5-1_10_9.tar.gz'
 HDF5_SRCDIR='hdf5-hdf5-1_10_9'


### PR DESCRIPTION
The NetCDF 4.6.1 TAR file appears deprecated. Use a newer NetCDF TAR file (4.9.2). Disable CURL support for the bundled NetCDF to simplify linking.