### PR TITLE
Fix compilation on ARM based systems

### DIFF
--- a/src/StringRoutines.cpp
+++ b/src/StringRoutines.cpp
@@ -93,23 +93,20 @@ int DigitWidth(long int numberIn) {
   return (minusSign + numi);
 }
 
-// FloatWidth()
-/** \return the number of characters necessary to express given float. */
-int FloatWidth(double floatIn) {
-  int total_width = 0;
-  if (floatIn < 0)
-    total_width = 1;
-  else if (floatIn > 0)
-    total_width = 0;
-  else {
-    // Cannot take log of 0. Return 3 chars for 0.0.
-    return 3;
-  }
-  double float_exponent = fabs( log10( floatIn ) );
-  ++float_exponent;
-
-  total_width += (int)float_exponent; // Cast to int implicitly rounds down
-  return total_width;
+/** \return the number of characters necessary for a minimal representation of
+  *         the fractional part of a floating point number, i.e. the number of
+  *         leading zeros plus 1. characters necessary to express given float.
+  */
+int MinNumFracChars(double floatIn) {
+  // Split number into integer and fractional part
+  double intpart = 0;
+  double frac = modf(floatIn, &intpart);
+  // Leading zeros
+  int n_leading_zeros = 0;
+  double absfrac = fabs(frac);
+  if (absfrac > 0)
+    n_leading_zeros = (int)ceil( fabs( log10( absfrac ) ) ) - 1;
+  return n_leading_zeros + 1;
 }
 
 // ---------- STRING CONVERSION ROUTINES --------------------------------------- 

--- a/src/StringRoutines.cpp
+++ b/src/StringRoutines.cpp
@@ -96,9 +96,20 @@ int DigitWidth(long int numberIn) {
 // FloatWidth()
 /** \return the number of characters necessary to express given float. */
 int FloatWidth(double floatIn) {
+  int total_width = 0;
+  if (floatIn < 0)
+    total_width = 1;
+  else if (floatIn > 0)
+    total_width = 0;
+  else {
+    // Cannot take log of 0. Return 3 chars for 0.0.
+    return 3;
+  }
   double float_exponent = fabs( log10( floatIn ) );
   ++float_exponent;
-  return (int)float_exponent; // Cast to int implicitly rounds down
+
+  total_width += (int)float_exponent; // Cast to int implicitly rounds down
+  return total_width;
 }
 
 // ---------- STRING CONVERSION ROUTINES --------------------------------------- 

--- a/src/StringRoutines.h
+++ b/src/StringRoutines.h
@@ -15,8 +15,8 @@ std::string AppendNumber(std::string const &, int);
 int WildcardMatch(std::string const&, std::string const&);
 /// \return number of characters needed to represent given digit.
 int DigitWidth(long int);
-/// \return number of characters needed to represent given floating point.
-int FloatWidth(double);
+/// \return Min number of chars needed to represent fractional part of given floating point.
+int MinNumFracChars(double);
 /// Remove any trailing whitespace from string.
 void RemoveTrailingWhitespace(std::string &);
 /// \return string stripped of trailing whitespace.

--- a/src/TextFormat.cpp
+++ b/src/TextFormat.cpp
@@ -59,7 +59,7 @@ void TextFormat::SetCoordFormat(size_t maxFrames, double min, double step,
   int col_width = DigitWidth( (long int)maxCoord );
   // Check if the precision is enough to support the step size.
   if (step < 1.0) {
-    int prec_exp_width = FloatWidth( step );
+    int prec_exp_width = MinNumFracChars( step );
     if (prec_exp_width > col_precision)
       col_precision = prec_exp_width;
   }

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.27.3"
+#define CPPTRAJ_INTERNAL_VERSION "V6.28.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 6.28.0.

This should fix the test failures on ARM systems observed in #1070 (I finally got access to an ARM system for testing). The problem was simple; the function that is supposed to detect the number of leading zeros in a floating point number fractional part wasn't properly protected against a value of 0 being passed to `log10()`. On ARM systems this failure lead to bad precision values which in turn gave bad output to ASCII data files. This PR fixes the behavior.