### PR TITLE
Ensure MPI tests work for higher process counts

### DIFF
--- a/test/Test_2DRMS/RunTest.sh
+++ b/test/Test_2DRMS/RunTest.sh
@@ -77,15 +77,19 @@ DoTest nofit.dat.save nofit.dat
 # Test 7 - coords with velocities
 TOP=''
 CRD=''
-cat > rms.in <<EOF
+UNITNAME="2D RMSD test, read coords with velocity info"
+CheckFor maxthreads 9
+if [ $? -eq 0 ] ; then
+  cat > rms.in <<EOF
 parm ../rGACC.full.parm7
 for i=1;i<10;i++
   trajin ../rGACC.full.nc
 done
 2drms crd1 :1-4&!@H= out rgacc.dat nosquare2d
 EOF
-RunCpptraj "2D RMSD test, read coords with velocity info"
-DoTest rgacc.dat.save rgacc.dat
+  RunCpptraj "$UNITNAME"
+  DoTest rgacc.dat.save rgacc.dat
+fi
 
 # Test 8 - 2drms with quaternion
 cat > rms.in <<EOF

--- a/test/Test_MinImage/RunTest.sh
+++ b/test/Test_MinImage/RunTest.sh
@@ -20,7 +20,10 @@ RunCpptraj "Minimum Image test."
 DoTest min.dat.save min.dat
 DoTest toface.dat.save toface.dat
 
-cat > test.pdb <<EOF
+UNITNAME="Simple distance to unit cell face test."
+CheckFor maxthreads 7
+if [ $? -eq 0 ] ; then
+  cat > test.pdb <<EOF
 CRYST1    4.000    4.000    4.000  90.00  90.00  90.00 P 1           2         
 MODEL     1 
 ATOM      1  N   THR A   1S      2.000   2.000   2.000  1.00 65.41           N 
@@ -45,15 +48,16 @@ ATOM      1  N   THR A   1S      2.000   2.000   3.000  1.00 65.41           N
 ENDMDL
 END                                                                             
 EOF
-cat > min.in <<EOF
+  cat > min.in <<EOF
 noprogress
 parm test.pdb
 trajin test.pdb
 minimage Test toface @1 out test.toface.dat
 run
 EOF
-RunCpptraj "Simple distance to unit cell face test."
-DoTest test.toface.dat.save test.toface.dat
+  RunCpptraj "$UNITNAME"
+  DoTest test.toface.dat.save test.toface.dat
+fi
 
 EndTest
 exit 0

--- a/test/Test_MinMaxDist/RunTest.sh
+++ b/test/Test_MinMaxDist/RunTest.sh
@@ -27,7 +27,10 @@ RunCpptraj "Min/max distance by atom tests"
 DoTest tz2.byatom.dat.save tz2.byatom.dat
 DoTest tz2.byatom.1.dat.save tz2.byatom.1.dat
 
-cat > mmdist.in <<EOF
+UNITNAME="Min/max distance by residue tests"
+CheckFor maxthreads 10
+if [ $? -eq 0 ] ; then
+  cat > mmdist.in <<EOF
 parm ../tz2.truncoct.parm7
 trajin ../tz2.truncoct.crd
 
@@ -36,11 +39,15 @@ maxdist name ResMax1 mask1 :1-7 byres out tz2.byres.1.dat
 mindist name ResMin2 mask1 :2-4 mask2 :9-11 byres out tz2.byres.2.dat
 maxdist name ResMax2 mask1 :2-4 mask2 :9-11 byres out tz2.byres.2.dat
 EOF
-RunCpptraj "Min/max distance by residue tests"
-DoTest tz2.byres.1.dat.save tz2.byres.1.dat
-DoTest tz2.byres.2.dat.save tz2.byres.2.dat
+  RunCpptraj "$UNITNAME"
+  DoTest tz2.byres.1.dat.save tz2.byres.1.dat
+  DoTest tz2.byres.2.dat.save tz2.byres.2.dat
+fi
 
-cat > mmdist.in <<EOF
+UNITNAME="Min/max distance by molecule tests"
+CheckFor maxthreads 10
+if [ $? -eq 0 ] ; then
+  cat > mmdist.in <<EOF
 parm ../tz2.truncoct.parm7
 trajin ../tz2.truncoct.crd
 
@@ -50,8 +57,9 @@ mindist name MolMin2 mask1 ^1 mask2 ^342,567,638,1026,1560,1846&@O bymol out tz2
 maxdist name MolMax2 mask1 ^1 mask2 ^342,567,638,1026,1560,1846&@O bymol out tz2.bymol.2.dat
 #closest 1 ^1 first closestout temp.dat
 EOF
-RunCpptraj "Min/max distance by molecule tests"
-DoTest tz2.bymol.1.dat.save tz2.bymol.1.dat
-DoTest tz2.bymol.2.dat.save tz2.bymol.2.dat
+  RunCpptraj "$UNITNAME"
+  DoTest tz2.bymol.1.dat.save tz2.bymol.1.dat
+  DoTest tz2.bymol.2.dat.save tz2.bymol.2.dat
+fi
 EndTest
 exit 0


### PR DESCRIPTION
Sometimes there aren't enough input frames in a trajectory for the requested number of processes. Ensure the parallel tests work with up to 16 processes.