### PR TITLE
Fix the -DDEBUG compile

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install cmake-data cmake
 
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Compile and test cpptraj
         shell: bash -lex {0}
@@ -137,7 +137,7 @@ jobs:
         sudo apt-get install libfftw3-dev
         sudo apt-get install clang
         sudo apt-get install cmake-data cmake    
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:

--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -14812,7 +14812,7 @@ change [parm <name> | parmindex <#> | <#> |
 \end_layout
 
 \begin_layout LyX-Code
-      bondparm <make1> [<mask2>] {setrk|scalerk|setreq|scalereq} <value>
+      bondparm <mask1> [<mask2>] {setrk|scalerk|setreq|scalereq} <value>
  |
 \end_layout
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.22.2"
+#define CPPTRAJ_INTERNAL_VERSION "V6.22.3"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/src/molsurf.c
+++ b/src/molsurf.c
@@ -6916,6 +6916,7 @@ static int non_axial_trim (int nat, ATOM atom[], RES res[], // NOTE: was void
   n_groups = ig;
 
 #ifdef DEBUG
+  int inew = -1;
   printf ("cusp groups\n");
   i = 0;
   for (ig = 0; ig < n_groups; ++ig) {
@@ -7236,6 +7237,8 @@ static int broken_concave_area (REAL_T probe_rad,
     total_area += broken_concave_face[iface].area;
     *broken_conc_area += broken_concave_face[iface].area;
 #ifdef DEBUG
+    int iedge = -1;
+    int ie = 0;
     printf ("-----\nbroken concave face probe %8.3f%8.3f%8.3f n_cycles %d\n",
             probe[iprobe].pos[0], probe[iprobe].pos[1], probe[iprobe].pos[2],
             broken_concave_face[iface].n_cycles);
@@ -7245,7 +7248,7 @@ static int broken_concave_area (REAL_T probe_rad,
       for (ie = 0; ie < concave_cycle[icycle].nedges; ++ie) {
         iedge = concave_cycle[icycle].edge[ie];
         if (concave_cycle[icycle].edge_direction[ie] == -1) {
-          printf (" !", iedge);
+          printf ("%d !", iedge);
         }
         printf ("%d:%d ", concave_edge[iedge].vert1, concave_edge[iedge].vert2);
       }

--- a/src/molsurf.h
+++ b/src/molsurf.h
@@ -48,6 +48,9 @@ typedef struct atom {
         int n_cycles;                 // cycles of edges associated with atom
         int cycle_start;              // points to start of cyclelist for the atom
         REAL_T area;                  // accessible surf area associated with the atom
+#       ifdef DEBUG
+        int res;
+#       endif
 } ATOM;
 
 typedef struct neighbor_torus {

--- a/src/readline/tparam.c
+++ b/src/readline/tparam.c
@@ -317,7 +317,7 @@ tparam1 (string, outstring, len, up, left, argp)
   return outstring;
 }
 
-#ifdef DEBUG
+/*#ifdef DEBUG
 
 main (argc, argv)
      int argc;
@@ -333,4 +333,4 @@ main (argc, argv)
   return 0;
 }
 
-#endif /* DEBUG */
+#endif*/ /* DEBUG */


### PR DESCRIPTION
Version 6.22.3. Minor fixes to enable compiling when the -DDEBUG flag is present (affects molsurf and readline). This is mainly important for when cpptraj is inside AmberTools.

Also addresses manual typo in #1050 and updates the GitHub checkout action to v4.