### PR TITLE
Fix ambpdb build

### DIFF
--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -568,6 +568,7 @@ VMDPLUGIN_OBJECTS= \
 # These objects contain trajectory file functionality. Requires core and file libraries.
 LIBCPPTRAJ_TRAJ_OBJECTS= \
   TrajectoryFile.o \
+  TrajectoryIO.o \
   Trajin_Single.o \
   Trajout_Single.o \
   InputTrajCommon.o \


### PR DESCRIPTION
Add TrajectoryIO.o to LIBCPPTRAJ_TRAJ_OBJECTS in order to fix things that need to link to it (like ambpdb). No code changes, no version bump needed.