### PR TITLE
Handle blank lines at the end of Karplus data file for jcoupling action

### DIFF
--- a/src/Action_Jcoupling.cpp
+++ b/src/Action_Jcoupling.cpp
@@ -56,9 +56,16 @@ int Action_Jcoupling::loadKarplus(std::string const& filename) {
   if (buffer == 0) return fileEOF(filename);
   while (buffer != 0) {
     // Skip empty lines (BufferedLine.Line() removes newlines) and comments
-    while (buffer[0]=='\0' || buffer[0]=='#')
+    while (buffer[0]=='\0' || buffer[0]=='#') {
       buffer = KarplusFile.Line();
-    if (buffer == 0) return fileEOF(filename);
+      if (buffer == 0) {
+        if (JcoupleData_.empty())
+          return fileEOF(filename);
+        else
+          break;
+      }
+    }
+    if (buffer == 0) break;
     const char* ptr = buffer;
     // First char is optional type. If optional type is C, then the Karplus 
     // function specified in Perez et al. JACS (2001) 123 will be used, and 

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.27.0"
+#define CPPTRAJ_INTERNAL_VERSION "V6.27.1"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
6.27.1.

Fixes behavior where CPPTRAJ would segfault if there were blank lines at the end of the Karplus data file in the `jcoupling` action.