### PR TITLE
Fix which atoms are reported in DSSP "missing atoms" warning message

### DIFF
--- a/src/Action_DSSP.cpp
+++ b/src/Action_DSSP.cpp
@@ -600,8 +600,8 @@ Action::RetType Action_DSSP::Setup(ActionSetup& setup)
       if (Res->IsMissingAtoms()) {
         mprintf("Warning: Res %s is missing atoms", setup.Top().TruncResNameNum( Res->Num() ).c_str());
         if (Res->C() == -1)  mprintf(" %s", *BB_C_);
-        if (Res->O() == -1)  mprintf(" %s", *BB_N_);
-        if (Res->N() == -1)  mprintf(" %s", *BB_O_);
+        if (Res->N() == -1)  mprintf(" %s", *BB_N_);
+        if (Res->O() == -1)  mprintf(" %s", *BB_O_);
         if (Res->H() == -1)  mprintf(" %s", *BB_H_);
         if (Res->CA() == -1) mprintf(" %s", *BB_CA_);
         mprintf("\n");

--- a/src/Action_DSSP.cpp
+++ b/src/Action_DSSP.cpp
@@ -600,8 +600,8 @@ Action::RetType Action_DSSP::Setup(ActionSetup& setup)
       if (Res->IsMissingAtoms()) {
         mprintf("Warning: Res %s is missing atoms", setup.Top().TruncResNameNum( Res->Num() ).c_str());
         if (Res->C() == -1)  mprintf(" %s", *BB_C_);
-        if (Res->N() == -1)  mprintf(" %s", *BB_N_);
         if (Res->O() == -1)  mprintf(" %s", *BB_O_);
+        if (Res->N() == -1)  mprintf(" %s", *BB_N_);
         if (Res->H() == -1)  mprintf(" %s", *BB_H_);
         if (Res->CA() == -1) mprintf(" %s", *BB_CA_);
         mprintf("\n");

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.27.1"
+#define CPPTRAJ_INTERNAL_VERSION "V6.27.2"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
6.27.2. Related to issue #1090. When reporting missing atoms, cpptraj was mistakenly reporting the `N` atom when `O` was missing and vice versa. This PR fixes the problem.