### PR TITLE
Add --disable-nczarr flag to netcdf configure

### DIFF
--- a/configure
+++ b/configure
@@ -133,8 +133,8 @@ COMPOUT='cpptrajcfg.compile.out'
 NETCDF_SRCTAR='v4.9.2.tar.gz'
 NETCDF_SRCDIR='netcdf-c-4.9.2'
 NETCDF_URL="https://github.com/Unidata/netcdf-c/archive/refs/tags/$NETCDF_SRCTAR"
-NETCDF_OPTS=" --disable-byterange --disable-libxml2 --disable-netcdf-4 --disable-dap $windows_hostflag --disable-shared --disable-doxygen"
-NETCDF4_OPTS=" --disable-byterange --disable-libxml2 --disable-dap $windows_hostflag --disable-shared --disable-doxygen"
+NETCDF_OPTS=" --disable-byterange --disable-libxml2 --disable-netcdf-4 --disable-dap --disable-nczarr $windows_hostflag --disable-shared --disable-doxygen"
+NETCDF4_OPTS=" --disable-byterange --disable-libxml2 --disable-dap --disable-nczarr $windows_hostflag --disable-shared --disable-doxygen"
 
 HDF5_SRCTAR='hdf5-1_10_9.tar.gz'
 HDF5_SRCDIR='hdf5-hdf5-1_10_9'

--- a/get_library.sh
+++ b/get_library.sh
@@ -209,6 +209,8 @@ $MAKE_COMMAND $MAKE_TARGET > $COMPILE_LOG 2>&1
 if [ $? -ne 0 ] ; then
   echo "Build failed."
   echo "Check $COMPILE_LOG for errors."
+  # DEBUG
+  cat $COMPILE_LOG
   exit 1
 fi
 

--- a/get_library.sh
+++ b/get_library.sh
@@ -210,7 +210,7 @@ if [ $? -ne 0 ] ; then
   echo "Build failed."
   echo "Check $COMPILE_LOG for errors."
   # DEBUG
-  cat $COMPILE_LOG
+  #cat $COMPILE_LOG
   exit 1
 fi
 


### PR DESCRIPTION
Makes the configure for netcdf have fewer dependencies. This used to be covered by the `--disable-dap` flag but the behavior has changed in more recent versions of netcdf.