### PR TITLE
Add missing include 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CPPTRAJ see the following publication:
 Disclaimer and Copyright
 ========================
 
-CPPTRAJ is Copyright (c) 2010-2023 Daniel R. Roe.
+CPPTRAJ is Copyright (c) 2010-2025 Daniel R. Roe.
 The terms for using, copying, modifying, and distributing CPPTRAJ are
 specified in the file LICENSE.
 

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -2,6 +2,7 @@
 #define INC_MATRIX_H
 #include "ArrayIterator.h"
 #include <cmath> // For linear least squares
+#include <algorithm> // for copy()
 /// Two-dimensional matrix template.
 template <class T> class Matrix {
 // TODO: Type may not be necessary here if in DataSet_2D

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V6.29.12"
+#define CPPTRAJ_INTERNAL_VERSION "V6.29.13"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
V6.29.13.

Add missing include to `Matrix.h` needed for compilation with clang++ (credit to @dacase ).