### PR TITLE
Try to improve compatibility with system readline libraries

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -149,7 +149,7 @@ jobs:
     - name: Install conda packages
       run: |
         which conda
-        conda install conda=23.11.0 python=3.11
+        conda install conda=24.11.0 python=3.10
         conda --version
         conda env update --file devtools/ci/environment.yml --name base
     - name: Install cpptraj

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -138,10 +138,10 @@ jobs:
         sudo apt-get install clang
         sudo apt-get install cmake-data cmake    
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.10'
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -138,10 +138,10 @@ jobs:
         sudo apt-get install clang
         sudo apt-get install cmake-data cmake    
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
@@ -149,7 +149,7 @@ jobs:
     - name: Install conda packages
       run: |
         which conda
-        conda install conda=23.11.0 python=3.10
+        conda install conda=23.11.0 python=3.11
         conda --version
         conda env update --file devtools/ci/environment.yml --name base
     - name: Install cpptraj

--- a/configure
+++ b/configure
@@ -1083,8 +1083,26 @@ EOF
   if [ "${LIB_STAT[$LREADLINE]}" = 'specified' ] ; then
     TestProgram "  Checking Readline" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]}"
   else
+    # Test with just -lreadline
     TestProgram silent "  Checking Readline" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]}"
-    if [ $? -ne 0 ] ; then
+    lreadline_err=$?
+    if [ $lreadline_err -ne 0 ] ; then
+      # Try -ltermcap
+      TestProgram silent "  Checking Readline with termcap" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]} -ltermcap"
+      lreadline_err=$?
+      if [ $lreadline_err -eq 0 ] ; then
+        LIB_FLAG[$LREADLINE]="${LIB_FLAG[$LREADLINE]} -ltermcap"
+      fi
+    fi
+    if [ $lreadline_err -ne 0 ] ; then
+      # Try -lncurses
+      TestProgram silent "  Checking Readline with ncurses" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]} -lncurses"
+      lreadline_err=$?
+      if [ $lreadline_err -eq 0 ] ; then
+        LIB_FLAG[$LREADLINE]="${LIB_FLAG[$LREADLINE]} -lncurses"
+      fi
+    fi
+    if [ $lreadline_err -ne 0 ] ; then
       echo "No readline available; using bundled readline."
       LIB_STAT[$LREADLINE]='bundled'
       LIB_FLAG[$LREADLINE]='readline/libreadline.a'

--- a/configure
+++ b/configure
@@ -1079,7 +1079,18 @@ static char *line_read = (char *)NULL;
 void Unused() { line_read = readline(""); }
 int main() { return 0; }
 EOF
