### PR TITLE
Fix copy of Frame information in the 'setvelocity' command

### DIFF
--- a/src/Action_SetVelocity.cpp
+++ b/src/Action_SetVelocity.cpp
@@ -140,10 +140,7 @@ Action::RetType Action_SetVelocity::Setup(ActionSetup& setup) {
 
 // Action_SetVelocity::DoAction()
 Action::RetType Action_SetVelocity::DoAction(int frameNum, ActionFrame& frm) {
-  std::copy( frm.Frm().xAddress(), frm.Frm().xAddress() + frm.Frm().size(), newFrame_.xAddress() );
-  if (frm.Frm().HasVelocity())
-    std::copy( frm.Frm().vAddress(), frm.Frm().vAddress() + frm.Frm().size(),
-               newFrame_.vAddress() );
+  newFrame_.SetFrame( frm.Frm() );
   if (mode_ == ZERO) {
     for (AtomMask::const_iterator atom = Mask_.begin(); atom != Mask_.end(); ++atom)
     {

--- a/src/Version.h
+++ b/src/Version.h
@@ -12,7 +12,7 @@
  * Whenever a number that precedes <revision> is incremented, all subsequent
  * numbers should be reset to 0.
  */
-#define CPPTRAJ_INTERNAL_VERSION "V7.8.0"
+#define CPPTRAJ_INTERNAL_VERSION "V7.9.0"
 /// PYTRAJ relies on this
 #define CPPTRAJ_VERSION_STRING CPPTRAJ_INTERNAL_VERSION
 #endif


### PR DESCRIPTION
Version 7.9.0.

Previously, only the coordinate/velocity information from the input Frame was being copied over to the new frame in the `setvelocity` command. This fix ensures all information from the incoming Frame is preserved.