### PR TITLE
Fix code alert. Improve Cmake.

### DIFF
--- a/configure
+++ b/configure
@@ -2516,11 +2516,11 @@ AddCmakePrefixPath() {
   # Search for existing
   for ((idx1=0; idx1 < $icpp; idx1++)) ; do
     if [ "$1" = "${cmake_prefix_paths[$idx1]}" ] ; then
-      echo DEBUG duplicate path $1
+      #echo DEBUG duplicate path $1
       return 0
     fi
   done
-  echo add cmake prefix path $icpp $1
+  #echo DEBUG add cmake prefix path $icpp $1
   cmake_prefix_paths[$icpp]=$1
   ((icpp++))
 }
@@ -2603,7 +2603,7 @@ SetupCmake() {
   icpp=0
   for ((idx=0; idx < $NLIB; idx++)) ; do
     if [ "${LIB_STAT[$idx]}" = 'specified' ] ; then
-      echo Lib $idx # DEBUG
+      #echo Lib $idx # DEBUG
       AddCmakePrefixPath "${LIB_HOME[$idx]}"
     fi
   done

--- a/configure
+++ b/configure
@@ -195,6 +195,7 @@ USE_PROFILE=0     # 0 = no profiling, 1 = C++ profiling, 2 = GLIBC profiling, 3 
 USE_AMBERLIB=0    # 1 = Use AMBERHOME to fill in NetCDF/BLAS/LAPACK/ARPACK as needed
 BUILD_LIBS=0      # 1 = Means automatically say yes to building enabled libs when not present.
 BUILD_MPI=''      # If not empty, attempt to download and build specified mpi dist.
+icpp=0            # Used to count cmake_prefix_paths
 
 USE_SINGLEENSEMBLE=0 # Enable support for single ensemble trajectories
 USE_CPPTRAJDEBUG=0   # Enable internal cpptraj debug flags
@@ -2510,6 +2511,20 @@ EOF
 }
 
 #-------------------------------------------------------------------------------
