### PR TITLE
If wildcard expansion fails in a list for loop, do not add to the loop.

### DIFF
--- a/src/ForLoop_list.cpp
+++ b/src/ForLoop_list.cpp
@@ -54,7 +54,7 @@ int ForLoop_list::BeginFor(DataSetList const& CurrentVars) {
       // Allow wildcard expansion to fail with a warning.
       if (!files.empty() && files.front().Full().compare( listEntry ) == 0) {
         mprintf("Warning: '%s' selects no files.\n", it->c_str());
-        List_.push_back( listEntry );
+        //List_.push_back( listEntry );
       } else {
         for (File::NameArray::const_iterator fn = files.begin(); fn != files.end(); ++fn)
           List_.push_back( fn->Full() );

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.22.3"
+#define CPPTRAJ_INTERNAL_VERSION "V6.22.4"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.22.4. Fixes an incompatibility with the [AmberMdPrep.sh](https://github.com/drroe/AmberMdPrep) script. 
```
for FILE in final.?.out,final.??.out
  readdata $FILE name MD
done
evalplateau *[Density] name EQ out Eval.agr resultsout Eval.results
```
The evaluation portion would fail if no `final.??.out` files are present. This PR fixes that behavior (restores original behavior).