### PR TITLE
Add DTR plugin object to libcpptraj_traj static compile

### DIFF
--- a/src/cpptrajfiles
+++ b/src/cpptrajfiles
@@ -625,7 +625,8 @@ LIBCPPTRAJ_TRAJ_OBJECTS= \
   Traj_SDF.o \
   Traj_SQM.o \
   Traj_Tinker.o \
-  Traj_XYZ.o
+  Traj_XYZ.o \
+  vmdplugin/dtrplugin.o
 
 # These objects contain parameter file functionality. Requires core and file libraries.
 LIBCPPTRAJ_PARM_OBJECTS= \


### PR DESCRIPTION
This is only needed for ambpdb compile in AmberTools - should not affect anything else.