+# Add cmake prefix path
+AddCmakePrefixPath() {
+  # Search for existing
+  for ((i=$icpp; i < $icpp; i++)) ; do
+    if [ "$1" = "${cmake_prefix_paths[$i]}" ] ; then
+      echo DEBUG duplicate path $1
+      return 0
+    fi
+  done
+  echo add cmake prefix path $icpp $1
+  cmake_prefix_paths[$icpp]=$1
+  ((icpp++))
+}
+
 # Use cmake to configure build.
 SetupCmake() {
   CMAKE=`which cmake`
@@ -2584,6 +2599,25 @@ SetupCmake() {
   if [ $COMPILE_VERBOSE -eq 1 ] ; then
     cmake_options="$cmake_options -DCMAKE_VERBOSE_MAKEFILE=TRUE"
   fi
+  # Libraries
+  icpp=0
+  if [ "${LIB_STAT[$LNETCDF]}" = 'specified' ] ; then
+    AddCmakePrefixPath "${LIB_HOME[$LNETCDF]}"
+  fi
+  if [ "${LIB_STAT[$LZIP]}" = 'specified' ] ; then
+    AddCmakePrefixPath "${LIB_HOME[$LZIP]}"
+  fi
+  if [ $icpp -gt 0 ] ; then
+    cmppstring=""
+    for ((i=0; i < $icpp; i++)) ; do
+      if [ ! -z "$cmppstring" ] ; then
+        cmppstring="$cmppstring;${cmake_prefix_paths[$i]}"
+      else
+        cmppstring="${cmake_prefix_paths[$i]}"
+      fi
+    done
+    cmake_options="$cmake_options -DCMAKE_PREFIX_PATH=$cmppstring"
+  fi  
   echo "  Cmake options: $WORKDIR $cmake_options"
   # Run cmake
   $CMAKE $WORKDIR $cmake_options

--- a/configure
+++ b/configure
@@ -2514,8 +2514,8 @@ EOF
 # Add cmake prefix path
 AddCmakePrefixPath() {
   # Search for existing
-  for ((i=$icpp; i < $icpp; i++)) ; do
-    if [ "$1" = "${cmake_prefix_paths[$i]}" ] ; then
+  for ((idx1=0; idx1 < $icpp; idx1++)) ; do
+    if [ "$1" = "${cmake_prefix_paths[$idx1]}" ] ; then
       echo DEBUG duplicate path $1
       return 0
     fi
@@ -2601,19 +2601,29 @@ SetupCmake() {
   fi
   # Libraries
   icpp=0
-  if [ "${LIB_STAT[$LNETCDF]}" = 'specified' ] ; then
-    AddCmakePrefixPath "${LIB_HOME[$LNETCDF]}"
-  fi
-  if [ "${LIB_STAT[$LZIP]}" = 'specified' ] ; then
-    AddCmakePrefixPath "${LIB_HOME[$LZIP]}"
-  fi
+  for ((idx=0; idx < $NLIB; idx++)) ; do
+    if [ "${LIB_STAT[$idx]}" = 'specified' ] ; then
+      echo Lib $idx # DEBUG
+      AddCmakePrefixPath "${LIB_HOME[$idx]}"
+    fi
+  done
+  #if [ "${LIB_STAT[$LNETCDF]}" = 'specified' ] ; then
+  #  AddCmakePrefixPath "${LIB_HOME[$LNETCDF]}"
+  #fi
+  #if [ "${LIB_STAT[$LZIP]}" = 'specified' ] ; then
+  #  AddCmakePrefixPath "${LIB_HOME[$LZIP]}"
+  #fi
+  #if [ "${LIB_STAT[$LBZIP]}" = 'specified' ] ; then
+  #  AddCmakePrefixPath "${LIB_HOME[$LBZIP]}"
+  #fi
+
   if [ $icpp -gt 0 ] ; then
     cmppstring=""
-    for ((i=0; i < $icpp; i++)) ; do
+    for ((idx=0; idx < $icpp; idx++)) ; do
       if [ ! -z "$cmppstring" ] ; then
-        cmppstring="$cmppstring;${cmake_prefix_paths[$i]}"
+        cmppstring="$cmppstring;${cmake_prefix_paths[$idx]}"
       else
-        cmppstring="${cmake_prefix_paths[$i]}"
+        cmppstring="${cmake_prefix_paths[$idx]}"
       fi
     done
     cmake_options="$cmake_options -DCMAKE_PREFIX_PATH=$cmppstring"

--- a/src/TextBlockBuffer.cpp
+++ b/src/TextBlockBuffer.cpp
@@ -68,7 +68,7 @@ int TextBlockBuffer::BlockToDoubles(double* darray) {
   {
     Line();
     char* ptr = BufferPosition();
-    if (*ptr == '\0' || ptr == 0) return (int)elt;
+    if (ptr == 0 || *ptr == '\0') return (int)elt;
     unsigned int nRemaining = Nelts_ - elt;
     unsigned int maxcol = std::min(Ncols_, nRemaining);
     // Loop over columns in line

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.29.10"
+#define CPPTRAJ_INTERNAL_VERSION "V6.29.11"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif

--- a/src/tng/CMakeLists.txt
+++ b/src/tng/CMakeLists.txt
@@ -27,6 +27,10 @@ add_compile_options(${OPT_CFLAGS})
 add_library(tng_io STATIC ${TNG_IO_SOURCES})
 make_pic_if_needed(tng_io)
 target_include_directories(tng_io PUBLIC .)
+if(zlib_ENABLED)
+        include_directories(${ZLIB_INCLUDE_DIRS})
+endif()
+
 
 # checks based on tng_io's cmake script
 check_all_includes(C inttypes.h)


### PR DESCRIPTION
Version 6.29.11.

Fix code scan alert number 34.

Fix TNG build for cmake when zlib has been specified.

For the `configure`-based cmake build, respect the `--with-<lib>` flags.