### PR TITLE
Pin the cython version. Does not appear to work with cython 3.X.X.

### DIFF
--- a/devtools/ci/environment.yml
+++ b/devtools/ci/environment.yml
@@ -4,7 +4,7 @@ dependencies:
     - python=3.10
     - pyflakes
     - numpy
-    - cython
+    - cython=0.29.36
     - setuptools
     - pytest
     - mock


### PR DESCRIPTION
Recently, the pytraj CI GitHub action has been failing. Local testing indicated this may be due to the recent shift from cython 0.X.X to cython 3.X.X. Pinning the version to 0.29.36 in an attempt to get the pytraj CI working again.