### PR TITLE
Do not use "bad" box info from PDB files

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -148,7 +148,10 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install conda packages
       run: |
-        $CONDA/bin/conda env update --file devtools/ci/environment.yml --name base
+        which conda
+        conda install conda=23.11.0 python=3.10
+        conda --version
+        conda env update --file devtools/ci/environment.yml --name base
     - name: Install cpptraj
       run: |
         export PATH=$HOME/bin:${PATH}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -148,7 +148,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install conda packages
       run: |
-        conda env update --file devtools/ci/environment.yml --name base
+        $CONDA/bin/conda env update --file devtools/ci/environment.yml --name base
     - name: Install cpptraj
       run: |
         export PATH=$HOME/bin:${PATH}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,42 +101,42 @@ pipeline {
                     }
                     post { cleanup { deleteDir() } }
                 }
-                stage("Linux PGI serial build") {
-                    agent {
-                        docker {
-                            // Until we figure out why PGI compilers fail on the master Jenkins node,
-                            // force them to run on Intel CPU slaves
-                            label "pgi && intel-cpu"
-                            image 'ambermd/cpu-build:latest'
-                            alwaysPull true
-                            // Pull the licensed PGI compilers from the host machine (must have
-                            // the compilers installed in /opt/pgi)
-                            args "-v /opt/pgi:/opt/pgi"
-                        }
-                    }
+                //stage("Linux PGI serial build") {
+                //    agent {
+                //        docker {
+                //            // Until we figure out why PGI compilers fail on the master Jenkins node,
+                //            // force them to run on Intel CPU slaves
+                //            label "pgi && intel-cpu"
+                //            image 'ambermd/cpu-build:latest'
+                //            alwaysPull true
+                //            // Pull the licensed PGI compilers from the host machine (must have
+                //            // the compilers installed in /opt/pgi)
+                //            args "-v /opt/pgi:/opt/pgi"
+                //        }
+                //    }
 
-                    steps {
-                        unstash "source"
-                        script {
-                            try {
-                                sh """#!/bin/sh -ex
-                                unset CUDA_HOME
-                                ./configure --with-netcdf --with-fftw3 pgi
-                                make -j6 install
-                                cd test && make test.showerrors
-                                """
-                            } catch (error) {
-                                echo "PGI BUILD AND/OR TEST FAILED"
-                                try {
-                                    pullRequest.comment("The PGI build in Jenkins failed.")
-                                } catch (err2) {
-                                    echo "Could not post a PR comment: ${err2}"
-                                }
-                            }
-                        }
-                    }
-                    post { cleanup { deleteDir() } }
-                }
+                //    steps {
+                //        unstash "source"
+                //        script {
+                //            try {
+                //                sh """#!/bin/sh -ex
+                //                unset CUDA_HOME
+                //                ./configure --with-netcdf --with-fftw3 pgi
+                //                make -j6 install
+                //                cd test && make test.showerrors
+                //                """
+                //            } catch (error) {
+                //                echo "PGI BUILD AND/OR TEST FAILED"
+                //                try {
+                //                    pullRequest.comment("The PGI build in Jenkins failed.")
+                //                } catch (err2) {
+                //                    echo "Could not post a PR comment: ${err2}"
+                //                }
+                //            }
+                //        }
+                //    }
+                //    post { cleanup { deleteDir() } }
+                //}
                 stage("Linux GNU parallel build") {
                     agent {
                         docker {

--- a/src/PDBfile.cpp
+++ b/src/PDBfile.cpp
@@ -483,24 +483,32 @@ void PDBfile::readCRYST1(double* box) {
 }
 
 /** Print a warning to STDOUT if unit cell lengths are strange. */
-static inline void box_warning(const double* box) {
-  if (box[0] == 1.0 && box[1] == 1.0 && box[2] == 1.0)
+static inline int box_warning(const double* box) {
+  if (box[0] == 1.0 && box[1] == 1.0 && box[2] == 1.0) {
     mprintf("Warning: PDB cell lengths are all 1.0 Ang.;"
             " this usually indicates an invalid box.\n");
+    return 1;
+  }
+  return 0;
 }
 
-/** Read box info from CRYST1, verbose. */
-void PDBfile::pdb_Box_verbose(double* box) {
+/** Read box info from CRYST1, verbose.
+  * \return 1 if box seems invalid.
+  */
+int PDBfile::pdb_Box_verbose(double* box) {
   readCRYST1(box);
-  box_warning(box);
+  int isbadbox = box_warning(box);
   mprintf("\tRead CRYST1 info from PDB: a=%g b=%g c=%g alpha=%g beta=%g gamma=%g\n",
           box[0], box[1], box[2], box[3], box[4], box[5]);
+  return isbadbox;
 }
 
-/** Read box info from CRYST1, warn only if box is strange looking. */
-void PDBfile::pdb_Box_terse(double* box) {
+/** Read box info from CRYST1, warn only if box is strange looking.
+  * \return 1 if box seems invalid.
+  */
+int PDBfile::pdb_Box_terse(double* box) {
   readCRYST1(box);
-  box_warning(box);
+  return box_warning(box);
 }
 
 /** Read serial #s of atoms from a CONECT record. */

--- a/src/PDBfile.h
+++ b/src/PDBfile.h
@@ -37,9 +37,9 @@ class PDBfile : public CpptrajFile {
     /// Get charge and radius from PQR ATOM/HETATM record.
     void pdb_ChargeAndRadius(float&, float&);
     /// Set given XYZ array with A/B/C/alpha/beta/gamma from CRYST1 record, verbose.
-    void pdb_Box_verbose(double*);
+    int pdb_Box_verbose(double*);
     /// Set given XYZ array with A/B/C/alpha/beta/gamma from CRYST1 record, terse.
-    void pdb_Box_terse(double*);
+    int pdb_Box_terse(double*);
     /// Set given array with atom and #s of bonded atoms from CONECT record.
     int pdb_Bonds(int*);
     /// \return Link record.

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.23.2"
+#define CPPTRAJ_INTERNAL_VERSION "V6.24.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.24.0.

Some PDBs (like 1FHK) contain `CRYST1` records where the unit cell lengths are all 1.0 Angstrom; this should be ignored (it even says so right in the PDB itself):
```
REMARK 215 NMR DATA.  PROTEIN DATA BANK CONVENTIONS REQUIRE THAT         
REMARK 215 CRYST1 AND SCALE RECORDS BE INCLUDED, BUT THE VALUES ON      
REMARK 215 THESE RECORDS ARE MEANINGLESS.
```
This PR changes cpptraj's behavior so that when this "bad" unit cell info is encountered it is ignored, which prevents bad imaging from taking place. As a result cpptraj will no longer print the bad CRYST1 records.