### PR TITLE
Add error message to 'for inmask' when no topology is present

### DIFF
--- a/src/ForLoop_mask.cpp
+++ b/src/ForLoop_mask.cpp
@@ -47,7 +47,10 @@ int ForLoop_mask::SetupFor(CpptrajState& State, ArgList& argIn) {
   }
   Topology* top = State.DSL().GetTopByIndex( argIn );
   if (top != 0) currentTop_ = top;
-  if (currentTop_ == 0) return 1;
+  if (currentTop_ == 0) {
+    mprinterr("Error: No topology found for mask for loop.\n");
+    return 1;
+  }
   // Get the variable name
   if (SetupLoopVar( State.DSL(), argIn.GetStringNext() )) return 1;
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.29.7"
+#define CPPTRAJ_INTERNAL_VERSION "V6.29.8"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
6.29.8. Previously when using `for inmask` it would fail silently if no topology was present. This PR adds an error message to make it clear to the user what went wrong.