### PR TITLE
Fix segfault when performing a second run with a reference after reference structures have been cleared

### DIFF
--- a/src/DataSetList.cpp
+++ b/src/DataSetList.cpp
@@ -1040,6 +1040,7 @@ void DataSetList::ClearRef() {
     for (DataListType::const_iterator ds = RefList_.begin(); ds != RefList_.end(); ++ds)
       delete *ds;
   RefList_.clear();
+  activeRef_ = 0;
   DataList_ = setsToKeep;
 }
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.20.0"
+#define CPPTRAJ_INTERNAL_VERSION "V6.20.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.20.1. Addresses #1039.

Previously, when the reference list was being cleared, the active reference was not cleared, which could cause a segfault. Behavior fixed by this PR.