### PR TITLE
Add command line flag to calculate charge

### DIFF
--- a/doc/cpptraj.lyx
+++ b/doc/cpptraj.lyx
@@ -419,7 +419,7 @@ cpptraj [-p <Top0>] [-i <Input0>] [-y <trajin>] [-x <trajout>]
 \end_layout
 
 \begin_layout LyX-Code
-        [--rng {marsaglia|stdlib|mt|pcg32|xo128}]
+        [--rng {marsaglia|stdlib|mt|pcg32|xo128}] [--charge <mask>]
 \end_layout
 
 \begin_deeper
@@ -580,7 +580,11 @@ cpptraj [-p <Top0>] [-i <Input0>] [-y <trajin>] [-x <trajout>]
 \end_layout
 
 \begin_layout Description
--mr <mask> : Print selected residue numbers to STDOUT.
+-mr
+\begin_inset space ~
+\end_inset
+
+<mask> : Print selected residue numbers to STDOUT.
  Selected residues are written out as 'Selected= 1 2 3 ...'
 \end_layout
 
@@ -593,11 +597,27 @@ cpptraj [-p <Top0>] [-i <Input0>] [-y <trajin>] [-x <trajout>]
 \end_layout
 
 \begin_layout Description
-–resmask <mask> : Print detailed residue selection to STDOUT.
+–resmask
+\begin_inset space ~
+\end_inset
+
+<mask> Print detailed residue selection to STDOUT.
 \end_layout
 
 \begin_layout Description
---rng <type> : Change default random number generator.
+--rng
+\begin_inset space ~
+\end_inset
+
+<type> Change default random number generator.
+\end_layout
+
+\begin_layout Description
+--charge
+\begin_inset space ~
+\end_inset
+
+<mask> Print total charge (in e-) of atoms selected by <mask> to STDOUT.
 \end_layout
 
 \end_deeper

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -73,7 +73,7 @@ void Cpptraj::Usage() {
             "               [-h | --help] [-V | --version] [--defines] [-debug <#>]\n"
             "               [--interactive] [--log <logfile>] [-tl]\n"
             "               [-ms <mask>] [-mr <mask>] [--mask <mask>] [--resmask <mask>]\n"
-            "               [--rng %s]\n"
+            "               [--rng %s] [--charge <mask>]\n"
             "\t-p <Top0>        : * Load <Top0> as a topology file.\n"
             "\t-i <Input0>      : * Read input from file <Input0>.\n"
             "\t-y <trajin>      : * Read from trajectory file <trajin>; same as input 'trajin <trajin>'.\n"
@@ -96,8 +96,8 @@ void Cpptraj::Usage() {
             "\t-mr <mask>       : Print selected residue numbers to STDOUT.\n"
             "\t--mask <mask>    : Print detailed atom selection to STDOUT.\n"
             "\t--resmask <mask> : Print detailed residue selection to STDOUT.\n"
-            "\t--charge <mask>  : Print total charge in e- of atoms selected by <mask>.\n"
             "\t--rng <type>     : Change default random number generator.\n"
+            "\t--charge <mask>  : Print total charge in e- of atoms selected by <mask>.\n"
             "      * Denotes flag may be specified multiple times.\n"
             "\n", CpptrajState::RngKeywords());
 }

--- a/src/Cpptraj.cpp
+++ b/src/Cpptraj.cpp
@@ -96,6 +96,7 @@ void Cpptraj::Usage() {
             "\t-mr <mask>       : Print selected residue numbers to STDOUT.\n"
             "\t--mask <mask>    : Print detailed atom selection to STDOUT.\n"
             "\t--resmask <mask> : Print detailed residue selection to STDOUT.\n"
+            "\t--charge <mask>  : Print total charge in e- of atoms selected by <mask>.\n"
             "\t--rng <type>     : Change default random number generator.\n"
             "      * Denotes flag may be specified multiple times.\n"
             "\n", CpptrajState::RngKeywords());
@@ -271,6 +272,35 @@ std::string Cpptraj::Defines() {
   defined_str.append(" -DHAS_OPENMM");
 #endif
   return defined_str;
+}
+
+/** Calculate the total charge from the command line. */
+int Cpptraj::CalcCharge(Sarray const& topFiles, std::string const& maskexpr)
+const
+{
+  SetWorldSilent(true);
+  if (maskexpr.empty()) {
+    mprinterr("Error: No mask given for '--charge'.\n");
+    return 1;
+  }
+  if (topFiles.empty()) {
+    mprinterr("Error: No topology file specified.\n");
+    return 1;
+  }
+  ParmFile pfile;
+  Topology parm;
+  if (pfile.ReadTopology(parm, topFiles[0], State_.Debug())) return 1;
+  AtomMask tempMask( maskexpr );
+  if (parm.SetupIntegerMask( tempMask )) return 1;
+  if (tempMask.None()) {
+    mprinterr("Error: Nothing selected by mask '%s'\n", maskexpr.c_str());
+    return 1;
+  }
+  double qtotal = 0;
+  for (AtomMask::const_iterator it = tempMask.begin(); it != tempMask.end(); ++it)
+    qtotal += parm[*it].Charge();
+  loudPrintf("%g\n", qtotal);
+  return 0;
 }
 
 /** Process a mask from the command line. */
@@ -520,6 +550,10 @@ Cpptraj::Mode Cpptraj::ProcessCmdLineArgs(int argc, char** argv) {
     } else if ( NotFinalArg(cmdLineArgs, "--resmask", iarg) ) {
       // --resmask: Parse mask string, print selected residue details
       if (ProcessMask( topFiles, refFiles, cmdLineArgs[++iarg], true, true )) return ERROR;
+      return QUIT;
+    } else if ( NotFinalArg(cmdLineArgs, "--charge", iarg) ) {
+      // --charge: Print the total charge of atoms selected by the mask
+      if (CalcCharge( topFiles, cmdLineArgs[++iarg])) return ERROR;
       return QUIT;
     } else if ( NotFinalArg(cmdLineArgs, "--rng", iarg) ) {
       // --rng: Change default RNG

--- a/src/Cpptraj.h
+++ b/src/Cpptraj.h
@@ -20,6 +20,8 @@ class Cpptraj {
     static void Finalize();
     static inline void AddArgs(Sarray&, ArgList const&, int&);
     static inline void ResizeArgs(Sarray const&, Sarray&, const char*);
+    /// Calculate total charge from command line
+    int CalcCharge(Sarray const&, std::string const&) const;
     int ProcessMask(Sarray const&, Sarray const&, std::string const&, bool,bool) const;
     Mode ProcessCmdLineArgs(int, char**);
     int Interactive();

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.23.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.23.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.23.2.

Adds the `--charge` command line flag for calculating charge and printing to stdout, e.g.
```
$ ../bin/cpptraj -p ../test/tz2.parm7 --charge @1,2
0.3747
```