### PR TITLE
Update handling of Zlib by configure

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -145,13 +145,17 @@ jobs:
     - name: Install conda packages
       run: |
         which conda
-        conda install conda=24.11.0 python=3.12
+        conda install conda python=3.12
         conda --version
         conda env update --file devtools/ci/environment.yml --name base
     - name: Install cpptraj
       run: |
         export PATH=$HOME/bin:${PATH}
         export LD_LIBRARY_PATH=$HOME/lib:${LD_LIBRARY_PATH}
+        export PATH=$CONDA/bin:${PATH}
+        export LD_LIBRARY_PATH=$CONDA/lib:${LD_LIBRARY_PATH}
+        echo $PATH
+        echo $LD_LIBRARY_PATH
         export MAKE_COMMAND="make -j2"
         ./configure --buildlibs -openmp -shared gnu
         source cpptraj.sh
@@ -159,10 +163,14 @@ jobs:
     - name: Install pytraj
       run: |        
         git clone https://github.com/Amber-MD/pytraj.git
+        export PATH=$CONDA/bin:${PATH}
+        export LD_LIBRARY_PATH=$CONDA/lib:${LD_LIBRARY_PATH}
         source cpptraj.sh
         cd pytraj
         python setup.py install
         cd ..
     - name: Test with pytest
       run: |
+        export PATH=$CONDA/bin:${PATH}
+        export LD_LIBRARY_PATH=$CONDA/lib:${LD_LIBRARY_PATH}
         source cpptraj.sh && cd pytraj/tests && pytest -vs --ignore=test_parallel_pmap

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -138,10 +138,10 @@ jobs:
         sudo apt-get install clang
         sudo apt-get install cmake-data cmake    
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
@@ -149,7 +149,7 @@ jobs:
     - name: Install conda packages
       run: |
         which conda
-        conda install conda=24.11.0 python=3.10
+        conda install conda=24.11.0 python=3.12
         conda --version
         conda env update --file devtools/ci/environment.yml --name base
     - name: Install cpptraj

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -156,8 +156,9 @@ jobs:
         export LD_LIBRARY_PATH=$CONDA/lib:${LD_LIBRARY_PATH}
         echo $PATH
         echo $LD_LIBRARY_PATH
+        ls $CONDA/lib
         export MAKE_COMMAND="make -j2"
-        ./configure --buildlibs -openmp -shared gnu
+        ./configure --buildlibs -openmp -shared --with-zlib=$CONDA --with-bzlib=$CONDA --with-hdf5=$CONDA --with-netcdf=$CONDA --with-fftw3=$CONDA gnu
         source cpptraj.sh
         make -j2 libcpptraj
     - name: Install pytraj

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -131,10 +131,6 @@ jobs:
     steps:
     - name: Install prerequisite packages
       run: |
-        sudo apt-get install gfortran
-        sudo apt-get install libbz2-dev
-        sudo apt-get install libblas-dev liblapack-dev
-        sudo apt-get install libfftw3-dev
         sudo apt-get install clang
         sudo apt-get install cmake-data cmake    
     - uses: actions/checkout@v4

--- a/configure
+++ b/configure
@@ -146,8 +146,8 @@ BZIP2_SRCDIR=''
 BZIP2_URL="https://www.sourceware.org/pub/bzip2/$BZIP2_SRCTAR"
 BZIP2_OPTS=''
 
-ZLIB_SRCTAR='zlib-1.2.11.tar.gz'
-ZLIB_SRCDIR='zlib-1.2.11'
+ZLIB_SRCTAR='zlib-1.3.1.tar.gz'
+ZLIB_SRCDIR='zlib-1.3.1'
 ZLIB_URL="https://zlib.net/$ZLIB_SRCTAR"
 ZLIB_OPTS=''
 
@@ -719,9 +719,15 @@ EOF
       TestProgram $BUILDTESTOPT "  Checking for bundled HDF5" "$CXX" "$CXXFLAGS ${LIB_INCL[$LHDF5]}" testp.cpp "${LIB_FLAG[$LHDF5]}"
       if [ $? -ne 0 ] ; then
         CheckRebuild "HDF5" "${LIB_FLAG[$LHDF5]}"
+	# If zlib was specified, pass that to hdf5
+        if [ "${LIB_STAT[$LZIP]}"='specified' ] ; then
+          hdf5zlib="--with-zlib=${LIB_HOME[$LZIP]}"
+	else
+          hdf5zlib=''
+	fi
         # See if user would like to get HDF5 
         PREFIX=$CPPTRAJHOME CC=$CC CFLAGS=$CFLAGS LIBNAME='hdf5' \
-            SRCDIR=$HDF5_SRCDIR SRCTAR=$HDF5_SRCTAR URL=$HDF5_URL ./get_library.sh $REBUILDOPT $HDF5_OPTS
+            SRCDIR=$HDF5_SRCDIR SRCTAR=$HDF5_SRCTAR URL=$HDF5_URL ./get_library.sh $REBUILDOPT $HDF5_OPTS $hdf5zlib
         if [ $? -ne 0 ] ; then
           ErrMsg "No HDF5 available. To build without HDF5 specify '-nohdf5'."
           exit 1

--- a/configure
+++ b/configure
@@ -720,7 +720,7 @@ EOF
       if [ $? -ne 0 ] ; then
         CheckRebuild "HDF5" "${LIB_FLAG[$LHDF5]}"
 	# If zlib was specified, pass that to hdf5
-        if [ "${LIB_STAT[$LZIP]}"='specified' ] ; then
+        if [ "${LIB_STAT[$LZIP]}" = 'specified' ] ; then
           hdf5zlib="--with-zlib=${LIB_HOME[$LZIP]}"
 	else
           hdf5zlib=''

--- a/devtools/ci/environment.yml
+++ b/devtools/ci/environment.yml
@@ -9,3 +9,8 @@ dependencies:
     - pytest
     - mock
     - curl
+    - gcc_linux-64
+    - gxx_linux-64
+    - gfortran_linux-64
+    - netcdf4
+    - fftw

--- a/devtools/ci/environment.yml
+++ b/devtools/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
     - python=3.12
     - pyflakes
-    - numpy=2.2.1
+    - numpy=2.0.0
     - cython=0.29.36
     - setuptools
     - pytest

--- a/devtools/ci/environment.yml
+++ b/devtools/ci/environment.yml
@@ -1,9 +1,9 @@
 channels:
     - conda-forge
 dependencies:
-    - python=3.10
+    - python=3.12
     - pyflakes
-    - numpy=2.0.0
+    - numpy=2.2.1
     - cython=0.29.36
     - setuptools
     - pytest

--- a/get_library.sh
+++ b/get_library.sh
@@ -196,7 +196,7 @@ if [ -z "$MAKE_COMMAND" ] ; then
   elif [ $NPROC -le 2 ] ; then
     MAKE_COMMAND='make'
   else
-    HALF=`echo "$NPROC / 2" | bc`
+    ((HALF = $NPROC / 2))
     MAKE_COMMAND="make -j$HALF"
   fi
   echo "    MAKE_COMMAND is not set; set to '$MAKE_COMMAND'"


### PR DESCRIPTION
Updates the downloaded zlib version to something more current. Make sure if zlib is built/specified it is passed to HDF5 (if also being built). Remove dependence on `bc`.