-  TestProgram "  Checking Readline" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]}"
+
+  if [ "${LIB_STAT[$LREADLINE]}" = 'specified' ] ; then
+    TestProgram "  Checking Readline" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]}"
+  else
+    TestProgram silent "  Checking Readline" "$CXX" "$CXXFLAGS ${LIB_INCL[$LREADLINE]}" testp.cpp "${LIB_FLAG[$LREADLINE]}"
+    if [ $? -ne 0 ] ; then
+      echo "No readline available; using bundled readline."
+      LIB_STAT[$LREADLINE]='bundled'
+      LIB_FLAG[$LREADLINE]='readline/libreadline.a'
+      LIB_INCL[$LREADLINE]='-I.'
+    fi
+  fi
 }
 
 TestXdrfile() {

--- a/configure
+++ b/configure
@@ -1701,8 +1701,8 @@ SetupCompilers() {
       # Check the GNU compiler version
       CheckCompilerVersion gcc
       # Set version-specific flags
-      if [ $cc_version_major -ge 14 ] ; then
-        # Needed for readline with gcc >= 14
+      if [ $cc_version_major -ge 13 ] ; then
+        # Needed for readline with gcc >= 13
         CFLAGS="$CFLAGS -D_DEFAULT_SOURCE -D_XOPEN_SOURCE"
       fi
       ;;

--- a/configure
+++ b/configure
@@ -318,9 +318,9 @@ LIB_D_ON[$LFFTW3]='-DFFTW_FFT'
 LIB_DOFF[$LFFTW3]=''
 LIB_TYPE[$LFFTW3]='cpp'
 
-LIB_STAT[$LREADLINE]='bundled'
+LIB_STAT[$LREADLINE]='enabled'
 LIB_CKEY[$LREADLINE]='readline'
-LIB_HOME[$LREADLINE]='readline'
+LIB_HOME[$LREADLINE]=''
 LIB_FLAG[$LREADLINE]='-lreadline'
 LIB_STTC[$LREADLINE]='libreadline.a'
 LIB_D_ON[$LREADLINE]=''
@@ -1073,7 +1073,7 @@ EOF
 TestReadline() {
   cat > testp.cpp <<EOF
 #include <cstdio>
-#include <readline.h>
+#include <readline/readline.h>
 static char *line_read = (char *)NULL;
 // Do not want to actually run this so leave outside main
 void Unused() { line_read = readline(""); }
@@ -1503,23 +1503,24 @@ SetupLibraries() {
             lflag="-L$lhdir ${LIB_FLAG[$i]}"
           fi
           # Library-specific CPPTRAJ_INC fixes when home specified.
-          if [ $i -eq $LREADLINE ] ; then
-            linc="$linc/readline"
-          fi
+          #if [ $i -eq $LREADLINE ] ; then
+          #  linc="$linc/readline"
+          #fi
           if [ $i -eq $LXDRFILE ] ; then
             linc="$linc/xdrfile"
           fi
         fi
         # Library-specific flag fixes
-        if [ $i -eq $LREADLINE ] ; then
+#        if [ $i -eq $LREADLINE ] ; then
           # For external readline, we need to link libtermcap for windows
           # and libncurses for Linux
           #if [ $USE_WINDOWS -eq 1 ]; then
-            lflag="$lflag -ltermcap"
+#            lflag="$lflag -ltermcap"
           #else
           #  lflag="$lflag -lncurses"
           #fi
-        elif [ $i -eq $LSANDER ] ; then
+#        elif [ $i -eq $LSANDER ] ; then
+        if [ $i -eq $LSANDER ] ; then
           # Always specify libsander location to prevent pulling in
           # other amber libraries.
           if [ ! -f "${LIB_FLAG[$LSANDER]}" ] ; then

--- a/src/ReadLine.cpp
+++ b/src/ReadLine.cpp
@@ -8,8 +8,8 @@
 #   include <iostream>
 #else
 #   define READLINE_LIBRARY
-#   include <readline.h>
-#   include <history.h>
+#   include <readline/readline.h>
+#   include <readline/history.h>
 #endif
 #include "ReadLine.h"
 #include "Command.h"

--- a/src/readline/CMakeLists.txt
+++ b/src/readline/CMakeLists.txt
@@ -43,4 +43,5 @@ add_compile_options(${OPT_CFLAGS})
 add_library(readline STATIC ${CPPTRAJ_READLINE_SOURCES})
 target_compile_definitions(readline PRIVATE HAVE_CONFIG_H=1) # make sure the code uses the premade config.h
 make_pic_if_needed(readline)
+target_include_directories(readline PUBLIC .)
 target_include_directories(readline PUBLIC ../)

--- a/src/readline/CMakeLists.txt
+++ b/src/readline/CMakeLists.txt
@@ -43,4 +43,4 @@ add_compile_options(${OPT_CFLAGS})
 add_library(readline STATIC ${CPPTRAJ_READLINE_SOURCES})
 target_compile_definitions(readline PRIVATE HAVE_CONFIG_H=1) # make sure the code uses the premade config.h
 make_pic_if_needed(readline)
-target_include_directories(readline PUBLIC .)
+target_include_directories(readline PUBLIC ../)


### PR DESCRIPTION
Change the way `readline` is included so that it is consistent between the internal `readline` and system `readline`s. Also add better checks for whether `ltermcap` or `lncurses` is needed. Should help the conda package.